### PR TITLE
[Tooltip]: fix wrong behavior in a property explorer example for tool…

### DIFF
--- a/epam-promo/components/overlays/docs/tooltip.doc.tsx
+++ b/epam-promo/components/overlays/docs/tooltip.doc.tsx
@@ -3,8 +3,9 @@ import { DocBuilder } from '@epam/uui-docs';
 import { TooltipProps } from '@epam/uui-components';
 import { Button, Tooltip, TooltipMods } from '../../../components';
 import { DefaultContext } from '../../../docs';
+import { ForwardedRef, forwardRef } from "react";
 
-const Sfc = (props: any) => <div ref={ props.ref }>123</div>;
+const Sfc = forwardRef((props: any, ref: ForwardedRef<HTMLDivElement>) => <div ref={ ref }>123</div>);
 
 const tooltipDoc = new DocBuilder<TooltipProps & TooltipMods>({ name: 'Tooltip', component: Tooltip })
     .prop('trigger', { examples: [{ value: 'hover', isDefault: true }, 'click', 'press'] })


### PR DESCRIPTION
…tip when children is a div element