### PR TITLE
[ColumnsConfigurationModal]: tooltip position fixed when no columns selected.

### DIFF
--- a/epam-promo/components/tables/columnsConfigurationModal/ColumnsConfigurationModal.tsx
+++ b/epam-promo/components/tables/columnsConfigurationModal/ColumnsConfigurationModal.tsx
@@ -134,7 +134,7 @@ export function ColumnsConfigurationModal<TItem, TId, TFilter>(props: ColumnsCon
                     <Button fill="white" color="gray50" caption={ i18nLocal.cancelButton } onClick={ close } />
                     { noVisibleColumns
                         ? (
-                            <Tooltip content={ i18nLocal.enableAtLeastOneColumnMessage } placement='top' color='red'>
+                            <Tooltip content={ i18nLocal.enableAtLeastOneColumnMessage } placement='top-end' color='red'>
                                 { applyButton }
                             </Tooltip>
                         )

--- a/loveship/components/tables/columnsConfigurationModal/ColumnsConfigurationModal.tsx
+++ b/loveship/components/tables/columnsConfigurationModal/ColumnsConfigurationModal.tsx
@@ -134,7 +134,7 @@ export function ColumnsConfigurationModal<TItem, TId, TFilter>(props: ColumnsCon
                     <Button fill="white" color="night500" caption={ i18nLocal.cancelButton } onClick={ close } />
                     { noVisibleColumns
                         ? (
-                            <Tooltip content={ i18nLocal.enableAtLeastOneColumnMessage } placement='top' color='fire'>
+                            <Tooltip content={ i18nLocal.enableAtLeastOneColumnMessage } placement='top-end' color='fire'>
                                 { applyButton }
                             </Tooltip>
                         )


### PR DESCRIPTION
### Summary
Changed the tooltip to the position, which is corresponding to the design, placed at the issue: https://github.com/epam/UUI/issues/878

#### Promo
<img width="449" alt="Screenshot 2023-01-11 at 16 01 16" src="https://user-images.githubusercontent.com/22456368/211825403-edc99f69-8338-4cb9-a6f7-d3cd7842db6d.png">

#### Loveship
<img width="449" alt="Screenshot 2023-01-11 at 15 59 53" src="https://user-images.githubusercontent.com/22456368/211825120-8bf772b0-5914-4818-b065-8722b1a832e6.png">
