### PR TITLE
[Button]: fixed text color for "fill:light" props in Promo skin

### DIFF
--- a/epam-promo/components/buttons/Button.scss
+++ b/epam-promo/components/buttons/Button.scss
@@ -122,8 +122,8 @@
 
 .fill-light {
     background-color: transparent;
-    color: var(--background-color);
-    fill: var(--background-color);
+    color: var(--caption-color);
+    fill: var(--caption-color);
     border-color: transparent;
 
     &:global(.-clickable) {


### PR DESCRIPTION
[Button]: issue #517 - fixed text color for "fill:light" props in Promo skin