### PR TITLE
[Refactor]: Refactor typings to both work with class components and FC

### DIFF
--- a/app/src/common/docs/ComponentEditor.tsx
+++ b/app/src/common/docs/ComponentEditor.tsx
@@ -22,7 +22,7 @@ interface DemoComponentProps<TProps = any> {
 }
 
 interface DemoContext {
-    context: React.ComponentClass<DemoComponentProps>;
+    context: React.ComponentType<DemoComponentProps>;
     name: string;
 }
 

--- a/epam-promo/components/inputs/docs/checkbox.doc.ts
+++ b/epam-promo/components/inputs/docs/checkbox.doc.ts
@@ -5,7 +5,7 @@ import { Checkbox, CheckboxMods } from '../Checkbox';
 import { isDisabledDoc, isInvalidDoc, iHasLabelDoc, iEditable } from '../../../docs';
 import { DefaultContext, FormContext } from '../../../docs';
 
-const CheckboxDoc = new DocBuilder<CheckboxProps & CheckboxMods>({ name: 'Checkbox', component: Checkbox as React.ComponentClass<any> })
+const CheckboxDoc = new DocBuilder<CheckboxProps & CheckboxMods>({ name: 'Checkbox', component: Checkbox })
     .implements([isDisabledDoc, isInvalidDoc, iHasLabelDoc, iEditable] as any)
     .prop('value', { examples: [true, false] })
     .prop('size', { examples: ['12', '18'], defaultValue: '18' })

--- a/epam-promo/components/inputs/docs/multiSwitch.doc.ts
+++ b/epam-promo/components/inputs/docs/multiSwitch.doc.ts
@@ -3,7 +3,7 @@ import { DocBuilder } from '@epam/uui-docs';
 import { DefaultContext, FormContext } from '../../../docs';
 import { sizeDoc, iEditable, isDisabledDoc } from '../../../docs';
 
-const multiSwitchDoc = new DocBuilder<MultiSwitchProps<any>>({ name: 'MultiSwitch', component: MultiSwitch as React.ComponentClass<any> })
+const multiSwitchDoc = new DocBuilder<MultiSwitchProps<any>>({ name: 'MultiSwitch', component: MultiSwitch })
     .implements([sizeDoc, iEditable, isDisabledDoc] as any)
     .prop('items', { examples: [
         {

--- a/epam-promo/components/inputs/docs/numericInput.doc.ts
+++ b/epam-promo/components/inputs/docs/numericInput.doc.ts
@@ -4,7 +4,7 @@ import { NumericInput, NumericInputMods } from '../NumericInput';
 import { iEditable, sizeDoc, isDisabledDoc, iHasPlaceholder, iFormatter } from '../../../docs';
 import { DefaultContext, FormContext } from '../../../docs';
 
-const NumericInputDoc = new DocBuilder<NumericInputProps & NumericInputMods>({ name: 'NumericInput', component: NumericInput as React.ComponentClass<any> })
+const NumericInputDoc = new DocBuilder<NumericInputProps & NumericInputMods>({ name: 'NumericInput', component: NumericInput })
     .implements([iEditable, iHasPlaceholder, sizeDoc, isDisabledDoc, isReadonlyDoc, iFormatter] as any)
     .prop('value', { examples: [{ value: 0, isDefault: true }, 111] })
     .prop('step', { examples: [5, 10, 100] })

--- a/epam-promo/components/inputs/docs/radioInput.doc.ts
+++ b/epam-promo/components/inputs/docs/radioInput.doc.ts
@@ -5,7 +5,7 @@ import { RadioInput, RadioInputMods } from '../RadioInput';
 import { isDisabledDoc, isInvalidDoc, iHasLabelDoc, iEditable } from '../../../docs';
 import { DefaultContext, FormContext } from '../../../docs';
 
-const RadioInputDoc = new DocBuilder<RadioInputProps & RadioInputMods>({ name: 'RadioInput', component: RadioInput as React.ComponentClass<any> })
+const RadioInputDoc = new DocBuilder<RadioInputProps & RadioInputMods>({ name: 'RadioInput', component: RadioInput })
     .implements([isDisabledDoc, isReadonlyDoc, isInvalidDoc, iHasLabelDoc, iEditable] as any)
     .prop('value', { examples: [true, false] })
     .prop('size', { examples: ['12', '18'] })

--- a/epam-promo/components/inputs/docs/rating.doc.ts
+++ b/epam-promo/components/inputs/docs/rating.doc.ts
@@ -3,7 +3,7 @@ import { RatingProps } from '@epam/uui-components';
 import { Rating, RatingMods } from '../Rating';
 import { isDisabledDoc, isInvalidDoc, iEditable, DefaultContext, FormContext } from '../../../docs';
 
-const RatingDoc = new DocBuilder<RatingProps & RatingMods>({ name: 'Rating', component: Rating as React.ComponentClass<any> })
+const RatingDoc = new DocBuilder<RatingProps & RatingMods>({ name: 'Rating', component: Rating })
     .implements([isDisabledDoc, isInvalidDoc, iEditable] as any)
     .prop('size', { examples: [18, 24], defaultValue: 18 })
     .prop('value', { examples: [0.5, 1, 1.5, 2, 2.5, 3, 3.5, 4, 4.5, 5] })

--- a/epam-promo/components/inputs/docs/searchInput.doc.ts
+++ b/epam-promo/components/inputs/docs/searchInput.doc.ts
@@ -7,7 +7,7 @@ import {
 } from '../../../docs';
 import { IEditableDebouncerOptions } from '@epam/uui';
 
-const SearchInputDoc = new DocBuilder<TextInputProps & TextInputMods & IEditableDebouncerOptions>({ name: 'SearchInput', component: SearchInput as React.ComponentClass<any> })
+const SearchInputDoc = new DocBuilder<TextInputProps & TextInputMods & IEditableDebouncerOptions>({ name: 'SearchInput', component: SearchInput })
     .implements([onClickDoc, sizeDoc, isDisabledDoc, isReadonlyDoc, isInvalidDoc, iconDoc, iconOptionsDoc, iEditable, iHasPlaceholder, dropdownTogglerDoc] as any)
     .prop('value', { examples: [
             { value: 'Hello, World!', isDefault: true },

--- a/epam-promo/components/inputs/docs/switch.doc.ts
+++ b/epam-promo/components/inputs/docs/switch.doc.ts
@@ -4,7 +4,7 @@ import { Switch, SwitchMods } from '../Switch';
 import { isDisabledDoc, isInvalidDoc, iHasLabelDoc, iEditable } from '../../../docs';
 import { DefaultContext, FormContext } from '../../../docs';
 
-const SwitchDoc = new DocBuilder<SwitchProps & SwitchMods>({ name: 'Switch', component: Switch as React.ComponentClass<any>})
+const SwitchDoc = new DocBuilder<SwitchProps & SwitchMods>({ name: 'Switch', component: Switch })
     .implements([isDisabledDoc, isInvalidDoc, iEditable, iHasLabelDoc] as any)
     .prop('size', { examples: ['12', '18', '24'], defaultValue: '18' })
     .prop('value', { examples: [true, false], defaultValue: false })

--- a/epam-promo/components/inputs/docs/textInput.doc.ts
+++ b/epam-promo/components/inputs/docs/textInput.doc.ts
@@ -4,7 +4,7 @@ import { TextInput, TextInputMods } from '../TextInput';
 import { iEditable, iHasPlaceholder, onClickDoc, isDisabledDoc, isReadonlyDoc, isInvalidDoc, iconDoc, iconOptionsDoc, dropdownTogglerDoc } from '../../../docs';
 import { DefaultContext, FormContext, TableContext, IHasEditModeDoc } from '../../../docs';
 
-const TextInputDoc = new DocBuilder<TextInputProps & TextInputMods>({ name: 'TextInput', component: TextInput as React.ComponentClass<any> })
+const TextInputDoc = new DocBuilder<TextInputProps & TextInputMods>({ name: 'TextInput', component: TextInput })
     .prop('size', { examples: ['24', '30', '36', '42', '48'], defaultValue: '36' })
     .implements([onClickDoc, isDisabledDoc, isReadonlyDoc, isInvalidDoc, iconDoc, iconOptionsDoc, iEditable, iHasPlaceholder, dropdownTogglerDoc, IHasEditModeDoc] as any)
     .prop('maxLength', { examples: [10, 20, 30], type: 'number' })

--- a/epam-promo/components/inputs/docs/timePicker.doc.ts
+++ b/epam-promo/components/inputs/docs/timePicker.doc.ts
@@ -4,7 +4,7 @@ import { iEditable, sizeDoc, isDisabledDoc, isInvalidDoc } from '../../../docs';
 import { FormContext, DefaultContext, TableContext, IHasEditModeDoc } from '../../../docs';
 import { TimePicker, TimePickerProps } from '../TimePicker';
 
-const TimePickerDoc = new DocBuilder<TimePickerProps>({ name: 'TimePicker', component: TimePicker as React.ComponentClass<any> })
+const TimePickerDoc = new DocBuilder<TimePickerProps>({ name: 'TimePicker', component: TimePicker })
     .implements([iEditable, sizeDoc, isDisabledDoc, isReadonlyDoc, isInvalidDoc, IHasEditModeDoc] as any)
     .prop('value', { examples: [{ name: '6:20', value: { hours: 6, minutes: 20 }, isDefault: true }] })
     .prop('minutesStep', { examples: [5, 10, 15], defaultValue: 5 })

--- a/epam-promo/components/navigation/docs/mainMenu.doc.tsx
+++ b/epam-promo/components/navigation/docs/mainMenu.doc.tsx
@@ -5,7 +5,7 @@ import { DocBuilder } from '@epam/uui-docs';
 import { ResizableContext } from "../../../docs";
 import * as svgTriangle from '../../../icons/triangle.svg';
 
-const mainMenuDoc = new DocBuilder<MainMenuMods & MainMenuProps>({ name: 'MainMenu', component: MainMenu as React.ComponentClass<any> })
+const mainMenuDoc = new DocBuilder<MainMenuMods & MainMenuProps>({ name: 'MainMenu', component: MainMenu })
     .prop('renderBurger', {
         examples: [
             {

--- a/epam-promo/components/overlays/docs/alert.doc.tsx
+++ b/epam-promo/components/overlays/docs/alert.doc.tsx
@@ -4,7 +4,7 @@ import { ResizableContext, iconWithInfoDoc, colorDoc } from '../../../docs';
 import { Text } from '../../typography';
 import { AlertProps, Alert } from '..';
 
-const SnackbarCardDoc = new DocBuilder<AlertProps>({ name: 'Alert', component: Alert as React.ComponentClass<any> })
+const SnackbarCardDoc = new DocBuilder<AlertProps>({ name: 'Alert', component: Alert })
     .implements([iconWithInfoDoc, colorDoc] as any)
     .prop('children', {
         examples: [

--- a/epam-promo/components/overlays/docs/dropdown.doc.tsx
+++ b/epam-promo/components/overlays/docs/dropdown.doc.tsx
@@ -4,7 +4,7 @@ import { DropdownProps, Dropdown } from '@epam/uui-components';
 import { Button, Panel, FlexRow, Text } from '../../../components';
 import { DefaultContext } from '../../../docs';
 
-const dropdownMenuDoc = new DocBuilder<DropdownProps>({ name: 'Dropdown', component: Dropdown as React.ComponentClass<any> })
+const dropdownMenuDoc = new DocBuilder<DropdownProps>({ name: 'Dropdown', component: Dropdown })
     .prop('renderBody', { isRequired: true, examples: [{
         value:
             () => {

--- a/epam-promo/components/pickers/docs/pickerModal.doc.tsx
+++ b/epam-promo/components/pickers/docs/pickerModal.doc.tsx
@@ -14,7 +14,7 @@ const dataSource = new ArrayDataSource({
     items: ["Product Manager", "Technician", "Senior Director", "Software Developer"].map(name => ({ id: name, name })),
 });
 
-const PickerInputDoc = new DocBuilder<PickerModalProps<any, any>>({ name: 'PickerModal', component: PickerModal as React.ComponentClass<any> })
+const PickerInputDoc = new DocBuilder<PickerModalProps<any, any>>({ name: 'PickerModal', component: PickerModal })
     .implements([pickerBaseOptionsDoc /*iconDoc, , */] as any)
     .prop('initialValue', { examples: [
             { name: '1', value: 1 },

--- a/epam-promo/components/pickers/docs/pickerToggler.doc.tsx
+++ b/epam-promo/components/pickers/docs/pickerToggler.doc.tsx
@@ -5,7 +5,7 @@ import { iEditable, isDisabledDoc, iconDoc, iconOptionsDoc, dropdownTogglerDoc }
 import { DefaultContext, ResizableContext, GridContext, FormContext, IHasEditModeDoc } from '../../../docs';
 import { PickerToggler, PickerTogglerMods } from '../PickerToggler';
 
-const PickerTogglerDoc = new DocBuilder<PickerTogglerProps<any, any> & PickerTogglerMods>({ name: 'PickerToggler', component: PickerToggler as React.ComponentClass<any> })
+const PickerTogglerDoc = new DocBuilder<PickerTogglerProps<any, any> & PickerTogglerMods>({ name: 'PickerToggler', component: PickerToggler })
     .prop('size', { examples: ['24', '30', '36', '42'], defaultValue: '36' })
     .implements([isDisabledDoc, isReadonlyDoc, iconDoc, iconOptionsDoc, dropdownTogglerDoc, iEditable, IHasEditModeDoc] as any)
     .prop('selection', { examples: [

--- a/epam-promo/components/typography/docs/richTextView.doc.tsx
+++ b/epam-promo/components/typography/docs/richTextView.doc.tsx
@@ -13,7 +13,7 @@ import cx from 'classnames';
 import * as css from '../../../assets/styles/typography.scss';
 import * as style from './richTextViewDoc.scss';
 
-const textDoc = new DocBuilder<RichTextViewProps & RichTextViewMods>({ name: 'RichTextView', component: RichTextView as React.ComponentClass<any> })
+const textDoc = new DocBuilder<RichTextViewProps & RichTextViewMods>({ name: 'RichTextView', component: RichTextView })
     .prop('htmlContent', {
         examples: [
             { value: '<h1>Hello</h1>', isDefault: false, name: '<h1>' },

--- a/extra/ideas/skin.ts
+++ b/extra/ideas/skin.ts
@@ -11,7 +11,7 @@ export type UUIInterfaceName = keyof UUIInterfaces;
 export type StandardIconType = 'dropdown' | 'btn-ok' | 'btn-delete';
 
 export interface SkinContext {
-    getComponent<T extends UUIInterfaceName>(type: T): React.ComponentClass<UUIInterfaces[T]>;  
+    getComponent<T extends UUIInterfaceName>(type: T): React.ComponentType<UUIInterfaces[T]>;
     getIcon(type: StandardIconType): Icon;
 }
 

--- a/loveship/components/datePickers/docs/calendar.doc.ts
+++ b/loveship/components/datePickers/docs/calendar.doc.ts
@@ -6,7 +6,7 @@ import { Calendar } from '../Calendar';
 import { iEditable } from '../../../docs';
 import { FormContext, DefaultContext, GridContext, ResizableContext } from '../../../docs';
 
-const DatepickerDoc = new DocBuilder<CalendarProps<Dayjs>>({ name: 'Calendar', component: Calendar as React.ComponentClass<any> })
+const DatepickerDoc = new DocBuilder<CalendarProps<Dayjs>>({ name: 'Calendar', component: Calendar })
     .implements([iEditable] as any)
     .prop('value', { examples: [{ value: dayjs('2017-12-30') }] })
     .prop('displayedDate', { examples: [{ value: dayjs('2017-12-30'), isDefault: true }], isRequired: true })

--- a/loveship/components/inputs/docs/checkbox.doc.tsx
+++ b/loveship/components/inputs/docs/checkbox.doc.tsx
@@ -4,7 +4,7 @@ import { CheckboxProps } from '@epam/uui-components';
 import { Checkbox, CheckboxMods } from '../Checkbox';
 import { isDisabledDoc, isInvalidDoc, iHasLabelDoc, iEditable, DefaultContext, ResizableContext, FormContext, GridContext, colorDoc } from '../../../docs';
 
-const CheckboxDoc = new DocBuilder<CheckboxProps & CheckboxMods>({ name: 'Checkbox', component: Checkbox as React.ComponentClass<any> })
+const CheckboxDoc = new DocBuilder<CheckboxProps & CheckboxMods>({ name: 'Checkbox', component: Checkbox })
     .implements([isDisabledDoc, isReadonlyDoc, colorDoc, isInvalidDoc, iHasLabelDoc, iEditable] as any)
     .prop('value', { examples: [true, false] })
     .prop('size', { examples: ['12', '18'], defaultValue: '18' })

--- a/loveship/components/inputs/docs/multiSwitch.doc.ts
+++ b/loveship/components/inputs/docs/multiSwitch.doc.ts
@@ -4,7 +4,7 @@ import { DocBuilder } from '@epam/uui-docs';
 import { FormContext, GridContext, DefaultContext } from '../../../docs';
 import { sizeDoc, colorDoc, iEditable } from '../../../docs';
 
-const multiSwitchDoc = new DocBuilder<MultiSwitchProps<any>>({ name: 'MultiSwitch', component: MultiSwitch as React.ComponentClass<any> })
+const multiSwitchDoc = new DocBuilder<MultiSwitchProps<any>>({ name: 'MultiSwitch', component: MultiSwitch })
     .implements([sizeDoc, colorDoc, iEditable] as any)
     .prop('items', { examples: [
         {

--- a/loveship/components/inputs/docs/numericInput.doc.ts
+++ b/loveship/components/inputs/docs/numericInput.doc.ts
@@ -5,7 +5,7 @@ import { NumericInput, NumericInputMods } from '../NumericInput';
 import { iEditable, sizeDoc, textSettingsDoc, isDisabledDoc, iHasPlaceholder, modeDoc, iFormatter } from '../../../docs';
 import { FormContext, GridContext, ResizableContext, DefaultContext } from '../../../docs';
 
-const NumericInputDoc = new DocBuilder<NumericInputProps & NumericInputMods>({ name: 'NumericInput', component: NumericInput as React.ComponentClass<any> })
+const NumericInputDoc = new DocBuilder<NumericInputProps & NumericInputMods>({ name: 'NumericInput', component: NumericInput })
     .implements([iEditable, iHasPlaceholder, sizeDoc, textSettingsDoc, isDisabledDoc, isReadonlyDoc, modeDoc, iFormatter] as any)
     .prop('value', { examples: [{ value: 0, isDefault: true }, 11] })
     .prop('step', { examples: [2, 5, 10] })

--- a/loveship/components/inputs/docs/radioInput.doc.tsx
+++ b/loveship/components/inputs/docs/radioInput.doc.tsx
@@ -5,7 +5,7 @@ import { RadioInput, RadioInputMods } from '../RadioInput';
 import { isDisabledDoc, isInvalidDoc, iHasLabelDoc, iEditable } from '../../../docs';
 import { DefaultContext, ResizableContext, FormContext, GridContext, colorDoc } from '../../../docs';
 
-const RadioInputDoc = new DocBuilder<RadioInputProps & RadioInputMods>({ name: 'RadioInput', component: RadioInput as React.ComponentClass<any> })
+const RadioInputDoc = new DocBuilder<RadioInputProps & RadioInputMods>({ name: 'RadioInput', component: RadioInput })
     .implements([isDisabledDoc, isReadonlyDoc, colorDoc, isInvalidDoc, iHasLabelDoc, iEditable] as any)
     .prop('value', { examples: [true, false] })
     .prop('size', { examples: ['12', '18'] })

--- a/loveship/components/inputs/docs/rating.doc.ts
+++ b/loveship/components/inputs/docs/rating.doc.ts
@@ -4,7 +4,7 @@ import { RatingProps } from '@epam/uui-components';
 import { Rating, RatingMods } from '../Rating';
 import { isDisabledDoc, isInvalidDoc, colorDoc, iEditable, DefaultContext, FormContext, GridContext } from '../../../docs';
 
-const RatingDoc = new DocBuilder<RatingProps & RatingMods>({ name: 'Rating', component: Rating as React.ComponentClass<any> })
+const RatingDoc = new DocBuilder<RatingProps & RatingMods>({ name: 'Rating', component: Rating })
     .implements([isDisabledDoc, isInvalidDoc, iEditable, colorDoc] as any)
     .prop('size', { examples: [18, 24, 30], defaultValue: 18 })
     .prop('value', { examples: [0.5, 1, 1.5, 2, 2.5, 3, 3.5, 4, 4.5, 5] })

--- a/loveship/components/inputs/docs/searchInput.doc.ts
+++ b/loveship/components/inputs/docs/searchInput.doc.ts
@@ -8,7 +8,7 @@ import {
 } from '../../../docs';
 import { IEditableDebouncerOptions } from '@epam/uui';
 
-const SearchInputDoc = new DocBuilder<TextInputProps & TextInputMods & IEditableDebouncerOptions>({ name: 'SearchInput', component: SearchInput as React.ComponentClass<any> })
+const SearchInputDoc = new DocBuilder<TextInputProps & TextInputMods & IEditableDebouncerOptions>({ name: 'SearchInput', component: SearchInput })
     .implements([onClickDoc, sizeDoc, textSettingsDoc, isDisabledDoc, isReadonlyDoc, isInvalidDoc, iconDoc, iconOptionsDoc, iEditable, iHasPlaceholder, dropdownTogglerDoc] as any)
     .prop('value', { examples: [
         { value: 'Hello, World!', isDefault: true },

--- a/loveship/components/inputs/docs/switch.doc.ts
+++ b/loveship/components/inputs/docs/switch.doc.ts
@@ -5,7 +5,7 @@ import { Switch, SwitchMods } from '../Switch';
 import { isDisabledDoc, iHasLabelDoc, iEditable, colorDoc } from '../../../docs';
 import { DefaultContext, ResizableContext, FormContext, GridContext } from '../../../docs';
 
-const SwitchDoc = new DocBuilder<SwitchProps & SwitchMods>({ name: 'Switch', component: Switch as React.ComponentClass<any>})
+const SwitchDoc = new DocBuilder<SwitchProps & SwitchMods>({ name: 'Switch', component: Switch })
     .implements([isDisabledDoc, iHasLabelDoc, iEditable, colorDoc] as any)
     .prop('theme', { examples: (['light', 'dark']), defaultValue: 'light' })
     .prop('size', { examples: ['12', '18', '24'], defaultValue: '18' })

--- a/loveship/components/inputs/docs/textInput.doc.ts
+++ b/loveship/components/inputs/docs/textInput.doc.ts
@@ -5,7 +5,7 @@ import { TextInput, TextInputMods } from '../TextInput';
 import { iEditable, textSettingsDoc, iHasPlaceholder, onClickDoc, isDisabledDoc, isReadonlyDoc, isInvalidDoc, iconDoc, iconOptionsDoc, dropdownTogglerDoc, modeDoc } from '../../../docs';
 import { DefaultContext, ResizableContext, GridContext, FormContext } from '../../../docs';
 
-const TextInputDoc = new DocBuilder<TextInputProps & TextInputMods>({ name: 'TextInput', component: TextInput as React.ComponentClass<any> })
+const TextInputDoc = new DocBuilder<TextInputProps & TextInputMods>({ name: 'TextInput', component: TextInput })
     .prop('size', { examples: ['60', '48', '42', '36', '30', '24'], defaultValue: '36' })
     .implements([textSettingsDoc, onClickDoc, isDisabledDoc, isReadonlyDoc, isInvalidDoc, iconDoc, iconOptionsDoc, iEditable, iHasPlaceholder, dropdownTogglerDoc, modeDoc] as any)
     .prop('maxLength', { examples: [10, 20, 30], type: 'number' })

--- a/loveship/components/inputs/docs/timePicker.doc.ts
+++ b/loveship/components/inputs/docs/timePicker.doc.ts
@@ -4,7 +4,7 @@ import { DocBuilder, isReadonlyDoc } from '@epam/uui-docs';
 import { iEditable, sizeDoc, isDisabledDoc, isInvalidDoc, modeDoc } from '../../../docs';
 import { FormContext, DefaultContext, GridContext, ResizableContext } from '../../../docs';
 
-const TimePickerDoc = new DocBuilder<TimePickerProps>({ name: 'TimePicker', component: TimePicker as React.ComponentClass<any> })
+const TimePickerDoc = new DocBuilder<TimePickerProps>({ name: 'TimePicker', component: TimePicker })
     .implements([iEditable, sizeDoc, isDisabledDoc, isReadonlyDoc, isInvalidDoc, modeDoc] as any)
     .prop('value', { examples: [{ name: '6:20', value: { hours: 6, minutes: 20 }, isDefault: true }] })
     .prop('minutesStep', { examples: [5, 10, 15], defaultValue: 5 })

--- a/loveship/components/layout/RadioGroup.tsx
+++ b/loveship/components/layout/RadioGroup.tsx
@@ -3,6 +3,6 @@ import { RadioGroup as uuiRadioGroup, RadioGroupProps } from '@epam/uui-componen
 import { RadioInput } from '../inputs';
 import * as css from './RadioGroup.scss';
 
-export const RadioGroup = withMods<RadioGroupProps<any>, any>(uuiRadioGroup, () => [css.root],
+export const RadioGroup = withMods<RadioGroupProps<any>>(uuiRadioGroup, () => [css.root],
     () => ({ RadioInput })
 );

--- a/loveship/components/layout/docs/blocker.doc.ts
+++ b/loveship/components/layout/docs/blocker.doc.ts
@@ -3,7 +3,7 @@ import { DocBuilder } from '@epam/uui-docs';
 import { BlockerProps } from '@epam/uui-components';
 import { RelativePanelContext } from '../../../docs';
 
-const blockerDoc = new DocBuilder<BlockerProps>({ name: 'Blocker', component: Blocker as React.ComponentClass<any> })
+const blockerDoc = new DocBuilder<BlockerProps>({ name: 'Blocker', component: Blocker })
     .prop('isEnabled', { examples: [{ value: true, isDefault: true }] })
     .prop('spacerHeight', { examples: [0, 24, 30, 36, 50, { value: 100, isDefault: true }, 200, 300] })
     .prop('hideSpinner', { examples:[true] })

--- a/loveship/components/navigation/docs/mainMenu.doc.tsx
+++ b/loveship/components/navigation/docs/mainMenu.doc.tsx
@@ -5,7 +5,7 @@ import { DocBuilder } from '@epam/uui-docs';
 import { ResizableContext } from "../../../docs";
 import * as svgTriangle from '../../icons/triangle.svg';
 
-const mainMenuDoc = new DocBuilder<MainMenuMods & MainMenuProps>({ name: 'MainMenu', component: MainMenu as React.ComponentClass<any> })
+const mainMenuDoc = new DocBuilder<MainMenuMods & MainMenuProps>({ name: 'MainMenu', component: MainMenu })
     .prop('renderBurger', {
         examples: [
             {

--- a/loveship/components/overlays/docs/alert.doc.tsx
+++ b/loveship/components/overlays/docs/alert.doc.tsx
@@ -6,7 +6,7 @@ import { AlertProps, Alert } from '..';
 import { colors } from "../../../helpers/colorMap";
 import { allEpamPrimaryColors } from "../../types";
 
-const SnackbarCardDoc = new DocBuilder<AlertProps>({ name: 'Alert', component: Alert as React.ComponentClass<any> })
+const SnackbarCardDoc = new DocBuilder<AlertProps>({ name: 'Alert', component: Alert })
     .implements([iconDoc] as any)
     .prop('color', { renderEditor: (editable: any, examples) => <ColorPicker colors={ examples.map(i => ({ value: i, hex: colors[i] })) } { ...editable } />, examples: allEpamPrimaryColors })
     .prop('children', {

--- a/loveship/components/overlays/docs/dropdown.doc.tsx
+++ b/loveship/components/overlays/docs/dropdown.doc.tsx
@@ -4,7 +4,7 @@ import { DropdownProps, Dropdown } from '@epam/uui-components';
 import { DropdownMenuItemMods, DropdownMenuButton, Button, DropdownMenuSplitter, DropdownMenuBody, DropdownMenuHeader } from '../../../components';
 import { DefaultContext } from '../../../docs';
 
-const dropdownMenuDoc = new DocBuilder<DropdownProps & DropdownMenuItemMods>({ name: 'Dropdown', component: Dropdown as React.ComponentClass<any> })
+const dropdownMenuDoc = new DocBuilder<DropdownProps & DropdownMenuItemMods>({ name: 'Dropdown', component: Dropdown })
     .prop('renderBody', { isRequired: true, examples: [{
         value:
             () =>

--- a/loveship/components/overlays/docs/dropdownMenu.doc.tsx
+++ b/loveship/components/overlays/docs/dropdownMenu.doc.tsx
@@ -4,7 +4,7 @@ import { DropdownProps, Dropdown } from '@epam/uui-components';
 import { DropdownMenuItemMods, DropdownMenuButton, MainMenuButton , DropdownMenuSplitter, DropdownMenuBody, DropdownMenuHeader } from '../../../components';
 import { DefaultContext, MainMenuContext } from '../../../docs';
 
-const dropdownMenuDoc = new DocBuilder<DropdownProps & DropdownMenuItemMods>({ name: 'DropdownMenu', component: Dropdown as React.ComponentClass<any> })
+const dropdownMenuDoc = new DocBuilder<DropdownProps & DropdownMenuItemMods>({ name: 'DropdownMenu', component: Dropdown })
     .prop('renderBody', { examples: [{
         value:
             () =>

--- a/loveship/components/overlays/docs/notificationCard.doc.tsx
+++ b/loveship/components/overlays/docs/notificationCard.doc.tsx
@@ -2,9 +2,9 @@ import React from 'react';
 import { DocBuilder } from '@epam/uui-docs';
 import { DefaultContext, colorDoc, iconWithInfoDoc } from '../../../docs';
 import { Text } from '../../typography';
-import { NotificationCard, DefaultNotificationProps } from '../NotificationCard';
+import { NotificationCard, NotificationCardProps } from '../NotificationCard';
 
-const SnackbarCardDoc = new DocBuilder<DefaultNotificationProps>({ name: 'NotificationCard', component: NotificationCard as React.ComponentClass<any> })
+const SnackbarCardDoc = new DocBuilder<NotificationCardProps>({ name: 'NotificationCard', component: NotificationCard })
     .implements([iconWithInfoDoc, colorDoc] as any)
     .prop('children', {
         examples: [

--- a/loveship/components/overlays/docs/snackbarCard.doc.tsx
+++ b/loveship/components/overlays/docs/snackbarCard.doc.tsx
@@ -6,7 +6,7 @@ import { LinkButton } from '../../buttons';
 import { FlexRow } from '../../layout';
 import { Text } from '../../typography';
 
-const SnackbarCardDoc = new DocBuilder<SnackbarCardProps>({ name: 'SnackbarCard', component: SnackbarCard as React.ComponentClass<any> })
+const SnackbarCardDoc = new DocBuilder<SnackbarCardProps>({ name: 'SnackbarCard', component: SnackbarCard })
     .prop('snackType', {
         examples: [
             { value: 'success' },

--- a/loveship/components/pickers/docs/pickerList.doc.tsx
+++ b/loveship/components/pickers/docs/pickerList.doc.tsx
@@ -11,7 +11,7 @@ import { LinkButton, Button } from '../../buttons';
 import { Text } from '../../typography';
 import { FlexRow } from '../../layout';
 
-const PickerListDoc = new DocBuilder<PickerListProps<any, any> & PickerListBaseProps<any, any> >({ name: 'PickerList', component: PickerList as React.ComponentClass<any> })
+const PickerListDoc = new DocBuilder<PickerListProps<any, any> & PickerListBaseProps<any, any> >({ name: 'PickerList', component: PickerList })
     .implements([/*sizeDoc, */isDisabledDoc, iEditable, pickerBaseOptionsDoc /*iconDoc, , */] as any)
     .prop('value', { examples: [
             { name: '1', value: 1 },

--- a/loveship/components/pickers/docs/pickerModal.doc.tsx
+++ b/loveship/components/pickers/docs/pickerModal.doc.tsx
@@ -14,7 +14,7 @@ const dataSource = new ArrayDataSource({
     items: ["Product Manager", "Technician", "Senior Director", "Software Developer"].map(name => ({ id: name, name })),
 });
 
-const PickerInputDoc = new DocBuilder<PickerModalProps<any, any>>({ name: 'PickerModal', component: PickerModal as React.ComponentClass<any> })
+const PickerInputDoc = new DocBuilder<PickerModalProps<any, any>>({ name: 'PickerModal', component: PickerModal })
     .implements([pickerBaseOptionsDoc /*iconDoc, , */] as any)
     .prop('valueType', { examples: ['id', 'entity'], isRequired: true })
     .prop('selectionMode', { examples: ['single', 'multi'], isRequired: true })

--- a/loveship/components/pickers/docs/pickerToggler.doc.tsx
+++ b/loveship/components/pickers/docs/pickerToggler.doc.tsx
@@ -6,7 +6,7 @@ import { DefaultContext, ResizableContext, GridContext, FormContext } from '../.
 import { PickerToggler } from '../PickerToggler';
 import { Button } from '../../buttons';
 
-const PickerTogglerDoc = new DocBuilder<PickerTogglerProps<any, any>>({ name: 'PickerToggler', component: PickerToggler as React.ComponentClass<any> })
+const PickerTogglerDoc = new DocBuilder<PickerTogglerProps<any, any>>({ name: 'PickerToggler', component: PickerToggler })
     .implements([sizeDoc, isDisabledDoc, isReadonlyDoc, iconDoc, iconOptionsDoc, dropdownTogglerDoc, iEditable, modeDoc] as any)
     .prop('selection', { examples: [
         { name:'Tags', value: [{ value: '.Net' }, { value: 'JS' }, { value: 'React' }], isDefault: true },

--- a/loveship/components/typography/docs/richTextView.doc.tsx
+++ b/loveship/components/typography/docs/richTextView.doc.tsx
@@ -12,7 +12,7 @@ import cx from 'classnames';
 import * as css from '../../../assets/styles/scss/typography.scss';
 import * as style from './richTextViewDoc.scss';
 
-const textDoc = new DocBuilder<RichTextViewProps & RichTextViewMods>({ name: 'RichTextView', component: RichTextView as React.ComponentClass<any> })
+const textDoc = new DocBuilder<RichTextViewProps & RichTextViewMods>({ name: 'RichTextView', component: RichTextView })
     .prop('htmlContent', {
         examples: [
             { value: '<h1>Hello</h1>', isDefault: false, name: '<h1>' },

--- a/loveship/components/widgets/docs/carousel.doc.tsx
+++ b/loveship/components/widgets/docs/carousel.doc.tsx
@@ -38,7 +38,7 @@ const items = [
     { country: 'Italy' },
 ];
 
-const textDoc = new DocBuilder<CarouselProps & CarouselMods>({ name: 'Carousel', component: Carousel as React.ComponentClass<any> })
+const textDoc = new DocBuilder<CarouselProps & CarouselMods>({ name: 'Carousel', component: Carousel })
     .implements([colorDoc] as any)
     .prop('items', {
         examples: [

--- a/uui-components/src/inputs/Rating/Rating.tsx
+++ b/uui-components/src/inputs/Rating/Rating.tsx
@@ -9,7 +9,7 @@ export interface RatingProps extends BaseRatingProps<number> {
     emptyStarIcon?: any;
     hideTooltip?: boolean;
     hint?: (value: number) => string;
-    Tooltip?: React.ComponentClass<TooltipProps>;
+    Tooltip?: React.ComponentType<TooltipProps>;
 }
 
 const uuiRating: Record<string, string> = {

--- a/uui-components/src/layout/CheckboxGroup.tsx
+++ b/uui-components/src/layout/CheckboxGroup.tsx
@@ -10,7 +10,7 @@ interface CheckboxGroupItem<TValue> {
 }
 
 export interface CheckboxGroupProps<TValue> extends ICanBeInvalid, IHasCX, IEditable<TValue[]>, IDisableable, IHasDirection, ICanBeReadonly, IHasRawProps<HTMLFieldSetElement> {
-    CheckboxInput?: React.ComponentClass<CheckboxProps>;
+    CheckboxInput?: React.ComponentType<CheckboxProps>;
     items: CheckboxGroupItem<TValue>[];
 }
 

--- a/uui-components/src/layout/LabeledInput.tsx
+++ b/uui-components/src/layout/LabeledInput.tsx
@@ -6,7 +6,7 @@ import { Svg } from '../widgets/Svg';
 import { i18n } from '../../i18n';
 
 export interface LabeledInputProps extends LabeledInputCoreProps {
-    Tooltip?: React.ComponentClass<TooltipProps>;
+    Tooltip?: React.ComponentType<TooltipProps>;
     infoIcon?: Icon;
 }
 

--- a/uui-components/src/layout/RadioGroup.tsx
+++ b/uui-components/src/layout/RadioGroup.tsx
@@ -10,7 +10,7 @@ export interface RadioGroupItem<TValue> extends IDisableable {
 }
 
 export interface RadioGroupProps<TValue> extends IHasCX, IEditable<TValue>, IDisableable, IHasDirection, ICanBeReadonly, IHasRawProps<HTMLFieldSetElement> {
-    RadioInput?: React.ComponentClass<RadioInputProps>;
+    RadioInput?: React.ComponentType<RadioInputProps>;
     items: RadioGroupItem<TValue>[];
     radioInputProps?: any;
 }

--- a/uui-components/src/navigation/MainMenu/MainMenu.tsx
+++ b/uui-components/src/navigation/MainMenu/MainMenu.tsx
@@ -28,8 +28,8 @@ export interface MainMenuProps extends IHasCX, IHasRawProps<HTMLDivElement> {
     onLogoClick?: (e: MouseEvent) => any;
     customerLogoLink?: Link;
     customerLogoHref?: string;
-    MainMenuDropdown?: React.ComponentClass<MainMenuDropdownProps>;
-    Burger?: React.ComponentClass<BurgerProps>;
+    MainMenuDropdown?: React.ComponentType<MainMenuDropdownProps>;
+    Burger?: React.ComponentType<BurgerProps>;
 }
 
 interface MainMenuState {

--- a/uui-docs/src/DocBuilder.ts
+++ b/uui-docs/src/DocBuilder.ts
@@ -38,7 +38,7 @@ export class DocBuilder<TProps> implements IComponentDocs<TProps> {
         return this;
     }
 
-    public withContexts(...contexts: (React.ComponentClass<DemoComponentProps> & { displayName: string })[]) {
+    public withContexts(...contexts: (React.ComponentType<DemoComponentProps> & { displayName: string })[]) {
         contexts.forEach(context => this.contexts.push({ context, name: context.displayName }));
         return this;
     }

--- a/uui-docs/src/types.ts
+++ b/uui-docs/src/types.ts
@@ -7,15 +7,15 @@ export interface DemoComponentProps<TProps = any> {
     props: any;
 }
 
-export interface IComponentDocs<TProps> {
+export interface IComponentDocs<TProps extends {}> {
     name: string;
-    component?: React.ComponentType<TProps>;
+    component?: React.ComponentType<TProps> | React.NamedExoticComponent<TProps>;
     props?: PropDoc<TProps, keyof TProps>[];
     contexts?: DemoContext[];
 }
 
 export interface DemoContext {
-    context: React.ComponentClass<DemoComponentProps>;
+    context: React.ComponentType<DemoComponentProps>;
     name: string;
 }
 

--- a/uui-editor/src/implementation/Toolbar.tsx
+++ b/uui-editor/src/implementation/Toolbar.tsx
@@ -44,7 +44,7 @@ export class Toolbar extends React.Component<ToolbarProps, any> {
         };
     }
 
-    renderButton = (Button: React.ComponentClass<{ editor: Editor }>, index: number) => {
+    renderButton = (Button: React.ComponentType<{ editor: Editor }>, index: number) => {
         return <Button editor={ this.props.editor } key={ `toolbar-button-${index}` } />;
     }
 

--- a/uui/helpers/withMods.ts
+++ b/uui/helpers/withMods.ts
@@ -2,26 +2,13 @@ import * as React from 'react';
 import { IHasCX, CX } from '../types';
 
 export function withMods<TProps extends IHasCX, TMods = {}>(
-    component: React.ComponentClass<TProps> | React.FC<TProps>,
+    Component: React.ComponentType<TProps>,
     getCx: (props: Readonly<TProps & TMods>) => CX,
     getProps?: (props: Readonly<TProps & TMods>) => Partial<TProps>,
-): React.ComponentClass<TProps & TMods> {
-    const wrappedComponent: React.RefForwardingComponent<any, TProps & TMods> = (outerProps, ref) => {
-        const cx = [getCx(outerProps), outerProps.cx];
-        const innerProps = getProps && getProps(outerProps);
-
-        // Spread operator is faster than Object.assign. However, with ES5 target, is transpiled to a slower TypeScript helpers.
-        // We can revisit that when we'll target ES7 with native spread operator.
-        // tslint:disable-next-line
-        const props: any = Object.assign({}, outerProps, innerProps);
-        props.cx = cx;
-        props.ref = ref;
-        //const props = { ...outerProps as any, ...innerProps as any, cx, ref }; // spread version
-
-        return React.createElement(component, props);
-    };
-
-    (wrappedComponent as any).displayName = `withMods(${component?.displayName || component?.name || 'unknown'})`;
-
-    return React.forwardRef(wrappedComponent) as any;
-}
+) {
+    return React.forwardRef<any, TProps & TMods>((props, ref) => {
+        const allProps: TProps & TMods = Object.assign({}, props, getProps?.(props));
+        Component.displayName = `withMods(${Component?.displayName || Component?.name || 'unknown'})`;
+        return React.createElement(Component, { ...allProps, cx: [getCx(props), props.cx] , ref });
+    });
+};

--- a/uui/services/ModalContext.ts
+++ b/uui/services/ModalContext.ts
@@ -16,7 +16,7 @@ export interface ModalComponentProps<TParameters, TResult> {
 }
 
 export interface ModalOperation {
-    component?: React.ComponentClass<any>;
+    component?: React.ComponentType<any>;
     props: ModalComponentProps<any, any>;
 }
 
@@ -63,7 +63,7 @@ export class ModalContext extends BaseContext implements IModalContext {
     }
 
     private showModal<TParameters, TResult>(
-        component: React.ComponentClass<ModalComponentProps<TParameters, TResult>>,
+        component: React.ComponentType<ModalComponentProps<TParameters, TResult>>,
         parameters?: TParameters,
     ): Promise<TResult> {
         const layer = this.layoutCtx.getLayer();

--- a/uui/services/NotificationContext.tsx
+++ b/uui/services/NotificationContext.tsx
@@ -6,7 +6,7 @@ import { LayoutContext } from './LayoutContext';
 import { INotification } from '../types/props';
 
 export interface NotificationOperation {
-    component: React.ComponentClass<any>;
+    component: React.ComponentType<any>;
     props: INotification;
     config: NotificationParams;
 }

--- a/uui/services/SkinContext.ts
+++ b/uui/services/SkinContext.ts
@@ -3,7 +3,7 @@ import { ButtonCoreProps, CheckboxCoreProps, FlexCellProps, FlexRowProps, TextIn
 import * as React from 'react';
 
 interface ISkinComponent<TProps, TSemanticProps= {}> {
-    component: React.ComponentClass<TProps>;
+    component: React.ComponentType<TProps>;
     mapProps?(props: SkinContextComponentProps<TProps, TSemanticProps>): TProps;
     render(props: SkinContextComponentProps<TProps, TSemanticProps>): React.ReactElement<SkinContextComponentProps<TProps, TSemanticProps>>;
 }
@@ -14,7 +14,7 @@ export type SkinContextComponentProps<TProps, TSemanticProps = {}> = TProps & TS
 
 
 export function skinComponent<TProps, TSemanticProps = {}>(
-    component: React.ComponentClass<TProps>,
+    component: React.ComponentType<TProps>,
     mapProps?: (props: SkinContextComponentProps<TProps, TSemanticProps>) => TProps,
 ): ISkinComponent<TProps, TSemanticProps> {
     return {


### PR DESCRIPTION
Refactor withMods to be more flexible while working with FunctionComponent and ClassComponent
By doing this, it leverages DocBuilder component type problems

Any context or component that requires a component to be passed can work with both FC and ClassComponent. (This one should be discussed)