### PR TITLE
[Bugfix]: Fix table row, picker row double click on checkbox label

### DIFF
--- a/epam-promo/components/inputs/__tests__/__snapshots__/Checkbox.test.tsx.snap
+++ b/epam-promo/components/inputs/__tests__/__snapshots__/Checkbox.test.tsx.snap
@@ -2,7 +2,8 @@
 
 exports[`Checkbox should be rendered correctly 1`] = `
 <label
-  className="container root size-18 checkbox-color-blue"
+  className="container root size-18 checkbox-color-blue -clickable"
+  role="checkbox"
 >
   <div
     className="uui-checkbox"
@@ -19,7 +20,8 @@ exports[`Checkbox should be rendered correctly 1`] = `
 
 exports[`Checkbox should be rendered correctly 2`] = `
 <label
-  className="container root size-18 checkbox-color-blue"
+  className="container root size-18 checkbox-color-blue -clickable"
+  role="checkbox"
 >
   <div
     className="uui-checkbox"

--- a/epam-promo/components/inputs/__tests__/__snapshots__/RadioInput.test.tsx.snap
+++ b/epam-promo/components/inputs/__tests__/__snapshots__/RadioInput.test.tsx.snap
@@ -3,6 +3,7 @@
 exports[`RadioInput should be rendered correctly 1`] = `
 <label
   className="container root size-18"
+  role="checkbox"
 >
   <div
     className="uui-radioinput"
@@ -21,6 +22,7 @@ exports[`RadioInput should be rendered correctly 1`] = `
 exports[`RadioInput should be rendered correctly 2`] = `
 <label
   className="container root size-18"
+  role="checkbox"
 >
   <div
     className="uui-radioinput"

--- a/epam-promo/components/inputs/__tests__/__snapshots__/RadioInput.test.tsx.snap
+++ b/epam-promo/components/inputs/__tests__/__snapshots__/RadioInput.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`RadioInput should be rendered correctly 1`] = `
 <label
-  className="container root size-18"
+  className="container root size-18 -clickable"
   role="checkbox"
 >
   <div
@@ -21,7 +21,7 @@ exports[`RadioInput should be rendered correctly 1`] = `
 
 exports[`RadioInput should be rendered correctly 2`] = `
 <label
-  className="container root size-18"
+  className="container root size-18 -clickable"
   role="checkbox"
 >
   <div

--- a/epam-promo/components/layout/__tests__/__snapshots__/CheckboxGroup.test.tsx.snap
+++ b/epam-promo/components/layout/__tests__/__snapshots__/CheckboxGroup.test.tsx.snap
@@ -5,38 +5,46 @@ exports[`CheckboxGroup should be rendered correctly 1`] = `
   className="uui-vertical-direction root container"
 >
   <label
-    className="container root size-18 checkbox-color-blue"
+    className="container root size-18 checkbox-color-blue -clickable"
+    role="checkbox"
   >
-    <input
-      aria-checked={false}
-      checked={false}
+    <div
       className="uui-checkbox"
-      onChange={[Function]}
-      type="checkbox"
-    />
-    <span
+    >
+      <input
+        aria-checked={false}
+        checked={false}
+        onChange={[Function]}
+        type="checkbox"
+      />
+    </div>
+    <div
       className="uui-input-label"
       role="label"
     >
       Test1
-    </span>
+    </div>
   </label>
   <label
-    className="container root size-18 checkbox-color-blue"
+    className="container root size-18 checkbox-color-blue -clickable"
+    role="checkbox"
   >
-    <input
-      aria-checked={false}
-      checked={false}
+    <div
       className="uui-checkbox"
-      onChange={[Function]}
-      type="checkbox"
-    />
-    <span
+    >
+      <input
+        aria-checked={false}
+        checked={false}
+        onChange={[Function]}
+        type="checkbox"
+      />
+    </div>
+    <div
       className="uui-input-label"
       role="label"
     >
       Test2
-    </span>
+    </div>
   </label>
 </fieldset>
 `;
@@ -47,39 +55,47 @@ exports[`CheckboxGroup should be rendered correctly with props 1`] = `
 >
   <label
     className="container root size-18 checkbox-color-blue uui-disabled"
+    role="checkbox"
   >
-    <input
-      aria-checked={false}
-      checked={false}
+    <div
       className="uui-checkbox"
-      disabled={true}
-      onChange={null}
-      type="checkbox"
-    />
-    <span
+    >
+      <input
+        aria-checked={false}
+        checked={false}
+        disabled={true}
+        onChange={[Function]}
+        type="checkbox"
+      />
+    </div>
+    <div
       className="uui-input-label"
       role="label"
     >
       Test1
-    </span>
+    </div>
   </label>
   <label
     className="container root size-18 checkbox-color-blue uui-disabled"
+    role="checkbox"
   >
-    <input
-      aria-checked={false}
-      checked={false}
+    <div
       className="uui-checkbox"
-      disabled={true}
-      onChange={null}
-      type="checkbox"
-    />
-    <span
+    >
+      <input
+        aria-checked={false}
+        checked={false}
+        disabled={true}
+        onChange={[Function]}
+        type="checkbox"
+      />
+    </div>
+    <div
       className="uui-input-label"
       role="label"
     >
       Test2
-    </span>
+    </div>
   </label>
 </fieldset>
 `;

--- a/epam-promo/components/layout/__tests__/__snapshots__/RadioGroup.test.tsx.snap
+++ b/epam-promo/components/layout/__tests__/__snapshots__/RadioGroup.test.tsx.snap
@@ -6,39 +6,47 @@ exports[`RadioGroup should be rendered correctly 1`] = `
 >
   <label
     className="container root size-18"
+    role="checkbox"
   >
-    <input
-      aria-checked={false}
-      checked={false}
+    <div
       className="uui-radioinput"
-      onChange={[Function]}
-      tabIndex={0}
-      type="radio"
-    />
-    <span
+    >
+      <input
+        aria-checked={false}
+        checked={false}
+        onChange={[Function]}
+        tabIndex={0}
+        type="radio"
+      />
+    </div>
+    <div
       className="uui-input-label"
       role="label"
     >
       Test1
-    </span>
+    </div>
   </label>
   <label
     className="container root size-18"
+    role="checkbox"
   >
-    <input
-      aria-checked={false}
-      checked={false}
+    <div
       className="uui-radioinput"
-      onChange={[Function]}
-      tabIndex={0}
-      type="radio"
-    />
-    <span
+    >
+      <input
+        aria-checked={false}
+        checked={false}
+        onChange={[Function]}
+        tabIndex={0}
+        type="radio"
+      />
+    </div>
+    <div
       className="uui-input-label"
       role="label"
     >
       Test2
-    </span>
+    </div>
   </label>
 </fieldset>
 `;
@@ -49,41 +57,49 @@ exports[`RadioGroup should be rendered correctly with props 1`] = `
 >
   <label
     className="container uui-disabled root size-18"
+    role="checkbox"
   >
-    <input
-      aria-checked={false}
-      checked={false}
+    <div
       className="uui-radioinput"
-      disabled={true}
-      onChange={[Function]}
-      tabIndex={0}
-      type="radio"
-    />
-    <span
+    >
+      <input
+        aria-checked={false}
+        checked={false}
+        disabled={true}
+        onChange={[Function]}
+        tabIndex={0}
+        type="radio"
+      />
+    </div>
+    <div
       className="uui-input-label"
       role="label"
     >
       Test1
-    </span>
+    </div>
   </label>
   <label
     className="container uui-disabled root size-18"
+    role="checkbox"
   >
-    <input
-      aria-checked={false}
-      checked={false}
+    <div
       className="uui-radioinput"
-      disabled={true}
-      onChange={[Function]}
-      tabIndex={0}
-      type="radio"
-    />
-    <span
+    >
+      <input
+        aria-checked={false}
+        checked={false}
+        disabled={true}
+        onChange={[Function]}
+        tabIndex={0}
+        type="radio"
+      />
+    </div>
+    <div
       className="uui-input-label"
       role="label"
     >
       Test2
-    </span>
+    </div>
   </label>
 </fieldset>
 `;

--- a/epam-promo/components/layout/__tests__/__snapshots__/RadioGroup.test.tsx.snap
+++ b/epam-promo/components/layout/__tests__/__snapshots__/RadioGroup.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`RadioGroup should be rendered correctly 1`] = `
   className="uui-vertical-direction root container"
 >
   <label
-    className="container root size-18"
+    className="container root size-18 -clickable"
     role="checkbox"
   >
     <div
@@ -27,7 +27,7 @@ exports[`RadioGroup should be rendered correctly 1`] = `
     </div>
   </label>
   <label
-    className="container root size-18"
+    className="container root size-18 -clickable"
     role="checkbox"
   >
     <div

--- a/epam-promo/components/pickers/DataPickerRow.tsx
+++ b/epam-promo/components/pickers/DataPickerRow.tsx
@@ -68,10 +68,7 @@ export class DataPickerRow<TItem, TId> extends React.Component<DataPickerRowProp
     render() {
         const clickHandler = this.props.onSelect || this.props.onFold || this.props.onCheck;
         return <FlexRow
-            onClick={ (event) => {
-                clickHandler && clickHandler(this.props);
-                event.preventDefault();
-            } }
+            onClick={ () => clickHandler && clickHandler(this.props)}
             rawProps={ {
                 role: 'listitem',
                 'aria-posinset': this.props.index,

--- a/epam-promo/components/tables/__tests__/__snapshots__/ColumnsConfigurationModal.test.tsx.snap
+++ b/epam-promo/components/tables/__tests__/__snapshots__/ColumnsConfigurationModal.test.tsx.snap
@@ -136,36 +136,40 @@ exports[`ColumnsConfigurationModal should be rendered correctly 1`] = `
                   />
                   <label
                     className="container root size-18 checkbox-color-blue uui-disabled"
+                    role="checkbox"
                   >
-                    <input
-                      aria-checked={true}
-                      checked={true}
-                      className="uui-checkbox uui-checked"
-                      disabled={true}
-                      onChange={null}
-                      type="checkbox"
-                    />
                     <div
-                      className="container uui-icon uui-enabled"
-                      style={Object {}}
+                      className="uui-checkbox uui-checked"
                     >
-                      <svg
-                        className=""
-                        height={24}
-                        viewBox="0 0 12 24"
-                        width={12}
+                      <input
+                        aria-checked={true}
+                        checked={true}
+                        disabled={true}
+                        onChange={[Function]}
+                        type="checkbox"
+                      />
+                      <div
+                        className="container uui-icon uui-enabled"
+                        style={Object {}}
                       >
-                        <use
-                          xlinkHref="#check-18.svg"
-                        />
-                      </svg>
+                        <svg
+                          className=""
+                          height={24}
+                          viewBox="0 0 12 24"
+                          width={12}
+                        >
+                          <use
+                            xlinkHref="#check-18.svg"
+                          />
+                        </svg>
+                      </div>
                     </div>
-                    <span
+                    <div
                       className="uui-input-label"
                       role="label"
                     >
                       ID
-                    </span>
+                    </div>
                   </label>
                 </div>
               </div>
@@ -189,36 +193,40 @@ exports[`ColumnsConfigurationModal should be rendered correctly 1`] = `
                   />
                   <label
                     className="container root size-18 checkbox-color-blue uui-disabled"
+                    role="checkbox"
                   >
-                    <input
-                      aria-checked={true}
-                      checked={true}
-                      className="uui-checkbox uui-checked"
-                      disabled={true}
-                      onChange={null}
-                      type="checkbox"
-                    />
                     <div
-                      className="container uui-icon uui-enabled"
-                      style={Object {}}
+                      className="uui-checkbox uui-checked"
                     >
-                      <svg
-                        className=""
-                        height={24}
-                        viewBox="0 0 12 24"
-                        width={12}
+                      <input
+                        aria-checked={true}
+                        checked={true}
+                        disabled={true}
+                        onChange={[Function]}
+                        type="checkbox"
+                      />
+                      <div
+                        className="container uui-icon uui-enabled"
+                        style={Object {}}
                       >
-                        <use
-                          xlinkHref="#check-18.svg"
-                        />
-                      </svg>
+                        <svg
+                          className=""
+                          height={24}
+                          viewBox="0 0 12 24"
+                          width={12}
+                        >
+                          <use
+                            xlinkHref="#check-18.svg"
+                          />
+                        </svg>
+                      </div>
                     </div>
-                    <span
+                    <div
                       className="uui-input-label"
                       role="label"
                     >
                       Level
-                    </span>
+                    </div>
                   </label>
                 </div>
               </div>

--- a/loveship/components/inputs/__tests__/__snapshots__/Checkbox.test.tsx.snap
+++ b/loveship/components/inputs/__tests__/__snapshots__/Checkbox.test.tsx.snap
@@ -2,7 +2,8 @@
 
 exports[`Checkbox should be rendered correctly 1`] = `
 <label
-  className="container root size-18 theme-light color-sky"
+  className="container root size-18 theme-light color-sky -clickable"
+  role="checkbox"
 >
   <div
     className="uui-checkbox uui-checked"
@@ -34,7 +35,8 @@ exports[`Checkbox should be rendered correctly 1`] = `
 
 exports[`Checkbox should be rendered correctly with new props 1`] = `
 <label
-  className="container root size-12 theme-dark color-sun"
+  className="container root size-12 theme-dark color-sun -clickable"
+  role="checkbox"
 >
   <div
     className="uui-checkbox uui-checked"

--- a/loveship/components/inputs/__tests__/__snapshots__/RadioInput.test.tsx.snap
+++ b/loveship/components/inputs/__tests__/__snapshots__/RadioInput.test.tsx.snap
@@ -3,6 +3,7 @@
 exports[`RadioInput should be rendered correctly 1`] = `
 <label
   className="container root size-18 color-sky theme-light"
+  role="checkbox"
 >
   <div
     className="uui-radioinput uui-checked"
@@ -36,6 +37,7 @@ exports[`RadioInput should be rendered correctly 1`] = `
 exports[`RadioInput should be rendered correctly with new props 1`] = `
 <label
   className="container root size-12 color-sun theme-dark"
+  role="checkbox"
 >
   <div
     className="uui-radioinput uui-checked"

--- a/loveship/components/inputs/__tests__/__snapshots__/RadioInput.test.tsx.snap
+++ b/loveship/components/inputs/__tests__/__snapshots__/RadioInput.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`RadioInput should be rendered correctly 1`] = `
 <label
-  className="container root size-18 color-sky theme-light"
+  className="container root size-18 color-sky theme-light -clickable"
   role="checkbox"
 >
   <div
@@ -36,7 +36,7 @@ exports[`RadioInput should be rendered correctly 1`] = `
 
 exports[`RadioInput should be rendered correctly with new props 1`] = `
 <label
-  className="container root size-12 color-sun theme-dark"
+  className="container root size-12 color-sun theme-dark -clickable"
   role="checkbox"
 >
   <div

--- a/loveship/components/layout/__tests__/__snapshots__/CheckboxGroup.test.tsx.snap
+++ b/loveship/components/layout/__tests__/__snapshots__/CheckboxGroup.test.tsx.snap
@@ -6,54 +6,62 @@ exports[`CheckboxGroup should be rendered correctly with extra props 1`] = `
 >
   <label
     className="container root size-18 theme-light color-sky uui-disabled"
+    role="checkbox"
   >
-    <input
-      aria-checked={false}
-      checked={false}
+    <div
       className="uui-checkbox"
-      disabled={true}
-      onChange={null}
-      type="checkbox"
-    />
-    <span
+    >
+      <input
+        aria-checked={false}
+        checked={false}
+        disabled={true}
+        onChange={[Function]}
+        type="checkbox"
+      />
+    </div>
+    <div
       className="uui-input-label"
       role="label"
     >
       test1
-    </span>
+    </div>
   </label>
   <label
     className="container root size-18 theme-light color-sky uui-disabled"
+    role="checkbox"
   >
-    <input
-      aria-checked={true}
-      checked={true}
-      className="uui-checkbox uui-checked"
-      disabled={true}
-      onChange={null}
-      type="checkbox"
-    />
     <div
-      className="container uui-icon uui-enabled"
-      style={Object {}}
+      className="uui-checkbox uui-checked"
     >
-      <svg
-        className=""
-        height={24}
-        viewBox="0 0 12 24"
-        width={12}
+      <input
+        aria-checked={true}
+        checked={true}
+        disabled={true}
+        onChange={[Function]}
+        type="checkbox"
+      />
+      <div
+        className="container uui-icon uui-enabled"
+        style={Object {}}
       >
-        <use
-          xlinkHref="#checkbox-checked.svg"
-        />
-      </svg>
+        <svg
+          className=""
+          height={24}
+          viewBox="0 0 12 24"
+          width={12}
+        >
+          <use
+            xlinkHref="#checkbox-checked.svg"
+          />
+        </svg>
+      </div>
     </div>
-    <span
+    <div
       className="uui-input-label"
       role="label"
     >
       test2
-    </span>
+    </div>
   </label>
 </fieldset>
 `;
@@ -63,53 +71,61 @@ exports[`CheckboxGroup should render with default props 1`] = `
   className="uui-vertical-direction root container"
 >
   <label
-    className="container root size-18 theme-light color-sky"
+    className="container root size-18 theme-light color-sky -clickable"
+    role="checkbox"
   >
-    <input
-      aria-checked={true}
-      checked={true}
-      className="uui-checkbox uui-checked"
-      onChange={[Function]}
-      type="checkbox"
-    />
     <div
-      className="container uui-icon uui-enabled"
-      style={Object {}}
+      className="uui-checkbox uui-checked"
     >
-      <svg
-        className=""
-        height={24}
-        viewBox="0 0 12 24"
-        width={12}
+      <input
+        aria-checked={true}
+        checked={true}
+        onChange={[Function]}
+        type="checkbox"
+      />
+      <div
+        className="container uui-icon uui-enabled"
+        style={Object {}}
       >
-        <use
-          xlinkHref="#checkbox-checked.svg"
-        />
-      </svg>
+        <svg
+          className=""
+          height={24}
+          viewBox="0 0 12 24"
+          width={12}
+        >
+          <use
+            xlinkHref="#checkbox-checked.svg"
+          />
+        </svg>
+      </div>
     </div>
-    <span
+    <div
       className="uui-input-label"
       role="label"
     >
       test1
-    </span>
+    </div>
   </label>
   <label
-    className="container root size-18 theme-light color-sky"
+    className="container root size-18 theme-light color-sky -clickable"
+    role="checkbox"
   >
-    <input
-      aria-checked={false}
-      checked={false}
+    <div
       className="uui-checkbox"
-      onChange={[Function]}
-      type="checkbox"
-    />
-    <span
+    >
+      <input
+        aria-checked={false}
+        checked={false}
+        onChange={[Function]}
+        type="checkbox"
+      />
+    </div>
+    <div
       className="uui-input-label"
       role="label"
     >
       test2
-    </span>
+    </div>
   </label>
 </fieldset>
 `;

--- a/loveship/components/layout/__tests__/__snapshots__/RadioGroup.test.tsx.snap
+++ b/loveship/components/layout/__tests__/__snapshots__/RadioGroup.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`RadioGroup should be rendered correctly 1`] = `
   className="uui-vertical-direction root container"
 >
   <label
-    className="container root size-18 color-sky theme-light"
+    className="container root size-18 color-sky theme-light -clickable"
     role="checkbox"
   >
     <div
@@ -27,7 +27,7 @@ exports[`RadioGroup should be rendered correctly 1`] = `
     </div>
   </label>
   <label
-    className="container root size-18 color-sky theme-light"
+    className="container root size-18 color-sky theme-light -clickable"
     role="checkbox"
   >
     <div

--- a/loveship/components/layout/__tests__/__snapshots__/RadioGroup.test.tsx.snap
+++ b/loveship/components/layout/__tests__/__snapshots__/RadioGroup.test.tsx.snap
@@ -6,39 +6,47 @@ exports[`RadioGroup should be rendered correctly 1`] = `
 >
   <label
     className="container root size-18 color-sky theme-light"
+    role="checkbox"
   >
-    <input
-      aria-checked={false}
-      checked={false}
+    <div
       className="uui-radioinput"
-      onChange={[Function]}
-      tabIndex={0}
-      type="radio"
-    />
-    <span
+    >
+      <input
+        aria-checked={false}
+        checked={false}
+        onChange={[Function]}
+        tabIndex={0}
+        type="radio"
+      />
+    </div>
+    <div
       className="uui-input-label"
       role="label"
     >
       Test1
-    </span>
+    </div>
   </label>
   <label
     className="container root size-18 color-sky theme-light"
+    role="checkbox"
   >
-    <input
-      aria-checked={false}
-      checked={false}
+    <div
       className="uui-radioinput"
-      onChange={[Function]}
-      tabIndex={0}
-      type="radio"
-    />
-    <span
+    >
+      <input
+        aria-checked={false}
+        checked={false}
+        onChange={[Function]}
+        tabIndex={0}
+        type="radio"
+      />
+    </div>
+    <div
       className="uui-input-label"
       role="label"
     >
       Test2
-    </span>
+    </div>
   </label>
 </fieldset>
 `;
@@ -49,41 +57,49 @@ exports[`RadioGroup should be rendered correctly with props 1`] = `
 >
   <label
     className="container uui-disabled root size-18 color-sky theme-light"
+    role="checkbox"
   >
-    <input
-      aria-checked={false}
-      checked={false}
+    <div
       className="uui-radioinput"
-      disabled={true}
-      onChange={[Function]}
-      tabIndex={0}
-      type="radio"
-    />
-    <span
+    >
+      <input
+        aria-checked={false}
+        checked={false}
+        disabled={true}
+        onChange={[Function]}
+        tabIndex={0}
+        type="radio"
+      />
+    </div>
+    <div
       className="uui-input-label"
       role="label"
     >
       Test1
-    </span>
+    </div>
   </label>
   <label
     className="container uui-disabled root size-18 color-sky theme-light"
+    role="checkbox"
   >
-    <input
-      aria-checked={false}
-      checked={false}
+    <div
       className="uui-radioinput"
-      disabled={true}
-      onChange={[Function]}
-      tabIndex={0}
-      type="radio"
-    />
-    <span
+    >
+      <input
+        aria-checked={false}
+        checked={false}
+        disabled={true}
+        onChange={[Function]}
+        tabIndex={0}
+        type="radio"
+      />
+    </div>
+    <div
       className="uui-input-label"
       role="label"
     >
       Test2
-    </span>
+    </div>
   </label>
 </fieldset>
 `;

--- a/loveship/components/pickers/__tests__/__snapshots__/PickerListItem.test.tsx.snap
+++ b/loveship/components/pickers/__tests__/__snapshots__/PickerListItem.test.tsx.snap
@@ -6,14 +6,18 @@ exports[`PickerListItem should render with all new props 1`] = `
 >
   <label
     className="container uui-disabled root size-18 color-sky theme-light"
+    role="checkbox"
   >
-    <input
+    <div
       className="uui-radioinput"
-      disabled={true}
-      onChange={[Function]}
-      tabIndex={0}
-      type="radio"
-    />
+    >
+      <input
+        disabled={true}
+        onChange={[Function]}
+        tabIndex={0}
+        type="radio"
+      />
+    </div>
   </label>
 </div>
 `;
@@ -24,14 +28,18 @@ exports[`PickerListItem should render with default props 1`] = `
 >
   <label
     className="container uui-disabled root size-18 color-sky theme-light"
+    role="checkbox"
   >
-    <input
+    <div
       className="uui-radioinput"
-      disabled={true}
-      onChange={[Function]}
-      tabIndex={0}
-      type="radio"
-    />
+    >
+      <input
+        disabled={true}
+        onChange={[Function]}
+        tabIndex={0}
+        type="radio"
+      />
+    </div>
   </label>
 </div>
 `;

--- a/loveship/components/tables/__tests__/__snapshots__/ColumnsConfigurationModal.test.tsx.snap
+++ b/loveship/components/tables/__tests__/__snapshots__/ColumnsConfigurationModal.test.tsx.snap
@@ -136,36 +136,40 @@ exports[`ColumnsConfigurationModal should be rendered correctly 1`] = `
                   />
                   <label
                     className="container root size-18 theme-light color-sky uui-disabled"
+                    role="checkbox"
                   >
-                    <input
-                      aria-checked={true}
-                      checked={true}
-                      className="uui-checkbox uui-checked"
-                      disabled={true}
-                      onChange={null}
-                      type="checkbox"
-                    />
                     <div
-                      className="container uui-icon uui-enabled"
-                      style={Object {}}
+                      className="uui-checkbox uui-checked"
                     >
-                      <svg
-                        className=""
-                        height={24}
-                        viewBox="0 0 12 24"
-                        width={12}
+                      <input
+                        aria-checked={true}
+                        checked={true}
+                        disabled={true}
+                        onChange={[Function]}
+                        type="checkbox"
+                      />
+                      <div
+                        className="container uui-icon uui-enabled"
+                        style={Object {}}
                       >
-                        <use
-                          xlinkHref="#checkbox-checked.svg"
-                        />
-                      </svg>
+                        <svg
+                          className=""
+                          height={24}
+                          viewBox="0 0 12 24"
+                          width={12}
+                        >
+                          <use
+                            xlinkHref="#checkbox-checked.svg"
+                          />
+                        </svg>
+                      </div>
                     </div>
-                    <span
+                    <div
                       className="uui-input-label"
                       role="label"
                     >
                       ID
-                    </span>
+                    </div>
                   </label>
                 </div>
               </div>
@@ -189,36 +193,40 @@ exports[`ColumnsConfigurationModal should be rendered correctly 1`] = `
                   />
                   <label
                     className="container root size-18 theme-light color-sky uui-disabled"
+                    role="checkbox"
                   >
-                    <input
-                      aria-checked={true}
-                      checked={true}
-                      className="uui-checkbox uui-checked"
-                      disabled={true}
-                      onChange={null}
-                      type="checkbox"
-                    />
                     <div
-                      className="container uui-icon uui-enabled"
-                      style={Object {}}
+                      className="uui-checkbox uui-checked"
                     >
-                      <svg
-                        className=""
-                        height={24}
-                        viewBox="0 0 12 24"
-                        width={12}
+                      <input
+                        aria-checked={true}
+                        checked={true}
+                        disabled={true}
+                        onChange={[Function]}
+                        type="checkbox"
+                      />
+                      <div
+                        className="container uui-icon uui-enabled"
+                        style={Object {}}
                       >
-                        <use
-                          xlinkHref="#checkbox-checked.svg"
-                        />
-                      </svg>
+                        <svg
+                          className=""
+                          height={24}
+                          viewBox="0 0 12 24"
+                          width={12}
+                        >
+                          <use
+                            xlinkHref="#checkbox-checked.svg"
+                          />
+                        </svg>
+                      </div>
                     </div>
-                    <span
+                    <div
                       className="uui-input-label"
                       role="label"
                     >
                       name
-                    </span>
+                    </div>
                   </label>
                 </div>
               </div>
@@ -241,37 +249,41 @@ exports[`ColumnsConfigurationModal should be rendered correctly 1`] = `
                     className="dragHandle container uui-drag-handle"
                   />
                   <label
-                    className="container root size-18 theme-light color-sky"
+                    className="container root size-18 theme-light color-sky -clickable"
+                    role="checkbox"
                   >
-                    <input
-                      aria-checked={true}
-                      checked={true}
-                      className="uui-checkbox uui-checked"
-                      disabled={false}
-                      onChange={[Function]}
-                      type="checkbox"
-                    />
                     <div
-                      className="container uui-icon uui-enabled"
-                      style={Object {}}
+                      className="uui-checkbox uui-checked"
                     >
-                      <svg
-                        className=""
-                        height={24}
-                        viewBox="0 0 12 24"
-                        width={12}
+                      <input
+                        aria-checked={true}
+                        checked={true}
+                        disabled={false}
+                        onChange={[Function]}
+                        type="checkbox"
+                      />
+                      <div
+                        className="container uui-icon uui-enabled"
+                        style={Object {}}
                       >
-                        <use
-                          xlinkHref="#checkbox-checked.svg"
-                        />
-                      </svg>
+                        <svg
+                          className=""
+                          height={24}
+                          viewBox="0 0 12 24"
+                          width={12}
+                        >
+                          <use
+                            xlinkHref="#checkbox-checked.svg"
+                          />
+                        </svg>
+                      </div>
                     </div>
-                    <span
+                    <div
                       className="uui-input-label"
                       role="label"
                     >
                       Level
-                    </span>
+                    </div>
                   </label>
                 </div>
               </div>
@@ -294,37 +306,41 @@ exports[`ColumnsConfigurationModal should be rendered correctly 1`] = `
                     className="dragHandle container uui-drag-handle"
                   />
                   <label
-                    className="container root size-18 theme-light color-sky"
+                    className="container root size-18 theme-light color-sky -clickable"
+                    role="checkbox"
                   >
-                    <input
-                      aria-checked={true}
-                      checked={true}
-                      className="uui-checkbox uui-checked"
-                      disabled={false}
-                      onChange={[Function]}
-                      type="checkbox"
-                    />
                     <div
-                      className="container uui-icon uui-enabled"
-                      style={Object {}}
+                      className="uui-checkbox uui-checked"
                     >
-                      <svg
-                        className=""
-                        height={24}
-                        viewBox="0 0 12 24"
-                        width={12}
+                      <input
+                        aria-checked={true}
+                        checked={true}
+                        disabled={false}
+                        onChange={[Function]}
+                        type="checkbox"
+                      />
+                      <div
+                        className="container uui-icon uui-enabled"
+                        style={Object {}}
                       >
-                        <use
-                          xlinkHref="#checkbox-checked.svg"
-                        />
-                      </svg>
+                        <svg
+                          className=""
+                          height={24}
+                          viewBox="0 0 12 24"
+                          width={12}
+                        >
+                          <use
+                            xlinkHref="#checkbox-checked.svg"
+                          />
+                        </svg>
+                      </div>
                     </div>
-                    <span
+                    <div
                       className="uui-input-label"
                       role="label"
                     >
                       DATE
-                    </span>
+                    </div>
                   </label>
                 </div>
               </div>

--- a/loveship/components/tables/__tests__/__snapshots__/DataTableHeaderRow.test.tsx.snap
+++ b/loveship/components/tables/__tests__/__snapshots__/DataTableHeaderRow.test.tsx.snap
@@ -23,7 +23,8 @@ exports[`DataTableHeaderRow should be rendered correctly with extra props 1`] = 
     }
   >
     <label
-      className="container root size-12 theme-light color-sky checkbox"
+      className="container root size-12 theme-light color-sky checkbox -clickable"
+      role="checkbox"
     >
       <div
         className="uui-checkbox"

--- a/uui-components/src/inputs/Checkbox.tsx
+++ b/uui-components/src/inputs/Checkbox.tsx
@@ -26,6 +26,7 @@ export class Checkbox extends React.Component<CheckboxProps, any> {
     render() {
         return (
             <label
+                role="checkbox"
                 className={ cx(
                     css.container,
                     this.props.cx,

--- a/uui-components/src/inputs/Checkbox.tsx
+++ b/uui-components/src/inputs/Checkbox.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { cx } from '@epam/uui';
+import { cx, uuiMarkers } from '@epam/uui';
 import * as css from './Checkbox.scss';
 import { Icon, uuiMod, uuiElement, isClickableChildClicked, CheckboxCoreProps, UuiContexts, UuiContext } from '@epam/uui';
 import { IconContainer } from '../layout';
@@ -33,9 +33,9 @@ export class Checkbox extends React.Component<CheckboxProps, any> {
                     this.props.isDisabled && uuiMod.disabled,
                     this.props.isReadonly && uuiMod.readonly,
                     this.props.isInvalid && uuiMod.invalid,
+                    (!this.props.isReadonly && !this.props.isDisabled) && uuiMarkers.clickable,
                 ) }
                 { ...this.props.rawProps }
-                onClick={ e => e.stopPropagation()}
             >
                 <div className={ cx(uuiElement.checkbox, (this.props.value || this.props.indeterminate) && uuiMod.checked) }>
                     <input

--- a/uui-components/src/inputs/Checkbox.tsx
+++ b/uui-components/src/inputs/Checkbox.tsx
@@ -34,11 +34,12 @@ export class Checkbox extends React.Component<CheckboxProps, any> {
                     this.props.isInvalid && uuiMod.invalid,
                 ) }
                 { ...this.props.rawProps }
+                onClick={ e => e.stopPropagation()}
             >
                 <div className={ cx(uuiElement.checkbox, (this.props.value || this.props.indeterminate) && uuiMod.checked) }>
                     <input
                         type="checkbox"
-                        onChange={(!this.props.isDisabled && !this.props.isReadonly) ? this.handleChange : null}
+                        onChange={ this.handleChange }
                         disabled={ this.props.isDisabled }
                         readOnly={ this.props.isReadonly }
                         aria-checked={ this.props.value }

--- a/uui-components/src/inputs/RadioInput.tsx
+++ b/uui-components/src/inputs/RadioInput.tsx
@@ -24,6 +24,7 @@ export class RadioInput extends React.Component<RadioInputProps, any> {
     render() {
         return (
             <label
+                role="checkbox"
                 className={ cx(
                     css.container,
                     this.props.isDisabled && uuiMod.disabled,
@@ -32,6 +33,7 @@ export class RadioInput extends React.Component<RadioInputProps, any> {
                     this.props.cx
                 ) }
                 { ...this.props.rawProps }
+                onClick={ e => e.stopPropagation() }
             >
                 <div className={ cx(uuiElement.radioInput, this.props.value && uuiMod.checked) }>
                     <input

--- a/uui-components/src/inputs/RadioInput.tsx
+++ b/uui-components/src/inputs/RadioInput.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import * as css from './RadioInput.scss';
-import { IHasRawProps, cx, IHasCX, IDisableable, IEditable, IHasLabel, Icon, uuiMod, uuiElement, ICanBeReadonly, IAnalyticableOnChange, uuiContextTypes, UuiContexts} from "@epam/uui";
+import { IHasRawProps, cx, IHasCX, IDisableable, IEditable, IHasLabel, Icon, uuiMod, uuiElement, ICanBeReadonly, IAnalyticableOnChange, uuiContextTypes, UuiContexts, uuiMarkers } from "@epam/uui";
 import { IconContainer } from '../layout';
 
 export interface RadioInputProps extends IHasCX, IDisableable, IEditable<boolean>, IHasLabel, ICanBeReadonly, IAnalyticableOnChange<boolean>, IHasRawProps<HTMLLabelElement> {
@@ -30,7 +30,8 @@ export class RadioInput extends React.Component<RadioInputProps, any> {
                     this.props.isDisabled && uuiMod.disabled,
                     this.props.isReadonly && uuiMod.readonly,
                     this.props.isInvalid && uuiMod.invalid,
-                    this.props.cx
+                    this.props.cx,
+                    (!this.props.isReadonly && !this.props.isDisabled) && uuiMarkers.clickable,
                 ) }
                 { ...this.props.rawProps }
             >

--- a/uui-components/src/inputs/RadioInput.tsx
+++ b/uui-components/src/inputs/RadioInput.tsx
@@ -33,7 +33,6 @@ export class RadioInput extends React.Component<RadioInputProps, any> {
                     this.props.cx
                 ) }
                 { ...this.props.rawProps }
-                onClick={ e => e.stopPropagation() }
             >
                 <div className={ cx(uuiElement.radioInput, this.props.value && uuiMod.checked) }>
                     <input

--- a/uui-components/src/inputs/Switch.tsx
+++ b/uui-components/src/inputs/Switch.tsx
@@ -27,7 +27,6 @@ export class Switch extends React.Component<SwitchProps, any> {
                     this.props.isDisabled && uuiMod.disabled,
                     (!this.props.isReadonly && !this.props.isDisabled) && uuiMarkers.clickable
                 ) }
-                onClick={ e => e.stopPropagation() }
             >
                 <div className={ cx(uuiElement.switchBody, this.props.value && uuiMod.checked) }>
                     <input

--- a/uui-components/src/inputs/Switch.tsx
+++ b/uui-components/src/inputs/Switch.tsx
@@ -27,6 +27,7 @@ export class Switch extends React.Component<SwitchProps, any> {
                     this.props.isDisabled && uuiMod.disabled,
                     (!this.props.isReadonly && !this.props.isDisabled) && uuiMarkers.clickable
                 ) }
+                onClick={ e => e.stopPropagation() }
             >
                 <div className={ cx(uuiElement.switchBody, this.props.value && uuiMod.checked) }>
                     <input


### PR DESCRIPTION
When table row is clicked, the checkbox whose top-level element is ```<label></label>``` triggers propagation by default. This behavior is fixed on pickerinput and tables. 