### PR TITLE
fix(NumericInput): add check for empty string

### DIFF
--- a/uui-components/src/inputs/NumericInput.tsx
+++ b/uui-components/src/inputs/NumericInput.tsx
@@ -72,7 +72,9 @@ export class NumericInput extends React.Component<NumericInputProps, NumericInpu
     }
 
     handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-        this.setState({value: e.target.value});
+        if (e.target.value !== "") {
+            this.setState({value: e.target.value});
+        }
     }
 
     handleFocus = () => this.setState({inFocus: true});

--- a/uui-components/src/inputs/NumericInput.tsx
+++ b/uui-components/src/inputs/NumericInput.tsx
@@ -72,12 +72,16 @@ export class NumericInput extends React.Component<NumericInputProps, NumericInpu
     }
 
     handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-        if (e.target.value !== "") {
-            this.setState({value: e.target.value});
-        }
+        this.setState({value: e.target.value});
     }
 
     handleFocus = () => this.setState({inFocus: true});
+
+    handleKeyPress = (e: React.KeyboardEvent<HTMLInputElement>) => {
+        if (!/\d/.test(e.key)) {
+            e.preventDefault()
+        }
+    }
 
     handleBlur = () => {
         let value: number | null;
@@ -153,6 +157,7 @@ export class NumericInput extends React.Component<NumericInputProps, NumericInpu
                     value={ this.state.value }
                     inputMode="numeric"
                     placeholder={ this.props.placeholder || '0' }
+                    onKeyPress={this.handleKeyPress}
                     onChange={ this.handleChange }
                     min={ this.props.min || 0 }
                     max={ this.props.max }


### PR DESCRIPTION
fixes #282

Safari considers any non-number values an empty string.
Added a check that will prevent entering an empty string into the input.