### PR TITLE
[RTE] Change connection of ListPlugin in RTE

### DIFF
--- a/uui-editor/src/plugins/listPlugin/listPlugin.tsx
+++ b/uui-editor/src/plugins/listPlugin/listPlugin.tsx
@@ -8,24 +8,12 @@ import { ToolbarButton } from "../../implementation/ToolbarButton";
 import { getBlockDesirialiser } from '../../helpers';
 
 export const listPlugin = () => {
-    const lists = Lists();
-    const toggleListCommand = lists[0].commands.toggleList;
-    lists[0].commands.wrapList = (editor: Editor, ...props: any[]) => {
-        const type = props[0].type || 'unordered-list';
-        const leafBlocks = editor.value.document.getLeafBlocksAtRange(editor.value.selection as any);
-
-        editor.withoutNormalizing(() => {
-            leafBlocks.forEach(block => {
-                if (block.type == 'unordered-list' || block.type == 'ordered-list') return;
-                editor.wrapBlockByKey(block.key, type);
-                editor.wrapBlockByKey(block.key, 'list-item');
-                editor.setNodeByKey(block.key, 'list-item-child');
-            });
-        });
-    };
-    lists[0].commands.toggleList = (editor: Editor, ...props: any[]) => {
-        toggleListCommand(editor, ...props);
-    };
+    const lists = Lists({
+        blocks: {
+          ordered_list: "ordered-list",
+          unordered_list: "unordered-list",
+          list_item: "list-item",
+        }});
 
     const isList = (editor: Editor, type: 'ordered-list' | 'unordered-list') => {
         let isActive = false;


### PR DESCRIPTION
bug related with #259 
Now, I can select element with list, transform that to new list, without crashing
![Recording 2022-08-17 at 15 25 55](https://user-images.githubusercontent.com/78467676/185120229-4b08b743-f8a7-4659-9ce4-cfa0988107ab.gif)

Before chnging work like that:

![Recording 2022-08-17 at 15 29 05](https://user-images.githubusercontent.com/78467676/185121650-4cdbcf02-2018-4a5e-b16e-2d05f08cd8b5.gif)

