### PR TITLE
Added spaces around unfound icon's name

### DIFF
--- a/app/src/docs/assets/Icons.doc.tsx
+++ b/app/src/docs/assets/Icons.doc.tsx
@@ -252,7 +252,7 @@ export class IconsDoc extends React.Component {
             return <div className={ css.unsuccessfulSearch } >
                 <Text fontSize='16' lineHeight='24' cx={ css.unsuccessfulSearchText }>
                     Unfortunately, we did not find
-                    <span>{ this.state.search }</span>
+                    <span> { this.state.search } </span>
                     icon in our package. But we can add it in the next release.
                 </Text>
                 <FlexRow>


### PR DESCRIPTION
<img width="313" alt="image" src="https://user-images.githubusercontent.com/45464847/147105988-ba845980-906b-4fef-949d-22952e03b1cb.png">
