### PR TITLE
[Form]: Add isSavedBeforeLeave arg to onSuccess hook

### DIFF
--- a/uui/data/forms/Form.tsx
+++ b/uui/data/forms/Form.tsx
@@ -13,7 +13,7 @@ export interface FormProps<T> {
     onSave(state: T): Promise<FormSaveResponse<T> | void>;
     beforeLeave?: (() => Promise<boolean>) | null;
     loadUnsavedChanges?: () => Promise<void>;
-    onSuccess?(state: T): any;
+    onSuccess?(state: T, isSavedBeforeLeave?: boolean): any;
     onError?(error: any): any;
     settingsKey?: string;
     value: T;

--- a/uui/data/forms/useForm.ts
+++ b/uui/data/forms/useForm.ts
@@ -106,18 +106,18 @@ export function useForm<T>(props: UseFormProps<T>): RenderFormProps<T> {
         return uuiValidate(valueToValidate, metadata);
     };
 
-    const handleSave = useCallback(() => {
+    const handleSave = useCallback((isSavedBeforeLeave?: boolean) => {
         const validationState = handleValidate();
         setFormState({ ...formState.current, validationState });
         if (!validationState.isInvalid) {
             setFormState({ ...formState.current, isInProgress: true });
             return props.onSave(formState.current.form)
-                .then(handleSaveResponse)
+                .then((response) => handleSaveResponse(response, isSavedBeforeLeave))
                 .catch(err => props.onError?.(err));
         } else return Promise.reject();
     }, [formState.current.validationState, formState.current.form, formState.current.isInProgress, props.onSave, props.onError]);
 
-    const handleSaveResponse = (response: FormSaveResponse<T> | void) => {
+    const handleSaveResponse = (response: FormSaveResponse<T> | void, isSavedBeforeLeave?: boolean) => {
         const newState: UseFormState<T> = {
             ...formState.current,
             isChanged: false,
@@ -130,7 +130,7 @@ export function useForm<T>(props: UseFormProps<T>): RenderFormProps<T> {
         resetForm(newState);
         removeUnsavedChanges();
         if (!props.onSuccess || !response) return;
-        props.onSuccess(response.form);
+        props.onSuccess(response.form, isSavedBeforeLeave);
     };
 
     const handleUndo = useCallback(() => {

--- a/uui/data/forms/useForm.ts
+++ b/uui/data/forms/useForm.ts
@@ -33,7 +33,7 @@ export function useForm<T>(props: UseFormProps<T>): RenderFormProps<T> {
     };
 
     const handleLeave = props.beforeLeave ? () => props.beforeLeave().then(res => {
-        if (res) return handleSave();
+        if (res) return handleSave(true);
         removeUnsavedChanges();
     }) : null;
 


### PR DESCRIPTION
Issue: #258

**Problem:** 
When we write a redirect logic in our onSuccess function, it will be called on both two cases.

1. On direct click to form save button.
2. On click to save button from beforeLeave modal.

When saving form from beforeLeave modal it causes to add unnecessary route to browser history.

**Solution:** 
Inside our onSuccess hook we need to know if form successfully saved from beforeLeave modal or from form submit button.
To do that, I've added `isSavedBeforeLeave` argument to onSuccess function.