### PR TITLE
[NumericInput]: fixed formatOptions prop works incorrect 

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,7 @@
 * [VerticalTabButton]: fix text trimmed and text align
 * [Switch]: remove margin-left when there is no label
 * [Anchor][BaseButton]: added `rel='noopener noreferrer'` where `target='_blank'` in order to fix the security issue
+* [NumericInput]: fixed `NumericInput` by preventing rounding up numbers if `formatOptions` are defined
 
 # 4.9.2 - 14.12.2022
 

--- a/uui-components/src/inputs/NumericInput.tsx
+++ b/uui-components/src/inputs/NumericInput.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import {
     IHasRawProps, cx, getCalculatedValue, IHasCX, IClickable, IDisableable, IEditable, IHasPlaceholder, Icon, uuiMod, uuiElement,
     CX, ICanBeReadonly, IAnalyticableOnChange, IHasForwardedRef, ICanFocus, uuiMarkers, getMinMaxValidatedValue, getSeparatedValue, useUuiContext,
-    i18n,
+    toFixedWithoutRoundingUp, i18n,
 } from '@epam/uui-core';
 import { IconContainer } from '../layout';
 import css from './NumericInput.scss';
@@ -59,12 +59,6 @@ const getFractionDigits = (formatOptions: Intl.NumberFormatOptions) => {
     const { maximumFractionDigits } = new Intl.NumberFormat(i18n.locale, formatOptions).resolvedOptions();
     return maximumFractionDigits;
 };
-
-const toFixedWithoutRoundingUp = (value: number, fractionDigits: number) => {
-    const valueExtractor = Math.pow(10, fractionDigits);
-    const valueWithoutUnusedDigits = Math.floor(value * valueExtractor) / valueExtractor;
-    return +valueWithoutUnusedDigits.toFixed(fractionDigits);
-}
 
 export const NumericInput = (props: NumericInputProps) => {
     let { value, min, max, step, formatter, formatOptions } = props;

--- a/uui-components/src/inputs/NumericInput.tsx
+++ b/uui-components/src/inputs/NumericInput.tsx
@@ -60,6 +60,12 @@ const getFractionDigits = (formatOptions: Intl.NumberFormatOptions) => {
     return maximumFractionDigits;
 };
 
+const toFixedWithoutRoundingUp = (value: number, fractionDigits: number) => {
+    const valueExtractor = Math.pow(10, fractionDigits);
+    const valueWithoutUnusedDigits = Math.floor(value * valueExtractor) / valueExtractor;
+    return +valueWithoutUnusedDigits.toFixed(fractionDigits);
+}
+
 export const NumericInput = (props: NumericInputProps) => {
     let { value, min, max, step, formatter, formatOptions } = props;
 
@@ -78,12 +84,14 @@ export const NumericInput = (props: NumericInputProps) => {
     const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
         let newValue = event.target.value === "" ? null : +event.target.value;
         const fractionDigits = getFractionDigits(formatOptions);
+
         if (newValue !== null) {
-            newValue = +newValue.toFixed(fractionDigits);
+            newValue = toFixedWithoutRoundingUp(newValue, fractionDigits);
         }
         if (formatter) {
             newValue = formatter(newValue);
         }
+
         props.onValueChange(newValue);
         if (props.getValueChangeAnalyticsEvent) {
             const event = props.getValueChangeAnalyticsEvent(newValue, props.value);
@@ -100,7 +108,7 @@ export const NumericInput = (props: NumericInputProps) => {
         setInFocus(false);
 
         // clearing the input when entering invalid data using special characters
-        if(event.target.validity?.badInput) {
+        if (event.target.validity?.badInput) {
             inputRef.current.value = ""
         } else {
             const validatedValue = getMinMaxValidatedValue({ value, min, max });
@@ -139,9 +147,9 @@ export const NumericInput = (props: NumericInputProps) => {
     React.useEffect(() => {
         const preventValueChange = (e: WheelEvent) => (document.activeElement === e.target) && e.preventDefault()
 
-        inputRef?.current?.addEventListener('wheel', preventValueChange, {passive: false})
+        inputRef?.current?.addEventListener('wheel', preventValueChange, { passive: false })
 
-        return () => {inputRef?.current?.removeEventListener('wheel', preventValueChange)}
+        return () => { inputRef?.current?.removeEventListener('wheel', preventValueChange) }
     }, [])
 
     const isPlaceholderColored = React.useMemo(() => Boolean(props.value || props.value === 0), [props.value]);
@@ -193,7 +201,7 @@ export const NumericInput = (props: NumericInputProps) => {
                 ref={ inputRef }
             />
 
-        { showArrows && (
+            { showArrows && (
                 <div className={ uuiNumericInput.buttonGroup }>
                     <IconContainer
                         cx={ uuiNumericInput.upButton }
@@ -208,7 +216,7 @@ export const NumericInput = (props: NumericInputProps) => {
                         isDisabled={ props.isDisabled }
                     />
                 </div>
-        ) }
+            ) }
         </div>
     );
 };

--- a/uui-core/src/helpers/__tests__/numericInputCalculations.test.tsx
+++ b/uui-core/src/helpers/__tests__/numericInputCalculations.test.tsx
@@ -1,4 +1,7 @@
-import { getDecimalLength, getCalculatedValue, getMinMaxValidatedValue, getSeparatedValue } from "../numericInputCalculations";
+import {
+    getDecimalLength, getCalculatedValue, getMinMaxValidatedValue, getSeparatedValue,
+    toFixedWithoutRoundingUp
+} from "../numericInputCalculations";
 
 describe('numericInputCalculations', () => {
     it('getDecimalLength return length of the decimal value', () => {
@@ -8,26 +11,26 @@ describe('numericInputCalculations', () => {
         expect(getDecimalLength(1.3333333333)).toBe(10);
     });
     it('getCalculatedValue return calculated value with default step and action', () => {
-        expect(getCalculatedValue({ value: 1.25})).toBe(2.25);
-        expect(getCalculatedValue({ value: 2})).toBe(3);
-        expect(getCalculatedValue({ value: 4.225})).toBe(5.225);
+        expect(getCalculatedValue({ value: 1.25 })).toBe(2.25);
+        expect(getCalculatedValue({ value: 2 })).toBe(3);
+        expect(getCalculatedValue({ value: 4.225 })).toBe(5.225);
     });
     it('getCalculatedValue return incremented value with custom step ', () => {
-        expect(getCalculatedValue({ value: 1.33, step: 0.125})).toBe(1.455);
-        expect(getCalculatedValue({ value: 2, step: 0.01})).toBe(2.01);
-        expect(getCalculatedValue({ value: 4.225, step: 0.3})).toBe(4.525);
+        expect(getCalculatedValue({ value: 1.33, step: 0.125 })).toBe(1.455);
+        expect(getCalculatedValue({ value: 2, step: 0.01 })).toBe(2.01);
+        expect(getCalculatedValue({ value: 4.225, step: 0.3 })).toBe(4.525);
     });
     it('getCalculatedValue return decremented value with custom step ', () => {
-        expect(getCalculatedValue({ value: 10.33333, step: 0.008, action: "decr"})).toBe(10.32533);
-        expect(getCalculatedValue({ value: 2, step: 1.0026, action: "decr"})).toBe(0.9974);
-        expect(getCalculatedValue({ value: 4.225, step: 0.03, action: "decr"})).toBe(4.195);
+        expect(getCalculatedValue({ value: 10.33333, step: 0.008, action: "decr" })).toBe(10.32533);
+        expect(getCalculatedValue({ value: 2, step: 1.0026, action: "decr" })).toBe(0.9974);
+        expect(getCalculatedValue({ value: 4.225, step: 0.03, action: "decr" })).toBe(4.195);
     });
 
     it('getMinMaxValidatedValue return validated value within min max range', () => {
-        expect(getMinMaxValidatedValue({ value: 10, min: 0, max: 10})).toBe(10);
-        expect(getMinMaxValidatedValue({ value: 12, min: 0, max: 10})).toBe(10);
-        expect(getMinMaxValidatedValue({ value: -1, max: 10})).toBe(0);
-        expect(getMinMaxValidatedValue({ value: null, max: 10})).toBe(null);
+        expect(getMinMaxValidatedValue({ value: 10, min: 0, max: 10 })).toBe(10);
+        expect(getMinMaxValidatedValue({ value: 12, min: 0, max: 10 })).toBe(10);
+        expect(getMinMaxValidatedValue({ value: -1, max: 10 })).toBe(0);
+        expect(getMinMaxValidatedValue({ value: null, max: 10 })).toBe(null);
     });
 
     it('getSeparatedValue return validated value within min max range', () => {
@@ -39,5 +42,13 @@ describe('numericInputCalculations', () => {
         expect(getSeparatedValue(1.5645514, formatOptions, locale)).toBe('1.565');
         expect(getSeparatedValue(1.5645514, { maximumFractionDigits: 2 }, locale)).toBe('1.56');
         expect(getSeparatedValue(null)).toBe(null);
+    });
+
+    it('toFixedWithoutRoundingUp return fixed value without rounding up', () => {
+        expect(toFixedWithoutRoundingUp(45521, 2)).toBe(45521);
+        expect(toFixedWithoutRoundingUp(45521.551, 2)).toBe(45521.55);
+        expect(toFixedWithoutRoundingUp(45521.556, 2)).toBe(45521.55);
+        expect(toFixedWithoutRoundingUp(45521.11111, 2)).toBe(45521.11);
+        expect(toFixedWithoutRoundingUp(45521.99999, 2)).toBe(45521.99);
     });
 });

--- a/uui-core/src/helpers/numericInputCalculations.ts
+++ b/uui-core/src/helpers/numericInputCalculations.ts
@@ -49,3 +49,9 @@ export const getSeparatedValue = (value: number, formatOptions: Intl.NumberForma
     if (!value && value !== 0) return null;
     return value.toLocaleString(locale, formatOptions);
 };
+
+export const toFixedWithoutRoundingUp = (value: number, fractionDigits: number) => {
+    const valueExtractor = Math.pow(10, fractionDigits);
+    const valueWithoutUnusedDigits = Math.floor(value * valueExtractor) / valueExtractor;
+    return +valueWithoutUnusedDigits.toFixed(fractionDigits);
+}


### PR DESCRIPTION
### Summary
Closes: https://github.com/epam/UUI/issues/916


Replaced `toFixed` with a function, which is not rounding up the number.

#### Before:

https://user-images.githubusercontent.com/22456368/211508939-d26703f8-ce58-4318-8459-4b7e48cd3ec9.mov

#### After:

https://user-images.githubusercontent.com/22456368/211508773-935e5848-5ad2-4eef-bec4-dbf9e0b1d8dc.mov

