### PR TITLE
[Bugfix]: Fix pickerinput focus management

### DIFF
--- a/uui-components/src/pickers/PickerToggler.tsx
+++ b/uui-components/src/pickers/PickerToggler.tsx
@@ -51,16 +51,12 @@ export class PickerToggler<TItem, TId> extends React.Component<PickerTogglerProp
 
     handleFocus = (e?: React.SyntheticEvent<HTMLElement>) => {
         this.props.onFocus && this.props.onFocus(e);
-        const input = this.toggleContainer?.querySelector('input');
-        input && input.focus();
         this.setState({ inFocus: true });
     }
 
     handleBlur = (e: React.SyntheticEvent<HTMLElement>) => {
         this.props.onBlur && this.props.onBlur(e);
         this.setState({ inFocus: false });
-        const input = this.toggleContainer?.querySelector('input');
-        input && input.blur();
     }
 
     handleActive = (e: Event) => {
@@ -111,6 +107,9 @@ export class PickerToggler<TItem, TId> extends React.Component<PickerTogglerProp
             return <div
                 aria-haspopup='listbox'
                 aria-multiselectable={ this.props.pickerMode === 'multi' }
+                tabIndex={ 0 }
+                onFocus={ this.handleFocus }
+                onBlur={ this.handleBlur }
                 className={ cx(
                     uuiElement.input,
                     this.props.selection.length === 0 && uuiElement.placeholder,
@@ -129,6 +128,9 @@ export class PickerToggler<TItem, TId> extends React.Component<PickerTogglerProp
                 this.props.pickerMode === 'single' && css.singleInput,
                 isActivePlaceholder && (!this.state.inFocus || this.props.isReadonly) && uuiElement.placeholder)
             }
+            tabIndex={ 0 }
+            onFocus={ this.handleFocus }
+            onBlur={ this.handleBlur }
             disabled={ this.props.isDisabled }
             placeholder={ placeholder }
             value={ this.props.value || '' }
@@ -154,9 +156,6 @@ export class PickerToggler<TItem, TId> extends React.Component<PickerTogglerProp
                     (!this.props.isReadonly && this.state.isActive) && uuiMod.active,
                     this.props.cx
                 ) }
-                tabIndex={ 0 }
-                onFocus={ this.handleFocus }
-                onBlur={ this.handleBlur }
                 onKeyDown={ this.handleKeyDown }
                 {...this.props.rawProps}
             >


### PR DESCRIPTION
Previously, focus was manually managed on the picker input wrapper, which lead to tab sequence breaks. Now the tabIndex and focus-blur events are passed directly to the pickertoggler.