### PR TITLE
Fix the link to license file in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,4 +89,4 @@ This would open the uui.epam.com web-site locally, in watch mode.
 
 ## License
 
-[MIT](./LICENCE.MD)
+[MIT](./LICENSE.md)


### PR DESCRIPTION
The link to the license file in the root `README.md` had a typo. Now it is fixed.
The case type of the file’s extension was also changed so that the link meet the file’s full name.