### PR TITLE
[VirtualList]: fix the width for the '.wrapper' so that when using

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -22,6 +22,7 @@
 * [PickerInput]: fix pass the mode prop to PickerToggler so that apply correct style according to the mode
 * [Button]: fix the text color for the button so that the text and border color are the same color
 * [TextArea]: fix scrolling jump after typing when received autosize prop
+* [VirtualList]: fix the width for the '.wrapper' so that when using renderRow the contents of the '.container3' do not go beyond the dropdown.
 # 4.1.1 - 05.07.2021
 
 **What’s Fixed**

--- a/uui-components/src/layout/VirtualList.scss
+++ b/uui-components/src/layout/VirtualList.scss
@@ -3,6 +3,7 @@
     align-self: stretch;
     display: flex;
     position: relative;
+    width: 100%;
 }
 
 .body {


### PR DESCRIPTION
renderRow the contents of the '.container3' do not go beyond the dropdown.