### PR TITLE
Fix wrongly formatted DatePicker value #826

### DIFF
--- a/app/src/data/codesandbox/service.ts
+++ b/app/src/data/codesandbox/service.ts
@@ -45,7 +45,6 @@ class CodesandboxService {
     }
 
     public getCodesandboxParameters(code: string, stylesheets?: FilesRecord): string {
-        console.log(this.files);
         return getParameters({
             files: getCodesandboxConfig(
                 this.processCodeContent(code),

--- a/app/src/docs/examples/blocker/Advanced.example.tsx
+++ b/app/src/docs/examples/blocker/Advanced.example.tsx
@@ -21,7 +21,7 @@ export default function AdvancedExample() {
                         <NumericInput max={ 100 } min={ 0 } value={ 20 } onValueChange={ null }/>
                     </LabeledInput>
                     <LabeledInput label='Country' >
-                        <DatePicker format={ 'DD/MM/YYYY' } value={ '20/11/2042' }  onValueChange={ null }/>
+                        <DatePicker format={ 'DD/MM/YYYY' } value={ '2042-11-20' }  onValueChange={ null }/>
                     </LabeledInput>
                 </FlexRow>
                 <FlexRow spacing='12' padding='24' vPadding='24'>

--- a/app/src/docs/examples/blocker/Basic.example.tsx
+++ b/app/src/docs/examples/blocker/Basic.example.tsx
@@ -21,7 +21,7 @@ export default function BasicExample() {
                         <NumericInput max={ 100 } min={ 0 } value={ 20 } onValueChange={ null }/>
                     </LabeledInput>
                     <LabeledInput label='Country' >
-                        <DatePicker format={ 'DD/MM/YYYY' } value={ '20/11/2042' }  onValueChange={ null }/>
+                        <DatePicker format={ 'DD/MM/YYYY' } value={ '2042-11-20' }  onValueChange={ null }/>
                     </LabeledInput>
                 </FlexRow>
                 <FlexRow spacing='12' padding='24' vPadding='24'>

--- a/loveship/docs/contexts/RelativePanelContext.tsx
+++ b/loveship/docs/contexts/RelativePanelContext.tsx
@@ -34,7 +34,7 @@ export class RelativePanelContext extends React.Component<DemoComponentProps, De
                         <NumericInput max={ 100 } min={ 0 } value={ 20 } onValueChange={ null }/>
                     </LabeledInput>
                     <LabeledInput label='Country' >
-                        <DatePicker format={ 'DD/MM/YYYY' } value={ '20/11/2042' }  onValueChange={ null }/>
+                        <DatePicker format={ 'DD/MM/YYYY' } value={ '2042-11-20' }  onValueChange={ null }/>
                     </LabeledInput>
                 </FlexRow>
                 <FlexRow type='form'>

--- a/next-app/components/lib/LoaderExample.tsx
+++ b/next-app/components/lib/LoaderExample.tsx
@@ -20,7 +20,7 @@ export const  LoaderExample = () => {
                         <NumericInput max={ 100 } min={ 0 } value={ 20 } onValueChange={ () => null }/>
                     </LabeledInput>
                     <LabeledInput label='Country' >
-                        <DatePicker format={ 'DD/MM/YYYY' } value={ '20/11/2042' }  onValueChange={ () => null }/>
+                        <DatePicker format={ 'DD/MM/YYYY' } value={ '2042-11-20' }  onValueChange={ () => null }/>
                     </LabeledInput>
                 </FlexRow>
                 <FlexRow spacing='12' padding='24' vPadding='24'>

--- a/public/docs/content/examples-blocker-Basic.json
+++ b/public/docs/content/examples-blocker-Basic.json
@@ -1,1 +1,21 @@
-{"object":"value","document":{"object":"document","data":{},"nodes":[{"object":"block","type":"paragraph","data":{},"nodes":[{"object":"text","text":"Basic Blocker usage","marks":[]}]}]}}
+{
+  "object": "value",
+  "document": {
+    "object": "document",
+    "data": {},
+    "nodes": [
+      {
+        "object": "block",
+        "type": "paragraph",
+        "data": {},
+        "nodes": [
+          {
+            "object": "text",
+            "text": "Basic Blocker usage",
+            "marks": []
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Fixes #826 
DatePicker `value` accepts YYYY-MM-DD format, so changed example values to that.
Also removed unnecessary console.log introduced in other bugfix.