### PR TITLE
settings: enable stylelint and auto fix on save for vscode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -91,9 +91,13 @@
     "typescript.tsdk": "node_modules\\typescript\\lib",
     "files.trimTrailingWhitespace": true,
     "editor.detectIndentation": false,
+    "stylelint.enable": true,
     "less.lint.unknownProperties": "ignore",
     "scss.lint.unknownProperties": "ignore",
     "css.lint.emptyRules": "ignore",
     "less.lint.emptyRules": "ignore",
-    "scss.lint.emptyRules": "ignore"
+    "scss.lint.emptyRules": "ignore",
+    "editor.codeActionsOnSave": {
+        "source.fixAll.stylelint": true
+    }
 }


### PR DESCRIPTION
Added settings to enable automatic checking of `stylelint` rules and fix them if possible when saving for VSCode.