### PR TITLE
[Assets Doc]: Fix misleading warning

### DIFF
--- a/app/src/docs/assets/Icons.doc.tsx
+++ b/app/src/docs/assets/Icons.doc.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import * as css from './IconsPage.scss';
 import { FlexCell, SearchInput, ControlSize, Panel, FlexRow, Text, IconContainer, Button, IconButton, LinkButton, TextInput,
     Tooltip, FlexSpacer, NotificationCard, MultiSwitch, ScrollBars } from '@epam/promo';
-import { ArrayDataSource, cx, DataRowProps, DataSourceState, Icon, INotification } from '@epam/uui';
+import { ArrayDataSource, cx, DataRowProps, DataSourceState, Icon } from '@epam/uui';
 import { getGroupedIcons, getIconList, IconList } from '@epam/assets/icons/helpers';
 import { ReactComponent as LockedIcon } from '@epam/assets/icons/common/action-lock-fill-18.svg';
 import { ReactComponent as UnlockedIcon } from '@epam/assets/icons/common/action-lock_open-fill-18.svg';
@@ -46,7 +46,7 @@ export class IconsDoc extends React.Component {
     }
 
     showNotification() {
-        svc.uuiNotifications.show((props: INotification) =>
+        svc.uuiNotifications.show(props =>
             <NotificationCard { ...props } icon={ NotificationIcon } color='gray60' onClose={ null } >
                 <Text size='36' font='sans'>Import was copied to the clipboard</Text>
             </NotificationCard>, { duration: 3 });
@@ -58,12 +58,16 @@ export class IconsDoc extends React.Component {
         return (
             <Panel cx={ css.iconCard }>
                 <FlexRow padding='24' vPadding='48' borderBottom >{ this.renderPreviewIcon() }</FlexRow>
-                <FlexRow cx={ css.recommendedSize } padding='24' vPadding='48' background='white' borderBottom >{ this.renderRecommendedSize() }</FlexRow>
+                <FlexRow cx={ css.recommendedSize } padding='24' vPadding='48' background='white' borderBottom>
+                    { this.renderRecommendedSize() }
+                </FlexRow>
                 <div className={ cx(this.state.isLocked ? css.hideControlSize : css.showControlSize, css.controlSizeWrapper) }>
-                    <FlexRow cx={ css.controlSizeContent } padding='24' vPadding='24' spacing='12' size='24' borderBottom >{ this.renderControlSize() }</FlexRow>
+                    <FlexRow cx={ css.controlSizeContent } padding='24' vPadding='24' spacing='12' size='24' borderBottom>
+                        { this.renderControlSize() }
+                    </FlexRow>
                 </div>
-                <FlexRow padding='24' vPadding='48' borderBottom cx={ css.iconCardDemo } >{ this.renderDemo() }</FlexRow>
-                <FlexRow vPadding='24' padding='24' background='gray5' cx={ css.iconCardImport } >{ this.renderImport() }</FlexRow>
+                <FlexRow padding='24' vPadding='48' borderBottom cx={ css.iconCardDemo }>{ this.renderDemo() }</FlexRow>
+                <FlexRow vPadding='24' padding='24' background='gray5' cx={ css.iconCardImport }>{ this.renderImport() }</FlexRow>
             </Panel>
         );
     }
@@ -71,7 +75,7 @@ export class IconsDoc extends React.Component {
     renderPreviewIcon() {
         const selectedItem = this.state.selectedIcon;
         const item = this.state.currentIcon;
-        const iconList =  [...this.groupedIcons[item.name]].reverse();
+        const iconList =  this.groupedIcons[item.name].reverse();
 
         return (
             <FlexCell width='100%' cx={ css.infoBox }>
@@ -91,17 +95,18 @@ export class IconsDoc extends React.Component {
                 <FlexRow spacing='12' alignItems='bottom'>
                     <FlexCell width='auto' shrink={ 0 } textAlign='center' >
                         <IconContainer icon={ selectedItem.icon } size={ 100 } cx={ css.previewIcon }/>
-                        <div className={ css.iconBoxLabel } >Preview</div>
+                        <div className={ css.iconBoxLabel }>Preview</div>
                     </FlexCell>
-                        { iconList.map(i => <FlexCell key={ i.id } width='auto' cx={ css.iconBox } shrink={ 0 }>
-                                <IconContainer
-                                    icon={ i.icon }
-                                    cx={ cx(css.sizeIcon, selectedItem.id === i.id && css.selectedIcon, !this.state.isLocked && css.selectableIcon) }
-                                    onClick={ this.state.isLocked ? null : () => this.setState({ selectedIcon: i }) }
-                                />
-                                <div className={ css.iconBoxLabel } >{ i.size || 'special' }</div>
-                            </FlexCell>,
-                        ) }
+                    { iconList.map(i => (
+                        <FlexCell key={ i.id } width='auto' cx={ css.iconBox } shrink={ 0 }>
+                            <IconContainer
+                                icon={ i.icon }
+                                cx={ cx(css.sizeIcon, selectedItem.id === i.id && css.selectedIcon, !this.state.isLocked && css.selectableIcon) }
+                                onClick={ this.state.isLocked ? null : () => this.setState({ selectedIcon: i }) }
+                            />
+                            <div className={ css.iconBoxLabel }>{ i.size || 'special' }</div>
+                        </FlexCell>
+                    )) }
                 </FlexRow>
             </FlexCell>
         );
@@ -111,7 +116,7 @@ export class IconsDoc extends React.Component {
         const importCode = this.getImportCode(this.state.selectedIcon);
         return (
             <Tooltip placement='left' content='Copy code' >
-                <div onClick={ () => copyTextToClipboard(importCode, this.showNotification) } >{ importCode }</div>
+                <div onClick={ () => copyTextToClipboard(importCode, this.showNotification) }>{ importCode }</div>
             </Tooltip>
         );
     }
@@ -125,24 +130,26 @@ export class IconsDoc extends React.Component {
                         <IconButton onClick={ () => {} } icon={ icon }/>
                     </FlexCell>
                     <FlexCell width='auto' shrink={ 0 } >
-                        <Button size={ this.state.controlSize } onClick={ () => {} } icon={ icon }/>
+                        <Button size={ this.state.controlSize } onClick={ () => {} } icon={ icon } />
                     </FlexCell>
                     <FlexCell width='auto' shrink={ 0 } >
-                        <Button caption='Click' size={ this.state.controlSize } onClick={ () => {} } icon={ icon }/>
+                        <Button caption='Click' size={ this.state.controlSize } onClick={ () => {} } icon={ icon } />
                     </FlexCell>
                     <FlexCell width='auto' shrink={ 0 } >
-                        <LinkButton caption='Click' size={ this.state.controlSize } onClick={ () => {} } icon={ icon }/>
+                        <LinkButton caption='Click' size={ this.state.controlSize } onClick={ () => {} } icon={ icon } />
                     </FlexCell>
                 </FlexRow>
-                <FlexRow size='24'  vPadding='24'>
-                    <TextInput value='Some text' size={ this.state.controlSize } onValueChange={ () => {} } icon={ icon }/>
+                <FlexRow size='24' vPadding='24'>
+                    <TextInput value='Some text' size={ this.state.controlSize } onValueChange={ () => {} } icon={ icon } />
                 </FlexRow>
             </FlexCell>
         );
     }
 
     checkValidSize = () => {
-        if (typeof recommendedSizes[this.state.selectedIcon.size] === 'undefined') {
+        if (this.state.selectedIcon.name) {
+            return true;
+        } else if (typeof recommendedSizes[this.state.selectedIcon.size] === 'undefined') {
             return false;
         } else {
             return recommendedSizes[this.state.selectedIcon.size].some(i => i === this.state.controlSize);
@@ -156,8 +163,8 @@ export class IconsDoc extends React.Component {
 
         const handleIconSizeChange = (size: string, control: string) => {
             return iconSizesList.some(i => i === size)
-                   ? this.setState({ controlSize: control, selectedIcon: iconList.filter(i => i.size.toString() === size)[0] })
-                   : null;
+                ? this.setState({ controlSize: control, selectedIcon: iconList.filter(i => i.size.toString() === size)[0] })
+                : null;
         };
 
         return (
@@ -176,33 +183,30 @@ export class IconsDoc extends React.Component {
                                         <FlexCell
                                             key={ control }
                                             minWidth={ 30 }
+                                            onClick={ () => handleIconSizeChange(size, control) }
                                             cx={ cx(
                                                 css.sizes,
                                                 iconSizesList.some(i => i === size) ? css.activeSizes : css.disabledSizes,
                                                 (control === this.state.controlSize && size === this.state.selectedIcon.size.toString()) && css.selectedSizes,
                                             ) }
-                                            onClick={ () => handleIconSizeChange(size, control) }
                                         >
                                             <Text size='30' font='sans-semibold' cx={ css.sizesText } >{ control }</Text>
                                             <Text size='30' cx={ css.sizesText } >{ size }</Text>
                                         </FlexCell>
                                     </Tooltip>
                                 ))
-                            ))
-                            }
+                            )) }
                         </FlexRow>
                     </FlexCell>
-                    { !this.checkValidSize() ? this.renderWarningIcon() : !this.state.isLocked && !this.checkValidSize() && this.renderWarningIcon() }
+                    { !this.checkValidSize() || (!this.state.selectedIcon.name && !this.state.isLocked) && this.renderWarningIcon() }
                 </FlexRow>
-                <FlexCell width='100%' >
-                    {
-                        !Object.keys(recommendedSizes).every(i => iconSizesList.includes(i))
-                        ? <FlexRow size='24' alignItems='bottom'>
+                <FlexCell width='100%'>
+                    { !Object.keys(recommendedSizes).every(i => iconSizesList.includes(i)) && (
+                        <FlexRow size='24' alignItems='bottom'>
                             <LinkButton cx={ css.bottomText } caption='Contact us' size='24' href='https://kb.epam.com/pages/viewpage.action?pageId=717764058' />
-                            <Text size='30' cx={ css.bottomText } > if you need more icon sizes</Text>
+                            &nbsp;<Text size='30' cx={ css.bottomText }> if you need more icon sizes</Text>
                         </FlexRow>
-                        : null
-                    }
+                    ) }
                 </FlexCell>
             </FlexCell>
         );
@@ -210,20 +214,20 @@ export class IconsDoc extends React.Component {
 
     renderWarningIcon() {
         return (
-            <>
-                <FlexCell minWidth={ 60 } cx={ css.warningWrapper } >
-                    <Tooltip placement='top-end' content={ "We don't recommend this combination of sizes" } >
-                        <IconContainer icon={ WarningIcon } color='red' cx={ css.warningIcon } />
-                    </Tooltip>
-                </FlexCell>
-            </>
+            <FlexCell minWidth={ 60 } cx={ css.warningWrapper } >
+                <Tooltip placement='top-end' content="We don't recommend this combination of sizes">
+                    <IconContainer icon={ WarningIcon } color='red' cx={ css.warningIcon } />
+                </Tooltip>
+            </FlexCell>
         );
     }
 
     renderControlSize() {
         return (
             <>
-                <FlexCell width='auto'><Text font='sans-semibold' size='24' fontSize='14'>Control size:</Text></FlexCell>
+                <FlexCell width='auto'>
+                    <Text font='sans-semibold' size='24' fontSize='14'>Control size:</Text>
+                </FlexCell>
                 <FlexCell width='auto'>
                     <MultiSwitch
                         size='24'
@@ -237,28 +241,32 @@ export class IconsDoc extends React.Component {
     }
 
     renderItem(item: IconList<Icon>) {
-        return <div
-            key={ item.id }
-            className={ cx(css.item, this.state.currentIcon && this.state.currentIcon.id == item.id && css.activeItem) }
-            onClick={ () => this.setState({ currentIcon: item, selectedIcon: this.groupedIcons[item.name][0], isLocked: true, controlSize: recommendedSizes[item.size] ? recommendedSizes[item.size][0] : '36' }) }
-        >
-            <IconContainer cx={ css.itemIcon } icon={ item.icon }/>
-            <Text size='18' color='gray60' cx={ css.itemName }>{ item.name }</Text>
-        </div>;
+        return (
+            <div
+                key={ item.id }
+                className={ cx(css.item, this.state.currentIcon && this.state.currentIcon.id == item.id && css.activeItem) }
+                onClick={ () => this.setState({ currentIcon: item, selectedIcon: this.groupedIcons[item.name][0], isLocked: true, controlSize: recommendedSizes[item.size] ? recommendedSizes[item.size][0] : '36' }) }
+            >
+                <IconContainer cx={ css.itemIcon } icon={ item.icon } />
+                <Text size='18' color='gray60' cx={ css.itemName }>{ item.name }</Text>
+            </div>
+        );
     }
 
     renderIconsBox(items: DataRowProps<IconList<Icon>, string>[]) {
         if (items.length === 0) {
-            return <div className={ css.unsuccessfulSearch } >
-                <Text fontSize='16' lineHeight='24' cx={ css.unsuccessfulSearchText }>
-                    Unfortunately, we did not find
-                    <span> { this.state.search } </span>
-                    icon in our package. But we can add it in the next release.
-                </Text>
-                <FlexRow>
-                    <Button caption='Request an Icon' color='green' href='https://kb.epam.com/pages/viewpage.action?pageId=717764058' />
-                </FlexRow>
-            </div>;
+            return (
+                <div className={ css.unsuccessfulSearch } >
+                    <Text fontSize='16' lineHeight='24' cx={ css.unsuccessfulSearchText }>
+                        Unfortunately, we did not find
+                        <span> { this.state.search } </span>
+                        icon in our package. But we can add it in the next release.
+                    </Text>
+                    <FlexRow>
+                        <Button caption='Request an Icon' color='green' href='https://kb.epam.com/pages/viewpage.action?pageId=717764058' />
+                    </FlexRow>
+                </div>
+            );
         }
 
         return <div className={ css.grid }>{ items.map(item => this.renderItem(item.value)) }</div>;
@@ -268,14 +276,10 @@ export class IconsDoc extends React.Component {
         items: this.typeIcons,
     });
 
-    onDataSourceStateChange = (data: any) => {
-        this.setState(data);
-    }
+    onDataSourceStateChange = (data: DataSourceState) => this.setState(data);
 
     render() {
-        const view = this.iconsDS.getView(this.state, this.onDataSourceStateChange, {
-            getSearchFields: (l: any) => [l.name],
-        });
+        const view = this.iconsDS.getView(this.state, this.onDataSourceStateChange, { getSearchFields: l => [l.name] });
         const items = view.getVisibleRows();
 
         return (
@@ -286,11 +290,11 @@ export class IconsDoc extends React.Component {
                         <SearchInput cx={ css.search } size='42' placeholder='Search icon' value={ this.state.search } onValueChange={ value => this.setState({ search: value }) } />
                         <FlexCell width='100%'>{ this.renderIconsBox(items) }</FlexCell>
                     </FlexCell>
-                    {
-                        items.length > 0 && <FlexCell minWidth={ 380 } cx={ cx(css.stickyPanel, css[`sticky-panel-height-${this.state.isLocked ? '563' : '612'}`]) }>
+                    { items.length > 0 && (
+                        <FlexCell minWidth={ 380 } cx={ cx(css.stickyPanel, css[`sticky-panel-height-${this.state.isLocked ? '563' : '612'}`]) }>
                             { this.state.currentIcon && this.renderIconCard() }
                         </FlexCell>
-                    }
+                    ) }
                 </ScrollBars>
             </div>
         );


### PR DESCRIPTION
For locked and unlocked states, if the icon exists in any possible sizes, do not show misleading warning.