### PR TITLE
[Avatar]: handle error on loading image and shows stub

### DIFF
--- a/epam-promo/components/navigation/MainMenu/__tests__/__snapshots__/MainMenuAvatar.test.tsx.snap
+++ b/epam-promo/components/navigation/MainMenu/__tests__/__snapshots__/MainMenuAvatar.test.tsx.snap
@@ -7,6 +7,7 @@ exports[`MainMenuAvatar should be rendered correctly 1`] = `
   <img
     className="avatar"
     height="36"
+    onError={[Function]}
     src="https://static.cdn.epam.com/uploads/690afa39a93c88c4dd13758fe1d869d5/EPM-UUI/Images/avatar_placeholder.jpg"
     width="36"
   />
@@ -20,6 +21,7 @@ exports[`MainMenuAvatar should be rendered correctly 2`] = `
   <img
     className="avatar"
     height="36"
+    onError={[Function]}
     src="https://static.cdn.epam.com/uploads/690afa39a93c88c4dd13758fe1d869d5/EPM-UUI/Images/avatar_placeholder.jpg"
     width="36"
   />

--- a/epam-promo/components/widgets/__tests__/Avatar.test.tsx
+++ b/epam-promo/components/widgets/__tests__/Avatar.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Avatar } from '../Avatar';
 import renderer from 'react-test-renderer';
+import {render, screen, fireEvent} from '@testing-library/react'
 
 describe('Avatar', () => {
     it('should be rendered correctly', () => {
@@ -25,6 +26,40 @@ describe('Avatar', () => {
             />)
             .toJSON();
         expect(tree).toMatchSnapshot();
+
     });
+
+    it('should show stub if image is not reachable', () => {
+        render(<Avatar img={ 'not-existing.jpg'}
+                size='36'
+                alt='Test avatar'
+          />);
+        const component: HTMLImageElement = screen.getByAltText('Test avatar');
+        fireEvent.error(component);
+        expect(component.src).toEqual('https://static.cdn.epam.com/uploads/690afa39a93c88c4dd13758fe1d869d5/EPM-UUI/Images/avatar_placeholder.jpg');
+    });
+
+    it('should show stub when prop isLoading true', () => {
+      render(<Avatar img={ 'not-existing.jpg'}
+                size='36'
+                alt='Test avatar'
+                isLoading={true}
+          />);
+        const component: HTMLImageElement = screen.getByAltText('Test avatar');
+        expect(component.src).toEqual('https://static.cdn.epam.com/uploads/690afa39a93c88c4dd13758fe1d869d5/EPM-UUI/Images/avatar_placeholder.jpg');
+    });
+
+    it('shouldn\'t call internal onError if there is onError in rawProps', () => {
+      const mockOnError = jest.fn(event => undefined);
+      render(<Avatar img={ 'https://static.cdn.epam.com/'}
+                size='36'
+                alt='Test avatar'
+                rawProps={ { onError: mockOnError } }
+          />);
+        const component: HTMLImageElement = screen.getByAltText('Test avatar');
+        fireEvent.error(component);
+        expect(component.src).toEqual('https://static.cdn.epam.com/');
+        expect(mockOnError).toHaveBeenCalled();
+    })
 });
 

--- a/epam-promo/components/widgets/__tests__/Avatar.test.tsx
+++ b/epam-promo/components/widgets/__tests__/Avatar.test.tsx
@@ -28,38 +28,5 @@ describe('Avatar', () => {
         expect(tree).toMatchSnapshot();
 
     });
-
-    it('should show stub if image is not reachable', () => {
-        render(<Avatar img={ 'not-existing.jpg'}
-                size='36'
-                alt='Test avatar'
-          />);
-        const component: HTMLImageElement = screen.getByAltText('Test avatar');
-        fireEvent.error(component);
-        expect(component.src).toEqual('https://static.cdn.epam.com/uploads/690afa39a93c88c4dd13758fe1d869d5/EPM-UUI/Images/avatar_placeholder.jpg');
-    });
-
-    it('should show stub when prop isLoading true', () => {
-      render(<Avatar img={ 'not-existing.jpg'}
-                size='36'
-                alt='Test avatar'
-                isLoading={true}
-          />);
-        const component: HTMLImageElement = screen.getByAltText('Test avatar');
-        expect(component.src).toEqual('https://static.cdn.epam.com/uploads/690afa39a93c88c4dd13758fe1d869d5/EPM-UUI/Images/avatar_placeholder.jpg');
-    });
-
-    it('shouldn\'t call internal onError if there is onError in rawProps', () => {
-      const mockOnError = jest.fn(event => undefined);
-      render(<Avatar img={ 'https://static.cdn.epam.com/'}
-                size='36'
-                alt='Test avatar'
-                rawProps={ { onError: mockOnError } }
-          />);
-        const component: HTMLImageElement = screen.getByAltText('Test avatar');
-        fireEvent.error(component);
-        expect(component.src).toEqual('https://static.cdn.epam.com/');
-        expect(mockOnError).toHaveBeenCalled();
-    })
 });
 

--- a/epam-promo/components/widgets/__tests__/__snapshots__/Avatar.test.tsx.snap
+++ b/epam-promo/components/widgets/__tests__/__snapshots__/Avatar.test.tsx.snap
@@ -4,6 +4,7 @@ exports[`Avatar should be rendered correctly 1`] = `
 <img
   className="avatar"
   height="36"
+  onError={[Function]}
   src="https://avatars.dicebear.com/api/human/avatar12.svg?background=%23EBEDF5&radius=50"
   width="36"
 />
@@ -14,6 +15,7 @@ exports[`Avatar should be rendered correctly with props 1`] = `
   alt="Test avatar"
   className="avatar"
   height="36"
+  onError={[Function]}
   src="https://static.cdn.epam.com/uploads/690afa39a93c88c4dd13758fe1d869d5/EPM-UUI/Images/avatar_placeholder.jpg"
   width="36"
 />

--- a/epam-promo/components/widgets/__tests__/__snapshots__/AvatarStack.test.tsx.snap
+++ b/epam-promo/components/widgets/__tests__/__snapshots__/AvatarStack.test.tsx.snap
@@ -17,6 +17,7 @@ exports[`AvatarStack should be rendered correctly 1`] = `
       alt="avatar"
       className="avatar"
       height="36"
+      onError={[Function]}
       src="https://avatars.dicebear.com/api/human/avatar12.svg?background=%23EBEDF5&radius=50"
       width="36"
     />
@@ -24,6 +25,7 @@ exports[`AvatarStack should be rendered correctly 1`] = `
       alt="avatar"
       className="avatar"
       height="36"
+      onError={[Function]}
       src="https://avatars.dicebear.com/api/human/avatar12.svg?background=%23EBEDF5&radius=50"
       width="36"
     />
@@ -31,6 +33,7 @@ exports[`AvatarStack should be rendered correctly 1`] = `
       alt="avatar"
       className="avatar"
       height="36"
+      onError={[Function]}
       src="https://avatars.dicebear.com/api/human/avatar12.svg?background=%23EBEDF5&radius=50"
       width="36"
     />

--- a/epam-promo/package.json
+++ b/epam-promo/package.json
@@ -27,6 +27,7 @@
   },
   "devDependencies": {
     "@epam/uui-docs": "4.9.2",
+    "@testing-library/react": "^12.1.2",
     "@types/react-test-renderer": "17.0.1",
     "@wojtekmaj/enzyme-adapter-react-17": "^0.6.2",
     "enzyme": "^3.9.0",

--- a/loveship/components/navigation/MainMenu/__tests__/__snapshots__/MainMenuAvatar.test.tsx.snap
+++ b/loveship/components/navigation/MainMenu/__tests__/__snapshots__/MainMenuAvatar.test.tsx.snap
@@ -7,6 +7,7 @@ exports[`MainMenuAvatar should be rendered correctly 1`] = `
   <img
     className="avatar photo"
     height="36"
+    onError={[Function]}
     src="https://static.cdn.epam.com/uploads/690afa39a93c88c4dd13758fe1d869d5/EPM-UUI/Images/avatar_placeholder.jpg"
     width="36"
   />
@@ -20,6 +21,7 @@ exports[`MainMenuAvatar should be rendered correctly with props 1`] = `
   <img
     className="avatar photo"
     height="36"
+    onError={[Function]}
     src="https://static.cdn.epam.com/uploads/690afa39a93c88c4dd13758fe1d869d5/EPM-UUI/Images/avatar_placeholder.jpg"
     width="36"
   />

--- a/loveship/components/widgets/__tests__/__snapshots__/Avatar.test.tsx.snap
+++ b/loveship/components/widgets/__tests__/__snapshots__/Avatar.test.tsx.snap
@@ -4,6 +4,7 @@ exports[`Avatar should be rendered correctly 1`] = `
 <img
   className="avatar"
   height="42"
+  onError={[Function]}
   src="https://avatars.dicebear.com/api/human/avatar12.svg?background=%23EBEDF5&radius=50"
   width="42"
 />
@@ -14,6 +15,7 @@ exports[`Avatar should be rendered correctly with extra props 1`] = `
   alt="Avatar"
   className="avatar"
   height="36"
+  onError={[Function]}
   src="https://static.cdn.epam.com/uploads/690afa39a93c88c4dd13758fe1d869d5/EPM-UUI/Images/avatar_placeholder.jpg"
   width="36"
 />

--- a/loveship/components/widgets/__tests__/__snapshots__/AvatarRow.test.tsx.snap
+++ b/loveship/components/widgets/__tests__/__snapshots__/AvatarRow.test.tsx.snap
@@ -7,6 +7,7 @@ exports[`AvatarRow should be rendered correctly 1`] = `
   <img
     className="avatar avatarContent size-42"
     height="42"
+    onError={[Function]}
     src="https://avatars.dicebear.com/api/human/avatar12.svg?background=%23EBEDF5&radius=50"
     width="42"
   />

--- a/loveship/components/widgets/__tests__/__snapshots__/AvatarStack.test.tsx.snap
+++ b/loveship/components/widgets/__tests__/__snapshots__/AvatarStack.test.tsx.snap
@@ -17,6 +17,7 @@ exports[`AvatarStack should be rendered correctly 1`] = `
       alt="avatar"
       className="avatar"
       height="48"
+      onError={[Function]}
       src="https://avatars.dicebear.com/api/human/avatar12.svg?background=%23EBEDF5&radius=50"
       width="48"
     />
@@ -24,6 +25,7 @@ exports[`AvatarStack should be rendered correctly 1`] = `
       alt="avatar"
       className="avatar"
       height="48"
+      onError={[Function]}
       src="https://avatars.dicebear.com/api/human/avatar12.svg?background=%23EBEDF5&radius=50"
       width="48"
     />
@@ -31,6 +33,7 @@ exports[`AvatarStack should be rendered correctly 1`] = `
       alt="avatar"
       className="avatar"
       height="48"
+      onError={[Function]}
       src="https://avatars.dicebear.com/api/human/avatar12.svg?background=%23EBEDF5&radius=50"
       width="48"
     />

--- a/uui-components/src/widgets/Avatar.test.tsx
+++ b/uui-components/src/widgets/Avatar.test.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { Avatar } from './Avatar';
+import {render, screen, fireEvent} from '@testing-library/react'
+
+describe('Avatar', () => {
+    it('should show stub if image is not reachable', () => {
+        render(<Avatar img={ 'not-existing.jpg'}
+                size='36'
+                alt='Test avatar'
+          />);
+        const component: HTMLImageElement = screen.getByAltText('Test avatar');
+        fireEvent.error(component);
+        expect(component.src).toEqual('https://static.cdn.epam.com/uploads/690afa39a93c88c4dd13758fe1d869d5/EPM-UUI/Images/avatar_placeholder.jpg');
+    });
+
+    it('should show stub when prop isLoading true', () => {
+      render(<Avatar img={ 'not-existing.jpg'}
+                size='36'
+                alt='Test avatar'
+                isLoading={true}
+          />);
+        const component: HTMLImageElement = screen.getByAltText('Test avatar');
+        expect(component.src).toEqual('https://static.cdn.epam.com/uploads/690afa39a93c88c4dd13758fe1d869d5/EPM-UUI/Images/avatar_placeholder.jpg');
+    });
+
+    it('shouldn\'t call internal onError if there is onError in rawProps', () => {
+      const mockOnError = jest.fn(event => undefined);
+      render(<Avatar img={ 'https://static.cdn.epam.com/'}
+                size='36'
+                alt='Test avatar'
+                rawProps={ { onError: mockOnError } }
+          />);
+        const component: HTMLImageElement = screen.getByAltText('Test avatar');
+        fireEvent.error(component);
+        expect(component.src).toEqual('https://static.cdn.epam.com/');
+        expect(mockOnError).toHaveBeenCalled();
+    })
+});
+

--- a/uui-components/src/widgets/Avatar.tsx
+++ b/uui-components/src/widgets/Avatar.tsx
@@ -20,11 +20,11 @@ export interface AvatarProps extends IHasCX, IHasRawProps<React.ImgHTMLAttribute
 }
 
 const AvatarComponent = (props: AvatarProps, ref: React.ForwardedRef<HTMLImageElement>) => {
-    const [errorMode, setErrorMode] = React.useState<boolean>(false);
+    const [isError, setIsError] = React.useState<boolean>(false);
 
     function onError() {
-      if (!errorMode) {
-        setErrorMode(true);
+      if (!isError) {
+        setIsError(true);
       }
     }
     return (
@@ -34,7 +34,7 @@ const AvatarComponent = (props: AvatarProps, ref: React.ForwardedRef<HTMLImageEl
                 className={ cx(css.avatar, props.cx) }
                 width={ props.size }
                 height={ props.size }
-                src={ (props.isLoading || !props.img || errorMode) ? 'https://static.cdn.epam.com/uploads/690afa39a93c88c4dd13758fe1d869d5/EPM-UUI/Images/avatar_placeholder.jpg' : props.img }
+                src={ (props.isLoading || !props.img || isError) ? 'https://static.cdn.epam.com/uploads/690afa39a93c88c4dd13758fe1d869d5/EPM-UUI/Images/avatar_placeholder.jpg' : props.img }
                 alt={ props.alt }
                 onError={ onError }
                 { ...props.rawProps }

--- a/uui-components/src/widgets/Avatar.tsx
+++ b/uui-components/src/widgets/Avatar.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React, {useState} from 'react';
 import { IHasCX, cx, IHasRawProps, IHasForwardedRef } from '@epam/uui-core';
 import * as css from './Avatar.scss';
 
@@ -20,6 +20,13 @@ export interface AvatarProps extends IHasCX, IHasRawProps<React.ImgHTMLAttribute
 }
 
 const AvatarComponent = (props: AvatarProps, ref: React.ForwardedRef<HTMLImageElement>) => {
+    const [errorMode, setErrorMode] = React.useState<boolean>(false);
+
+    function onError() {
+      if (!errorMode) {
+        setErrorMode(true);
+      }
+    }
     return (
             <img
                 onClick={ props.onClick }
@@ -27,8 +34,9 @@ const AvatarComponent = (props: AvatarProps, ref: React.ForwardedRef<HTMLImageEl
                 className={ cx(css.avatar, props.cx) }
                 width={ props.size }
                 height={ props.size }
-                src={ (props.isLoading || !props.img) ? 'https://static.cdn.epam.com/uploads/690afa39a93c88c4dd13758fe1d869d5/EPM-UUI/Images/avatar_placeholder.jpg' : props.img }
+                src={ (props.isLoading || !props.img || errorMode) ? 'https://static.cdn.epam.com/uploads/690afa39a93c88c4dd13758fe1d869d5/EPM-UUI/Images/avatar_placeholder.jpg' : props.img }
                 alt={ props.alt }
+                onError={ onError }
                 { ...props.rawProps }
             />
     );


### PR DESCRIPTION
For what: improve Avatar component, add handling of errors. 

Current behaviour: if there is incorrect path in Avatar (not undefined) -> Avatar shows broken image, not stub. 
After improvement: if there is incorrect path in Avatar -> Avatar shows stub. 

In case when developer pass rawProps with his own handler for onError -> we don't show stub, handling of error on developer side. 