### PR TITLE
[useForm]: Add type to handleSave's return value in useForm

### DIFF
--- a/uui-core/data/forms/Form.tsx
+++ b/uui-core/data/forms/Form.tsx
@@ -20,7 +20,7 @@ export interface FormProps<T> {
 }
 
 export interface RenderFormProps<T> extends IEditable<T>, ICanBeInvalid {
-    save(): void;
+    save(): Promise<void>;
     undo(): void;
     redo(): void;
     revert(): void;

--- a/uui-core/data/forms/useForm.ts
+++ b/uui-core/data/forms/useForm.ts
@@ -106,7 +106,7 @@ export function useForm<T>(props: UseFormProps<T>): RenderFormProps<T> {
         return uuiValidate(valueToValidate, metadata);
     };
 
-    const handleSave = useCallback((isSavedBeforeLeave?: boolean) => {
+    const handleSave = useCallback((isSavedBeforeLeave?: boolean): Promise<void> => {
         const validationState = handleValidate();
         setFormState({ ...formState.current, validationState });
         if (!validationState.isInvalid) {

--- a/uui-core/data/forms/useLock.ts
+++ b/uui-core/data/forms/useLock.ts
@@ -2,7 +2,7 @@ import { useEffect, useRef } from "react";
 import { useUuiContext } from "../../";
 
 export interface UseLockProps {
-    handleLeave: () => Promise<boolean>;
+    handleLeave: () => Promise<void>;
     isEnabled?: boolean;
 }
 


### PR DESCRIPTION
`handleSave` function returns Promise, but in `useForm`'s `save` method we have `void` as return type.

We have plans use save to catch Promise.reject after validation, for now we need to cast type:

```tsx
((form.save() as unknown) as Promise<void>).catch(() => {
    scrollManager.scrollToInvalid();
});
```

With this fix we will get rid of annoying type casting ☺

```tsx
form.save().catch(() => {
    scrollManager.scrollToInvalid();
});
```