### PR TITLE
Patched/Fix vulnerable CVE-2021-23337

### DIFF
--- a/server/yarn.lock
+++ b/server/yarn.lock
@@ -461,12 +461,7 @@ jake@^10.8.5:
     filelist "^1.0.1"
     minimatch "^3.0.4"
 
-lodash@4.17.20:
-  version "4.17.20"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
-  integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
-
-lodash@^4.17.20:
+lodash@4.17.21, lodash@^4.17.20:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==


### PR DESCRIPTION
## Describe the sumarry:
epam-project use `lodash` vulnerable to prior to 4.17.21 are vulnerable to Command Injection via the template function.

**PoC:**
```js
var _ = require('lodash');
_.template('', { variable: '){console.log(process.env)}; with(obj' })()
```
```js
      source = 'function(' + (variable || 'obj') + ') {\n' +
```

CVE-2021-23337
[CWE-77](https://cwe.mitre.org/data/definitions/77.html)
[CWE-94](https://cwe.mitre.org/data/definitions/94.html)
`CVSS:3.1/AV:N/AC:L/PR:H/UI:N/S:U/C:H/I:H/A:H`

