### PR TITLE
[Label Input]: Associate label with input element

### DIFF
--- a/uui-components/src/layout/LabeledInput.tsx
+++ b/uui-components/src/layout/LabeledInput.tsx
@@ -23,9 +23,9 @@ export class LabeledInput extends React.Component<LabeledInputProps> {
 
         return (
             <div className={ cx(css.container, this.props.cx) } {...this.props.rawProps} >
-                <div className={ cx(labelMod[this.props.labelPosition ? this.props.labelPosition : 'top']) }>
+                <label className={ cx(labelMod[this.props.labelPosition ? this.props.labelPosition : 'top']) }>
                     { this.props.label &&
-                        <div role="label" className={ uuiElement.label }>
+                        <div className={ uuiElement.label }>
                             { this.props.label }
                             { this.props.isRequired && <span className={ uuiLabeledInput.asterisk } >*</span> }
                             { this.props.info && Tooltip &&
@@ -43,7 +43,7 @@ export class LabeledInput extends React.Component<LabeledInputProps> {
                     <div className={ this.props.labelPosition === 'left' ? css.rightChildrenPosition : undefined }>
                         { this.props.children }
                     </div>
-                </div>
+                </label>
                 { this.props.isInvalid && <div className={ uuiElement.invalidMessage }>{ this.props.validationMessage }</div> }
             </div>
         );


### PR DESCRIPTION
Labels must be associated with inputs somehow. There are a lot of approaches using ```for-id``` pair or ```aria-label + aria-labelledby```, but the easiest and the most universal way is to put the interactive element within label. Current PR aims to fix this.

How can we now that the browser successfully associates a label with the element? If you press on the label next to the element, the following element will be focused.

As part of #104 (Labeled Input)