### PR TITLE
[RawProps]: Detalize data-attributes via template string types

### DIFF
--- a/app/src/common/AppFooter.tsx
+++ b/app/src/common/AppFooter.tsx
@@ -10,7 +10,7 @@ export class AppFooter extends React.Component {
         return (
             <div className={ css.layout } >
                 <FlexRow cx={ css.footer } >
-                    <Anchor rawProps={{ tabIndex: -1, rel: 'noreferrer noopener', "aria-label": "EPAM" }} href={ EPAM_LINK } target='_blank' >
+                    <Anchor rawProps={ { tabIndex: -1, "aria-label": "EPAM" } } href={ EPAM_LINK } target='_blank' >
                         <IconContainer icon={ EPAMIcon } />
                     </Anchor>
                     <Text color='gray60' font='sans' fontSize='14' lineHeight='24' cx={ css.copyright } >© 2020 EPAM Systems. All Rights reserved</Text>

--- a/app/src/common/sidebar/SidebarButton.tsx
+++ b/app/src/common/sidebar/SidebarButton.tsx
@@ -13,12 +13,12 @@ export class SidebarButton extends React.Component<SidebarButtonProps, any> {
     render() {
         return <Button
             { ...this.props }
-            rawProps={{
+            rawProps={ {
                 role: this.props.isDropdown ? undefined : 'tab',
                 "aria-expanded": this.props.isDropdown,
                 "aria-disabled": this.props.isDisabled,
-                "aria-current": this.props.isActive
-            }}
+                "aria-current": this.props.isActive,
+            } }
             cx={ cx(
                 css.root,
                 this.props.isActive && css.active,

--- a/app/src/common/slider/Slider.tsx
+++ b/app/src/common/slider/Slider.tsx
@@ -43,8 +43,8 @@ export class Slider extends React.Component<SliderProps> {
         return (
             <div className={ css.slider } >
                 <div className={ css.controls } >
-                    <IconButton rawProps={{ "aria-label": "Backward" }} color='blue' isDisabled={ this.state.activeSlide === 0 } icon={ ArrowPrev } onClick={ this.handlePreviousClick } />
-                    <IconButton rawProps={{ "aria-label": "Forward" }} color='blue' isDisabled={ this.state.activeSlide === this.props.slides.length - 1 } icon={ ArrowNext } onClick={ this.handleNextClick } />
+                    <IconButton rawProps={ { "aria-label": "Backward" } } color='blue' isDisabled={ this.state.activeSlide === 0 } icon={ ArrowPrev } onClick={ this.handlePreviousClick } />
+                    <IconButton rawProps={ { "aria-label": "Forward" } } color='blue' isDisabled={ this.state.activeSlide === this.props.slides.length - 1 } icon={ ArrowNext } onClick={ this.handleNextClick } />
                 </div>
                 <Slide { ...slides[this.state.activeSlide] } />
             </div>

--- a/app/src/demo/DemoPage.tsx
+++ b/app/src/demo/DemoPage.tsx
@@ -46,7 +46,7 @@ export class DemoPage extends React.Component {
 
     renderSecondaryMenu(source: string) {
         return (
-            <FlexRow rawProps={{ role: 'tablist' }} background='white' padding='12' cx={ css.secondaryNavigation } borderBottom >
+            <FlexRow rawProps={ { role: 'tablist' } } background='white' padding='12' cx={ css.secondaryNavigation } borderBottom >
                 { demoItems.map(item => {
                     return(
                         <TabButton

--- a/app/src/docs/examples/scrollSpy/BasicScrollSpy.example.tsx
+++ b/app/src/docs/examples/scrollSpy/BasicScrollSpy.example.tsx
@@ -28,7 +28,7 @@ export default function BasicScrollSpy() {
             <FlexCell grow={ 4 }>
                 <section ref={setRef}>
                     <Text font='museo-slab' size='48' cx={ css.content } lineHeight='30'>
-                        <Text rawProps={{ 'data-spy': 'a' }} cx={ css.header } color='gray90'>Section 1</Text>
+                        <Text rawProps={ { 'data-spy': 'a' } } cx={ css.header } color='gray90'>Section 1</Text>
                         Lorem, ipsum dolor sit amet consectetur adipisicing elit. Unde voluptates veritatis laborum, dolores atque, quos soluta nisi delectus placeat id dolor consectetur quas optio vero possimus quae accusamus rerum quod!
                         Lorem, ipsum dolor sit amet consectetur adipisicing elit. Unde voluptates veritatis laborum, dolores atque, quos soluta nisi delectus placeat id dolor consectetur quas optio vero possimus quae accusamus rerum quod!
                         Lorem, ipsum dolor sit amet consectetur adipisicing elit. Unde voluptates veritatis laborum, dolores atque, quos soluta nisi delectus placeat id dolor consectetur quas optio vero possimus quae accusamus rerum quod!
@@ -37,7 +37,7 @@ export default function BasicScrollSpy() {
                         Lorem, ipsum dolor sit amet consectetur adipisicing elit. Unde voluptates veritatis laborum, dolores atque, quos soluta nisi delectus placeat id dolor consectetur quas optio vero possimus quae accusamus rerum quod!
                         Lorem, ipsum dolor sit amet consectetur adipisicing elit. Unde voluptates veritatis laborum, dolores atque, quos soluta nisi delectus placeat id dolor consectetur quas optio vero possimus quae accusamus rerum quod!
                         Lorem, ipsum dolor sit amet consectetur adipisicing elit. Unde voluptates veritatis laborum, dolores atque, quos soluta nisi delectus placeat id dolor consectetur quas optio vero possimus quae accusamus rerum quod!
-                        <Text rawProps={{ 'data-spy': 'b' }} cx={ css.header } color='gray90'>Section 2</Text>
+                        <Text rawProps={ { 'data-spy': 'b' } } cx={ css.header } color='gray90'>Section 2</Text>
                         Lorem, ipsum dolor sit amet consectetur adipisicing elit. Unde voluptates veritatis laborum, dolores atque, quos soluta nisi delectus placeat id dolor consectetur quas optio vero possimus quae accusamus rerum quod!
                     </Text>
                 </section>

--- a/app/src/landing/ContactsBlock.tsx
+++ b/app/src/landing/ContactsBlock.tsx
@@ -37,7 +37,7 @@ export class ContactsBlock extends React.Component {
                                                         <LinkButton size='24' caption='Submit an Issue' target='_blank' href={ GIT_LINK } cx={ css.linkButton } clickAnalyticsEvent={ this.submitIssueClickEvent }/>
                                                     </div>
                                                 </>
-                                                : <Anchor rawProps={{ tabIndex: -1, 'aria-label': 'Github', rel: 'noreferrer noopener' }} href={ GIT_LINK } target='_blank' >
+                                                : <Anchor rawProps={ { tabIndex: -1, 'aria-label': 'Github' } } href={ GIT_LINK } target='_blank' >
                                                     <IconContainer icon={ GitIcon } size={ containerWidth > 768 ? 180 : null } cx={ css.cardIcon } />
                                                 </Anchor>
                                             }
@@ -51,7 +51,7 @@ export class ContactsBlock extends React.Component {
                                                         <LinkButton size='24' caption='Email us' target='_blank' href={ `mailto:${ EMAIL }` } cx={ css.linkButton } clickAnalyticsEvent={ this.emailClickEvent }/>
                                                     </div>
                                                 </>
-                                                : <Anchor rawProps={{ tabIndex: -1, 'aria-label': 'Email', rel: 'noreferrer noopener' }}  href={ `mailto:${ EMAIL }` } target='_blank' >
+                                                : <Anchor rawProps={ { tabIndex: -1, 'aria-label': 'Email' } }  href={ `mailto:${ EMAIL }` } target='_blank' >
                                                     <IconContainer icon={ MailIcon } size={ containerWidth > 768 ? 180 : null } cx={ css.cardIcon } />
                                                 </Anchor>
                                             }

--- a/app/src/landing/HeroBlock.tsx
+++ b/app/src/landing/HeroBlock.tsx
@@ -99,7 +99,7 @@ export class HeroBlock extends React.Component<HeroBlockProps, HeroBlockState> {
                             <div className={ css.layout } ref={ measureRef } >
                                 <FlexRow  cx={ css.hero }>
                                     <div className={ css.heroText }>
-                                        <Text rawProps={{ role: 'heading', 'aria-level': 1 }} font='museo-slab' cx={ css.heroHeader } >Unified UI</Text>
+                                        <Text rawProps={ { role: 'heading', 'aria-level': 1 } } font='museo-slab' cx={ css.heroHeader } >Unified UI</Text>
                                         <Text font='sans' fontSize='24' cx={ css.heroSecondary } >Digital Platform UX/UI accelerator used to build all EPAM internal products in one effective & consistent way.</Text>
                                         <Text font='sans' fontSize='24' cx={ css.heroSecondary } >No more need to build user interface from scratch every time. Just use "lego blocks" to assemble new pages in a quick way for any current or new EPAM product.</Text>
                                     </div>

--- a/app/src/landing/ProjectsBlock.tsx
+++ b/app/src/landing/ProjectsBlock.tsx
@@ -37,7 +37,7 @@ export class ProjectsBlock extends React.Component {
                                             <Anchor
                                                 key='allProjects'
                                                 cx={ css.project }
-                                                rawProps={{ tabIndex: -1 }}
+                                                rawProps={ { tabIndex: -1 } }
                                                 link={ { pathname: '/documents', query: { id: 'projects' } } }
                                                 onClick={ () => this.sendEvent('All') }
                                             >

--- a/app/src/landing/StartedBlock.tsx
+++ b/app/src/landing/StartedBlock.tsx
@@ -27,7 +27,7 @@ export class StartedBlock extends React.Component {
                                       cx={ css.contentText }>{ 'Learn more about React Components, Demos, Packages & Documentation' }</Text>
                                 <FlexRow alignItems='center'>
                                     <Button
-                                        rawProps={{ 'aria-label': 'For Developers' }}
+                                        rawProps={ { 'aria-label': 'For Developers' } }
                                         caption='FOR DEVELOPERS'
                                         fill='white'
                                         size='48'
@@ -48,7 +48,7 @@ export class StartedBlock extends React.Component {
                                       cx={ css.contentText }>{ 'Learn more about Design Library, Specifications, Palettes & Typography' }</Text>
                                 <FlexRow alignItems='center'>
                                     <Button
-                                        rawProps={{ 'aria-label': 'For Designers' }}
+                                        rawProps={ { 'aria-label': 'For Designers' } }
                                         caption='FOR DESIGNERS'
                                         fill='white'
                                         size='48'

--- a/app/src/landing/TechnologiesBlock.tsx
+++ b/app/src/landing/TechnologiesBlock.tsx
@@ -27,7 +27,7 @@ export class TechnologiesBlock extends React.Component {
                     <FlexRow cx={ css.technologies } >
                         { technologies.map(({ icon, label, link }) => (
                             <IconButton
-                                rawProps={{ 'aria-label': label, rel: 'noreferrer noopener' }}
+                                rawProps={ { 'aria-label': label } }
                                 key={ label }
                                 icon={ icon }
                                 target='_blank'

--- a/app/src/sandbox/forms/ExperienceEditor.tsx
+++ b/app/src/sandbox/forms/ExperienceEditor.tsx
@@ -53,7 +53,7 @@ export class ExperienceEditor extends React.Component<ExperienceEditorProps> {
             </FlexCell>
             <FlexCell width='auto'>
                 <LinkButton
-                    rawProps={{ "aria-label": 'Remove' }}
+                    rawProps={ { "aria-label": 'Remove' } }
                     icon={ RemoveIcon }
                     color='night600'
                     onClick={ () => this.props.onValueChange(this.props.value.filter((item, i) => index != i)) }

--- a/app/src/sandbox/forms/PersonDetailEditor.tsx
+++ b/app/src/sandbox/forms/PersonDetailEditor.tsx
@@ -159,56 +159,56 @@ export class PersonDetailEditor extends React.Component<PersonDetailEditorProps>
                         />
                     </LabeledInput>
                 </FlexCell>
-                <FlexCell grow={1}>
+                <FlexCell grow={ 1 }>
                     <LabeledInput
                         label='Time'
                         htmlFor='timeValue'
-                        {...this.props.lens.prop('timeValue').toProps()}
+                        { ...this.props.lens.prop('timeValue').toProps() }
                     >
                         <TimePicker
                             id='timeValue'
-                            {...this.props.lens.prop('timeValue').toProps()}
+                            { ...this.props.lens.prop('timeValue').toProps() }
                         />
                     </LabeledInput>
                 </FlexCell>
             </FlexRow>
             <FlexRow type='form'>
-                <FlexCell grow={1}>
-                    <LabeledInput label='Sex' {...this.props.lens.prop('sex').toProps()}>
+                <FlexCell grow={ 1 }>
+                    <LabeledInput label='Sex' { ...this.props.lens.prop('sex').toProps() }>
                         <ControlWrapper size='36'>
                             <RadioGroup
-                                items={[{ id: 'male', name: 'Male' }, { id: 'female', name: 'Female' }]}
-                                {...this.props.lens.prop('sex').toProps()}
+                                items={ [{ id: 'male', name: 'Male' }, { id: 'female', name: 'Female' }] }
+                                { ...this.props.lens.prop('sex').toProps() }
                                 direction='horizontal'
                             />
                         </ControlWrapper>
                     </LabeledInput>
                 </FlexCell>
-                <FlexCell grow={1}>
-                    <LabeledInput label='Role' {...this.props.lens.prop('roles').toProps()}>
-                        <ControlWrapper size='36' cx={css.control}>
+                <FlexCell grow={ 1 }>
+                    <LabeledInput label='Role' { ...this.props.lens.prop('roles').toProps() }>
+                        <ControlWrapper size='36' cx={ css.control }>
                             <CheckboxGroup
-                                {...this.props.lens.prop('roles').toProps()}
-                                items={[{ id: 'Admin', name: 'Admin' }, { id: 'User', name: 'User' }]}
+                                { ...this.props.lens.prop('roles').toProps() }
+                                items={ [{ id: 'Admin', name: 'Admin' }, { id: 'User', name: 'User' }] }
                                 direction='horizontal'
                             />
                         </ControlWrapper>
                     </LabeledInput>
                 </FlexCell>
-                <FlexCell grow={1}>
-                    <LabeledInput label='Rating' {...this.props.lens.prop('rating').toProps()} >
-                        <ControlWrapper size='36' cx={css.control}>
-                            <Rating {...this.props.lens.prop('rating').toProps()} rawProps={{ 'aria-label': 'Rating' }} />
+                <FlexCell grow={ 1 }>
+                    <LabeledInput label='Rating' { ...this.props.lens.prop('rating').toProps() } >
+                        <ControlWrapper size='36' cx={ css.control }>
+                            <Rating { ...this.props.lens.prop('rating').toProps() } rawProps={ { 'aria-label': 'Rating' } } />
                         </ControlWrapper>
                     </LabeledInput>
                 </FlexCell>
             </FlexRow>
             <FlexRow type='form'>
-                <FlexCell grow={1}>
-                    <LabeledInput htmlFor='notes' label='Notes' {...this.props.lens.prop('notes').toProps()}>
+                <FlexCell grow={ 1 }>
+                    <LabeledInput htmlFor='notes' label='Notes' { ...this.props.lens.prop('notes').toProps() }>
                         <TextArea
-                            {...this.props.lens.prop('notes').toProps()}
-                            rows={10}
+                            { ...this.props.lens.prop('notes').toProps() }
+                            rows={ 10 }
                             id='notes'
                         />
                     </LabeledInput>
@@ -217,55 +217,55 @@ export class PersonDetailEditor extends React.Component<PersonDetailEditorProps>
         </Panel>
         <Panel>
             <FlexRow type='form'>
-                <FlexCell grow={1}>
-                    <LabeledInput htmlFor='vacDays' label='Vacation days' {...this.props.lens.prop('vacDays').toProps()}>
+                <FlexCell grow={ 1 }>
+                    <LabeledInput htmlFor='vacDays' label='Vacation days' { ...this.props.lens.prop('vacDays').toProps() }>
                         <NumericInput
-                            {...this.props.lens.prop('vacDays').toProps()}
-                            max={100}
+                            { ...this.props.lens.prop('vacDays').toProps() }
+                            max={ 100 }
                             id='vacDays'
-                            min={0}
-                            step={1}
+                            min={ 0 }
+                            step={ 1 }
                         />
                     </LabeledInput>
                 </FlexCell>
-                <FlexCell grow={1}>
-                    <LabeledInput label='Vacation range' {...this.props.lens.prop('rangeDateValue').toProps()}>
+                <FlexCell grow={ 1 }>
+                    <LabeledInput label='Vacation range' { ...this.props.lens.prop('rangeDateValue').toProps() }>
                         <RangeDatePicker
                             format='YYYY-MM-DD'
-                            {...this.props.lens.prop('rangeDateValue').toProps()}
+                            { ...this.props.lens.prop('rangeDateValue').toProps() }
                         />
                     </LabeledInput>
                 </FlexCell>
             </FlexRow>
             <FlexRow type='form'>
-                <FlexCell grow={1}>
+                <FlexCell grow={ 1 }>
                     <LabeledInput
                         label='Slider'
                         htmlFor="vacationDaysSlider"
-                        {...this.props.lens.prop('vacDays').toProps()}
+                        { ...this.props.lens.prop('vacDays').toProps() }
                     >
-                        <Slider min={0} max={40} step={1}
-                            rawProps={{ 'aria-label': 'Vacation Days Slider', id: 'vacationDaysSlider' }}
-                            {...this.props.lens.prop('vacDays').toProps()}
+                        <Slider min={ 0 } max={ 40 } step={ 1 }
+                            rawProps={ { 'aria-label': 'Vacation Days Slider', id: 'vacationDaysSlider' } }
+                            { ...this.props.lens.prop('vacDays').toProps() }
                         />
                     </LabeledInput>
                 </FlexCell>
-                <FlexCell grow={1}>
+                <FlexCell grow={ 1 }>
                     <LabeledInput
                         label='Range'
-                        {...this.props.lens.prop('bracket').toProps()}
+                        { ...this.props.lens.prop('bracket').toProps() }
                     >
                         <RangeSlider
-                            min={-12}
-                            max={13}
-                            step={7}
-                            {...this.props.lens.prop('bracket').toProps()}
+                            min={ -12 }
+                            max={ 13 }
+                            step={ 7 }
+                            { ...this.props.lens.prop('bracket').toProps() }
                         />
                     </LabeledInput>
                 </FlexCell>
             </FlexRow>
             <ExperienceEditor
-                {...this.props.lens.prop("experience").toProps()}
+                { ...this.props.lens.prop("experience").toProps() }
             />
             <FlexRow type='form'>
                 <LabeledInput label='Attachment'>

--- a/app/src/sandbox/scroll-spy/ScrollSpyAnchor.tsx
+++ b/app/src/sandbox/scroll-spy/ScrollSpyAnchor.tsx
@@ -16,19 +16,19 @@ export function ScrollSpyAnchor() {
             <FlexCell grow={ 2 } alignSelf='start' cx={ css.menu } textAlign='center'>
                 {links.map(link => (
                     <LinkButton
-                        isLinkActive={currentActive === link.id}
-                        key={link.id}
+                        isLinkActive={ currentActive === link.id }
+                        key={ link.id }
                         cx={ css.spyLink }
-                        onClick={() => scrollToElement(link.id)}
-                        caption={link.caption}
-                        href={`#${link.id}`}
+                        onClick={ () => scrollToElement(link.id) }
+                        caption={ link.caption }
+                        href={ `#${link.id}` }
                     />
                 ))}
             </FlexCell>
             <FlexCell grow={ 5 }>
-                <section ref={setRef}>
+                <section ref={ setRef }>
                     <Text font='museo-slab' size='48' cx={ css.content } lineHeight='30'>
-                        <Text rawProps={{ 'data-spy': 'a' }} cx={css.header} color='gray90'>Section 1</Text>
+                        <Text rawProps={ { 'data-spy': 'a' } } cx={ css.header } color='gray90'>Section 1</Text>
                         Lorem, ipsum dolor sit amet consectetur adipisicing elit. Unde voluptates veritatis laborum, dolores atque, quos soluta nisi delectus placeat id dolor consectetur quas optio vero possimus quae accusamus rerum quod!
                         Lorem, ipsum dolor sit amet consectetur adipisicing elit. Unde voluptates veritatis laborum, dolores atque, quos soluta nisi delectus placeat id dolor consectetur quas optio vero possimus quae accusamus rerum quod!
                         Lorem, ipsum dolor sit amet consectetur adipisicing elit. Unde voluptates veritatis laborum, dolores atque, quos soluta nisi delectus placeat id dolor consectetur quas optio vero possimus quae accusamus rerum quod!
@@ -37,7 +37,7 @@ export function ScrollSpyAnchor() {
                         Lorem, ipsum dolor sit amet consectetur adipisicing elit. Unde voluptates veritatis laborum, dolores atque, quos soluta nisi delectus placeat id dolor consectetur quas optio vero possimus quae accusamus rerum quod!
                         Lorem, ipsum dolor sit amet consectetur adipisicing elit. Unde voluptates veritatis laborum, dolores atque, quos soluta nisi delectus placeat id dolor consectetur quas optio vero possimus quae accusamus rerum quod!
                         Lorem, ipsum dolor sit amet consectetur adipisicing elit. Unde voluptates veritatis laborum, dolores atque, quos soluta nisi delectus placeat id dolor consectetur quas optio vero possimus quae accusamus rerum quod!
-                        <Text rawProps={{ 'data-spy': 'b' }} cx={css.header} color='gray90'>Section 2</Text>
+                        <Text rawProps={ { 'data-spy': 'b' } } cx={ css.header } color='gray90'>Section 2</Text>
                         Lorem, ipsum dolor sit amet consectetur adipisicing elit. Unde voluptates veritatis laborum, dolores atque, quos soluta nisi delectus placeat id dolor consectetur quas optio vero possimus quae accusamus rerum quod!
                     </Text>
                 </section>

--- a/app/src/sandbox/scroll-spy/ScrollSpyModal.tsx
+++ b/app/src/sandbox/scroll-spy/ScrollSpyModal.tsx
@@ -60,7 +60,7 @@ export function ScrollSpyModal() {
             <FlexCell grow={ 5 }>
                 <section ref={setRef}>
                     <Text font='museo-slab' size='48' cx={ css.content } lineHeight='30'>
-                        <Text rawProps={{ 'data-spy': 'a' }} cx={css.header} color='gray90'>Section 1</Text>
+                        <Text rawProps={ { 'data-spy': 'a' } } cx={css.header} color='gray90'>Section 1</Text>
                         Lorem, ipsum dolor sit amet consectetur adipisicing elit. Unde voluptates veritatis laborum, dolores atque, quos soluta nisi delectus placeat id dolor consectetur quas optio vero possimus quae accusamus rerum quod!
                         Lorem, ipsum dolor sit amet consectetur adipisicing elit. Unde voluptates veritatis laborum, dolores atque, quos soluta nisi delectus placeat id dolor consectetur quas optio vero possimus quae accusamus rerum quod!
                         Lorem, ipsum dolor sit amet consectetur adipisicing elit. Unde voluptates veritatis laborum, dolores atque, quos soluta nisi delectus placeat id dolor consectetur quas optio vero possimus quae accusamus rerum quod!
@@ -69,7 +69,7 @@ export function ScrollSpyModal() {
                         Lorem, ipsum dolor sit amet consectetur adipisicing elit. Unde voluptates veritatis laborum, dolores atque, quos soluta nisi delectus placeat id dolor consectetur quas optio vero possimus quae accusamus rerum quod!
                         Lorem, ipsum dolor sit amet consectetur adipisicing elit. Unde voluptates veritatis laborum, dolores atque, quos soluta nisi delectus placeat id dolor consectetur quas optio vero possimus quae accusamus rerum quod!
                         Lorem, ipsum dolor sit amet consectetur adipisicing elit. Unde voluptates veritatis laborum, dolores atque, quos soluta nisi delectus placeat id dolor consectetur quas optio vero possimus quae accusamus rerum quod!
-                        <Text rawProps={{ 'data-spy': 'b' }} cx={css.header} color='gray90'>Section 2</Text>
+                        <Text rawProps={ { 'data-spy': 'b' } } cx={css.header} color='gray90'>Section 2</Text>
                         Lorem, ipsum dolor sit amet consectetur adipisicing elit. Unde voluptates veritatis laborum, dolores atque, quos soluta nisi delectus placeat id dolor consectetur quas optio vero possimus quae accusamus rerum quod!
                     </Text>
                 </section>

--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,7 @@
 * [Tooltip]: the Tooltip target needs to accept ref correctly
 * [Dropdown]: renderTarget now returns a ref, that needs to passed correctly to the target component
 * [DndActor]: ref needs to be passed to the root node in the render prop
+* [RawProps]: checks more strict
 * uui package moved to uui-core, uui-v package moved to uui, uui-core reexported to uui
 
 # 4.5.4 - 10.02.2022
@@ -57,7 +58,7 @@
 * [Breaking Change]: Changed VirtualList component api. Introduced new useVirtualList hook.
     More information here - https://uui.epam.com/documents?category=components&id=virtualList#advanced
 
-* Improved SSR support and introduced uui next.js app template. More information here - https://github.com/epam/UUI/tree/main/templates/uui-nextjs-template.  
+* Improved SSR support and introduced uui next.js app template. More information here - https://github.com/epam/UUI/tree/main/templates/uui-nextjs-template.
 * Added rawProps attribute to ModalHeader, ModalFooter, PickerInput, RangeDatePicker, DatePicker, TimePicker. Removed 'id' prop from PickerInput, DatePicker, TimePicker.
 * [FileCard]: Added extension to file card. Bugfixes.
 * [ArrayDataSource, LazyDataSource]: Added disableSelectAll attribute

--- a/epam-promo/components/widgets/Paginator.tsx
+++ b/epam-promo/components/widgets/Paginator.tsx
@@ -17,7 +17,7 @@ export class Paginator extends React.Component<PaginatorProps> {
                         if (page.type === 'spacer') {
                             return <PageButton size={ params.size } key={ index } caption={ '...' } fill='light' color='blue' tabIndex={ -1 } />;
                         } else {
-                            return <PageButton size={ params.size } key={ index } caption={ page.pageNumber } onClick={ () => page.onClick && page.onClick() } rawProps={{ 'aria-current': page.isActive }} fill={ (page.isActive && 'white') || 'light' } color={ 'blue' } />;
+                            return <PageButton size={ params.size } key={ index } caption={ page.pageNumber } onClick={ () => page.onClick && page.onClick() } rawProps={ { 'aria-current': page.isActive } } fill={ (page.isActive && 'white') || 'light' } color={ 'blue' } />;
                         }
                     })
                 }

--- a/loveship/components/widgets/Paginator.tsx
+++ b/loveship/components/widgets/Paginator.tsx
@@ -17,7 +17,7 @@ export class Paginator extends React.Component<PaginatorProps> {
                         if (page.type === 'spacer') {
                             return <PageButton size={ params.size } key={ index } caption={ '...' } fill='light' color='sky' tabIndex={ -1 } />;
                         } else {
-                            return <PageButton size={ params.size } key={ index } caption={ page.pageNumber } onClick={ () => page.onClick() } fill={ (page.isActive && 'white') || 'light' } color={ 'sky' } rawProps={{ 'aria-current': page.isActive }} />;
+                            return <PageButton size={ params.size } key={ index } caption={ page.pageNumber } onClick={ () => page.onClick() } fill={ (page.isActive && 'white') || 'light' } color={ 'sky' } rawProps={ { 'aria-current': page.isActive } } />;
                         }
                     })
                 }

--- a/uui-components/src/inputs/Slider/RangeSlider.tsx
+++ b/uui-components/src/inputs/Slider/RangeSlider.tsx
@@ -126,13 +126,13 @@ export class RangeSlider extends SliderBase<RangeSliderValue, RangeSliderState> 
                     onUpdate={ (mouseX) => this.onHandleValueChange(mouseX, 'from', valueWidth) }
                     onKeyDownUpdate={ type => this.handleKeyDown(type, { from: normValueFrom, to: normValueTo }) }
                     handleActiveState={ (isActive) => this.setState({ activeHandle: isActive ? 'from' : null }) }
-                    rawProps={{
+                    rawProps={ {
                         'aria-label': this.props.rawProps && this.props.rawProps['aria-label'] ? this.props.rawProps['aria-label'] : 'From',
                         'aria-valuenow': this.props.value?.from,
                         'aria-valuemax': this.props.max,
                         'aria-valuemin': this.props.min,
                         role: 'slider',
-                    }}
+                    } }
                 />
                 <SliderHandle
                     cx={ this.props.cx }
@@ -142,13 +142,13 @@ export class RangeSlider extends SliderBase<RangeSliderValue, RangeSliderState> 
                     onUpdate={ (mouseX: number) => this.onHandleValueChange(mouseX, 'to', valueWidth) }
                     handleActiveState={ (isActive) => this.setState({ activeHandle: isActive ? 'to' : null }) }
                     onKeyDownUpdate={ type => this.handleKeyDown(type, { from: normValueFrom, to: normValueTo }) }
-                    rawProps={{
+                    rawProps={ {
                         'aria-label': this.props.rawProps && this.props.rawProps['aria-label'] ? this.props.rawProps['aria-label'] : 'To',
                         'aria-valuenow': this.props.value?.to,
                         'aria-valuemax': this.props.max,
                         'aria-valuemin': this.props.min,
                         role: 'slider',
-                    }}
+                    } }
                 />
             </div>
         );

--- a/uui-components/src/inputs/Slider/Slider.tsx
+++ b/uui-components/src/inputs/Slider/Slider.tsx
@@ -71,13 +71,13 @@ export class Slider extends SliderBase<number, any> {
                     onUpdate={ (mouseX: number) => this.props.onValueChange(this.getValue(mouseX, valueWidth)) }
                     handleActiveState={ (newValue) => this.setState({ isActive: newValue }) }
                     showTooltip={ this.props.showTooltip !== undefined ? this.props.showTooltip : true }
-                    rawProps={{
+                    rawProps={ {
                         'aria-label': this.props.rawProps ? this.props.rawProps['aria-label'] : undefined,
                         'aria-valuenow': this.props.value,
                         'aria-valuemin': this.props.min,
                         'aria-valuemax': this.props.max,
                         role: 'slider',
-                    }}
+                    } }
                 />
             </div>
         );

--- a/uui-components/src/overlays/ModalWindow.tsx
+++ b/uui-components/src/overlays/ModalWindow.tsx
@@ -9,11 +9,11 @@ export class ModalWindow extends React.Component<ModalWindowProps> {
                 style={ this.props.style }
                 cx={ cx(uuiElement.modalWindow, this.props.cx) }
                 forwardedRef={ this.props.forwardedRef }
-                rawProps={{
+                rawProps={ {
                     'aria-modal': true,
                     'role': 'modal',
                     ...this.props.rawProps,
-                }}
+                } }
             >
                 { this.props.children }
             </VPanel>

--- a/uui-components/src/table/DataTableHeaderRow.tsx
+++ b/uui-components/src/table/DataTableHeaderRow.tsx
@@ -63,7 +63,7 @@ export class DataTableHeaderRow<TItem, TId> extends React.Component<DataTableHea
                 cx={ [this.props.cx, uuiDataTableHeaderRow.uuiTableHeaderRow] }
                 columns={ this.props.columns }
                 renderCell={ this.renderCell }
-                rawProps={{ role: 'row' }}
+                rawProps={ { role: 'row' } }
                 renderConfigButton={ this.props.onConfigButtonClick && this.props.renderConfigButton }
             />
         );

--- a/uui-components/src/table/DataTableRowContainer.tsx
+++ b/uui-components/src/table/DataTableRowContainer.tsx
@@ -58,10 +58,10 @@ export const DataTableRowContainer = React.forwardRef(<TItem, TId, TFilter>(prop
     function wrapScrollingSection(cells: DataColumnProps<TItem, TId, TFilter>[]) {
         if (props.wrapScrollingSection) return props.wrapScrollingSection(cells);
         return (
-            <div className={ css.container } style={{
+            <div className={ css.container } style= {{
                 flex: `1 0 ${getSectionWidth(cells)}px`,
                 minWidth: `${getSectionWidth(cells)}px`
-            }}>
+            } }>
                 { renderCells(cells) }
             </div>
         );

--- a/uui-core/types/props.ts
+++ b/uui-core/types/props.ts
@@ -137,7 +137,7 @@ export interface INotification {
 }
 
 export interface IHasRawProps<T> {
-    rawProps?: React.HTMLAttributes<T> & Record<string, any>;
+    rawProps?: React.HTMLAttributes<T> & Record<`data-${string}`, string>;
 }
 
 export interface IHasForwardedRef<T extends HTMLOrSVGElement> {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1305,6 +1305,13 @@
     is-absolute "^1.0.0"
     is-negated-glob "^1.0.0"
 
+"@epam/assets@4.5.3":
+  version "4.5.3"
+  resolved "https://registry.yarnpkg.com/@epam/assets/-/assets-4.5.3.tgz#0391330577230addee7307d4ddb69fb030c2920e"
+  integrity sha512-hc6U3UxrpXX44BhwU85N+AXGClN4K18Axou1g+eRs7cJQ8SpR7l6Z9cPyoBaqTpuDUJs2UjjQGhhjFF4YNEGuw==
+  dependencies:
+    normalize.css "^7.0.0"
+
 "@epam/internal@0.0.1":
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/@epam/internal/-/internal-0.0.1.tgz#742bbc31ef813264007346365aaf312c7b335a40"


### PR DESCRIPTION
As per Typescript docs changelog, since 4.5.0, we can now create types using template string type
[4.5.0 Changelog]https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-5.html

So, I added an additional check to check data-* attributes passed to rawProps
Compiler will allow anything matching the template: `data-${string}` and will complain in cases like `data232324-` since it's not matching the string type template.
