### PR TITLE
[Typescript, Amplitude]: Upgrade and remove importing helpers

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -24,7 +24,7 @@
     "@epam/uui-docs": "4.5.0",
     "@epam/uui-editor": "4.5.0",
     "@epam/uui-timeline": "4.5.0",
-    "amplitude-js": "7.4.1",
+    "amplitude-js": "^8.9.1",
     "classnames": "2.2.6",
     "codesandbox": "2.2.3",
     "history": "4.10.1",
@@ -66,7 +66,7 @@
   },
   "gitHead": "a46206079e94ed85069ae90a59cc4ba48b9bc9eb",
   "devDependencies": {
-    "@types/amplitude-js": "^7.0.0",
+    "@types/amplitude-js": "^8.0.1",
     "@types/history": "4.7.9",
     "@types/jest": "25.2.3",
     "@types/node": "14.0.5",
@@ -77,7 +77,7 @@
     "@types/react-router": "5.1.7",
     "@types/react-router-dom": "5.1.5",
     "@types/webpack-env": "1.16.2",
-    "typescript": "4.1.5",
+    "typescript": "4.5.4",
     "webpack-bundle-analyzer": "^4.4.2"
   }
 }

--- a/app/src/analyticsEvents/listeners/AmplitudeListener.ts
+++ b/app/src/analyticsEvents/listeners/AmplitudeListener.ts
@@ -1,17 +1,17 @@
 import { IAnalyticsListener, AnalyticsEvent } from "@epam/uui";
-import { AmplitudeClient, getInstance } from "amplitude-js";
+import amplitude from "amplitude-js";
 
 export class AmplitudeListener implements IAnalyticsListener {
     public ampCode: string;
-    public client: AmplitudeClient;
+    public client: amplitude.AmplitudeClient;
 
     constructor(ampCode: string) {
         this.ampCode = ampCode;
         this.client = this.getAmplitudeClient();
     }
 
-    private getAmplitudeClient(): AmplitudeClient {
-        const ampclient = getInstance();
+    private getAmplitudeClient(): amplitude.AmplitudeClient {
+        const ampclient = amplitude.getInstance();
         ampclient.init(this.ampCode, undefined, {includeReferrer: true, includeUtm: true, saveParamsReferrerOncePerSession: false});
         return ampclient;
     }

--- a/app/src/data/codesandbox/package.json
+++ b/app/src/data/codesandbox/package.json
@@ -35,7 +35,7 @@
     "@types/react": "17.0.0",
     "@types/react-dom": "17.0.0",
     "@types/node": "14.0.5",
-    "typescript": "4.1.3",
+    "typescript": "4.5.4",
     "typescript-plugin-css-modules": "1.2.1"
   },
   "scripts": {

--- a/app/src/docs/examples/contexts/AnalyticsContextBase.example.tsx
+++ b/app/src/docs/examples/contexts/AnalyticsContextBase.example.tsx
@@ -1,21 +1,21 @@
 import React, { useCallback } from "react";
 import { ContextProvider } from "@epam/uui";
 import { svc } from "../../../services";
-import { AmplitudeClient, getInstance} from "amplitude-js";
+import amplitude from "amplitude-js";
 import { IAnalyticsListener, AnalyticsEvent } from "@epam/uui";
 
 /**An example of creation AmplitudeClientListener */
 class AmplitudeListener implements IAnalyticsListener {
     public ampCode: string;
-    public client: AmplitudeClient;
+    public client: amplitude.AmplitudeClient;
 
     constructor(ampCode: string) {
         this.ampCode = ampCode;
         this.client = this.getAmplitudeClient();
     }
 
-    private getAmplitudeClient(): AmplitudeClient {
-        const ampclient = getInstance();
+    private getAmplitudeClient(): amplitude.AmplitudeClient {
+        const ampclient = amplitude.getInstance();
         ampclient.init(this.ampCode, undefined, {includeReferrer: true, includeUtm: true, saveParamsReferrerOncePerSession: false});
         return ampclient;
     }

--- a/edu-core-routing/urlParser.ts
+++ b/edu-core-routing/urlParser.ts
@@ -32,6 +32,7 @@ function parseQueryString(querystring: string) {
 function cleaningObject(obj: any) {
     const isArray = obj instanceof Array;
     for (const k in obj) {
+        if (typeof k !== 'number') return;
         if (obj[k] === null || obj[k] === undefined) isArray ? obj.splice(k, 1) : delete obj[k];
         else if (typeof obj[k] == "object") cleaningObject(obj[k]);
     }

--- a/loveship/components/datePickers/docs/rangeDatePicker.doc.tsx
+++ b/loveship/components/datePickers/docs/rangeDatePicker.doc.tsx
@@ -46,7 +46,7 @@ const RangeDatePickerDoc = new DocBuilder<RangeDatePickerProps>({ name: 'RangeDa
     })
     .prop('renderDay', { examples: ctx => [{
             name: 'Render custom day',
-            value: (day, onDayClick: (day: Dayjs) => void) => (
+            value: (day: any, onDayClick: (day: Dayjs) => void) => (
                 <Day
                     renderDayNumber={ getCustomDay }
                     value={ day }

--- a/next-app/tsconfig.json
+++ b/next-app/tsconfig.json
@@ -12,6 +12,7 @@
     "preserveConstEnums": true,
     "sourceMap": true,
     "noEmitOnError": true,
+    "importHelpers": true,
     "outDir": "./build",
     "rootDir": ".",
     "lib": [

--- a/next-app/tsconfig.json
+++ b/next-app/tsconfig.json
@@ -14,7 +14,6 @@
     "noEmitOnError": true,
     "outDir": "./build",
     "rootDir": ".",
-    "importHelpers": true,
     "lib": [
       "dom",
       "dom.iterable",

--- a/package.json
+++ b/package.json
@@ -64,6 +64,9 @@
     "not ie <= 11",
     "not op_mini all"
   ],
+  "dependencies": {
+    "tslib": "^2.3.1"
+  },
   "devDependencies": {
     "lerna": "3.22.1",
     "typedoc": "0.17.4"

--- a/package.json
+++ b/package.json
@@ -64,10 +64,8 @@
     "not ie <= 11",
     "not op_mini all"
   ],
-  "dependencies": {
-    "tslib": "^2.3.1"
-  },
   "devDependencies": {
+    "tslib": "^2.3.1",
     "lerna": "3.22.1",
     "typedoc": "0.17.4"
   }

--- a/templates/uui-cra-template/template.json
+++ b/templates/uui-cra-template/template.json
@@ -7,7 +7,7 @@
       "@epam/uui-components": "latest",
       "react-router-dom": "5.2.0",
       "history": "4.10.1",
-      "typescript": "^4.1.2",
+      "typescript": "^4.5.4",
       "dart-sass": "1.25.0",
       "node-sass": "npm:sass"
     },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,7 @@
         "jsx": "react",
         "outDir": "./build",
         "rootDir": ".",
-        "importHelpers": true,
+        "importHelpers": false,
         "esModuleInterop": true,
         "lib": [
             "dom",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,7 @@
         "jsx": "react",
         "outDir": "./build",
         "rootDir": ".",
-        "importHelpers": false,
+        "importHelpers": true,
         "esModuleInterop": true,
         "lib": [
             "dom",

--- a/uui-build/package.json
+++ b/uui-build/package.json
@@ -79,6 +79,7 @@
     "ts-morph": "7.1.2",
     "ts-pnp": "1.1.6",
     "tsconfig-paths-webpack-plugin": "3.2.0",
+    "tslib": "^2.3.1",
     "tslint": "^5.11.0",
     "tslint-config-airbnb": "^5.11.0",
     "tslint-react": "^3.6.0",

--- a/uui-build/package.json
+++ b/uui-build/package.json
@@ -90,7 +90,7 @@
     "workbox-webpack-plugin": "4.3.1"
   },
   "devDependencies": {
-    "typescript": "4.1.5"
+    "typescript": "4.5.4"
   },
   "publishConfig": {
     "directory": "build"

--- a/uui/helpers/urlParser.ts
+++ b/uui/helpers/urlParser.ts
@@ -25,6 +25,7 @@ function parse(querystring: string) {
 function cleanupObject(obj: any) {
     const isArray = obj instanceof Array;
     for (const k in obj) {
+        if (typeof k !== 'number') return;
         if (obj[k] === null || obj[k] === undefined) isArray ? obj.splice(k, 1) : delete obj[k];
         else if (typeof obj[k] === "object") cleanupObject(obj[k]);
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7,10 +7,10 @@
   resolved "https://registry.yarnpkg.com/@amplitude/types/-/types-1.9.1.tgz#df614ac6d278c60c39bb49e05014cdcc7e7714e9"
   integrity sha512-s10ewnlFjHjNWrUMVTPJ2YRj0eD5UoeL+d0HB01x2Ltae/jFgtHQBS/HGKYV5I+NyiaezjrrZImhAQ72Ww/+8g==
 
-"@amplitude/ua-parser-js@0.7.24":
-  version "0.7.24"
-  resolved "https://registry.yarnpkg.com/@amplitude/ua-parser-js/-/ua-parser-js-0.7.24.tgz#2ce605af7d2c38d4a01313fb2385df55fbbd69aa"
-  integrity sha512-VbQuJymJ20WEw0HtI2np7EdC3NJGUWi8+Xdbc7uk8WfMIF308T0howpzkQ3JFMN7ejnrcSM/OyNGveeE3TP3TA==
+"@amplitude/ua-parser-js@0.7.26":
+  version "0.7.26"
+  resolved "https://registry.yarnpkg.com/@amplitude/ua-parser-js/-/ua-parser-js-0.7.26.tgz#18d889d84d2ba90c248ab6fcd7e3dd07f1c9c86e"
+  integrity sha512-62/Rid6YQ7F2KT/5vTre41Y26ivrEoFC8lbrsJZqBKaiXMJWG0YpNv9RgxNSaZS2jPLVQgoB/FFeWxihOLfIcg==
 
 "@amplitude/utils@^1.0.5":
   version "1.9.1"
@@ -2620,10 +2620,10 @@
     multimatch "^4.0.0"
     typescript "~3.9.7"
 
-"@types/amplitude-js@^7.0.0":
-  version "7.0.1"
-  resolved "https://registry.yarnpkg.com/@types/amplitude-js/-/amplitude-js-7.0.1.tgz#c0b1bc6e508faa513a30ece580c300f0738a9449"
-  integrity sha512-xrmhX39GoSBIuOOPWYL5uvVLn6a5Cvea0wb6SkJNW9+2w5GCK6hT0vvMaH1GaaeSqvb1QFjHNsEgXuyQqML0sw==
+"@types/amplitude-js@^8.0.1":
+  version "8.9.3"
+  resolved "https://registry.yarnpkg.com/@types/amplitude-js/-/amplitude-js-8.9.3.tgz#d6280fe6cb6210d6dbc5a374577385ac5b682872"
+  integrity sha512-Sv7yiP7MLkcrrrNzUVHwpyGyR+3POMwQlJWHywqXhQa8ae3HpXPnwwvnEry0BQ1t+xRW3MoEuVXha/8Oy8i50w==
 
 "@types/babel__core@^7.1.0":
   version "7.1.17"
@@ -3475,13 +3475,14 @@ alphanum-sort@^1.0.0:
   resolved "https://registry.yarnpkg.com/alphanum-sort/-/alphanum-sort-1.0.2.tgz#97a1119649b211ad33691d9f9f486a8ec9fbe0a3"
   integrity sha1-l6ERlkmyEa0zaR2fn0hqjsn74KM=
 
-amplitude-js@7.4.1:
-  version "7.4.1"
-  resolved "https://registry.yarnpkg.com/amplitude-js/-/amplitude-js-7.4.1.tgz#ad1b47fefca3b1c9afe257f8b8164cce95e671cf"
-  integrity sha512-AiqYt9z0tzWBxcE0ILVDNOksXuPdZa4Jiak2VSWwBpgt+CUJ4jZzT3daGZPbw50o2/KnSIfMfAojcT7PpmKxLA==
+amplitude-js@^8.9.1:
+  version "8.15.0"
+  resolved "https://registry.yarnpkg.com/amplitude-js/-/amplitude-js-8.15.0.tgz#1f7f8b8985cac187d67a614c369bfa50bc90e3cc"
+  integrity sha512-8pHN4dfKB0XwzgtgdEZgPVgkPr/fRsv11BECATYdUAIpLkj+sVEob7DphBa7fpBWPmRm+NXe1LRryThPZp7UuQ==
   dependencies:
-    "@amplitude/ua-parser-js" "0.7.24"
+    "@amplitude/ua-parser-js" "0.7.26"
     "@amplitude/utils" "^1.0.5"
+    "@babel/runtime" "^7.3.4"
     blueimp-md5 "^2.10.0"
     query-string "5"
 
@@ -16535,10 +16536,10 @@ typedoc@0.17.4:
     shelljs "^0.8.3"
     typedoc-default-themes "^0.10.0"
 
-typescript@4.1.5:
-  version "4.1.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.5.tgz#123a3b214aaff3be32926f0d8f1f6e704eb89a72"
-  integrity sha512-6OSu9PTIzmn9TCDiovULTnET6BgXtDYL4Gg4szY+cGsc3JP1dQL8qvE8kShTRx1NIw4Q9IBHlwODjkjWEtMUyA==
+typescript@4.5.4:
+  version "4.5.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.5.4.tgz#a17d3a0263bf5c8723b9c52f43c5084edf13c2e8"
+  integrity sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg==
 
 typescript@~3.9.7:
   version "3.9.10"

--- a/yarn.lock
+++ b/yarn.lock
@@ -16331,7 +16331,7 @@ tslib@^1.10.0, tslib@^1.7.1, tslib@^1.8.0, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
-tslib@^2.0.3, tslib@^2.2.0:
+tslib@^2.0.3, tslib@^2.2.0, tslib@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
   integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==


### PR DESCRIPTION
1. Upgrade ```Typescript```
2. Upgrade ```Amplitude-JS```
3. Remove `importHelpers` flag from tsconfig.json, which required peer dep ```tslib``` to be installed