### PR TITLE
[NumericInput] Add custom formatting 

### DIFF
--- a/app/src/docs/_examples/numericInput/Formatting.example.tsx
+++ b/app/src/docs/_examples/numericInput/Formatting.example.tsx
@@ -27,6 +27,13 @@ export default function BasicExample() {
                     formatOptions={ { maximumFractionDigits: 0 } }
                 />
             </LabeledInput>
+            <LabeledInput label='Min 2 fractional digits'>
+                <NumericInput
+                    value={ value }
+                    onValueChange={ onValueChange }
+                    formatOptions={ { minimumFractionDigits: 2 } }
+                />
+            </LabeledInput>
             <LabeledInput label='Max 2 fractional digits'>
                 <NumericInput
                     value={ value }

--- a/app/src/docs/_examples/numericInput/Formatting.example.tsx
+++ b/app/src/docs/_examples/numericInput/Formatting.example.tsx
@@ -24,35 +24,43 @@ export default function BasicExample() {
                 <NumericInput
                     value={ value }
                     onValueChange={ onValueChange }
-                    formatOptions={{ maximumFractionDigits: 0 }}
+                    formatOptions={ { maximumFractionDigits: 0 } }
                 />
             </LabeledInput>
             <LabeledInput label='Max 2 fractional digits'>
                 <NumericInput
                     value={ value }
                     onValueChange={ onValueChange }
-                    formatOptions={{ minimumFractionDigits: 2, maximumFractionDigits: 2 }}
+                    formatOptions={ { minimumFractionDigits: 2, maximumFractionDigits: 2 } }
                 />
             </LabeledInput>
             <LabeledInput label='Exactly 2 fractional digits'>
                 <NumericInput
                     value={ value }
                     onValueChange={ onValueChange }
-                    formatOptions={{ minimumFractionDigits: 2, maximumFractionDigits: 2 }}
+                    formatOptions={ { minimumFractionDigits: 2, maximumFractionDigits: 2 } }
                 />
             </LabeledInput>
             <LabeledInput label='Currency'>
                 <NumericInput
                     value={ value }
                     onValueChange={ onValueChange }
-                    formatOptions={{ style: "currency", currency: "USD", currencyDisplay: "name" }}
+                    formatOptions={ { style: "currency", currency: "USD", currencyDisplay: "name" } }
                 />
             </LabeledInput>
             <LabeledInput label='Units (meters)'>
                 <NumericInput
                     value={ value }
                     onValueChange={ onValueChange }
-                    formatOptions={{ style: "unit", unit: "meter" }}
+                    formatOptions={ { style: "unit", unit: "meter" } }
+                />
+            </LabeledInput>
+            <LabeledInput label='Custom formatting (readonly mode only)'>
+                <NumericInput
+                    value={ value }
+                    onValueChange={ onValueChange }
+                    formatValue={ (value) => { return 'USD ' + value } }
+                    isReadonly
                 />
             </LabeledInput>
         </FlexCell>

--- a/app/src/docs/_examples/numericInput/Formatting.example.tsx
+++ b/app/src/docs/_examples/numericInput/Formatting.example.tsx
@@ -52,6 +52,7 @@ export default function BasicExample() {
                 <NumericInput
                     value={ value }
                     onValueChange={ onValueChange }
+                    formatOptions={ { maximumFractionDigits: 2 } }
                     formatValue={ (value) => { return 'USD ' + value } }
                 />
             </LabeledInput>

--- a/app/src/docs/_examples/numericInput/Formatting.example.tsx
+++ b/app/src/docs/_examples/numericInput/Formatting.example.tsx
@@ -48,19 +48,18 @@ export default function BasicExample() {
                     formatOptions={ { style: "currency", currency: "USD", currencyDisplay: "name" } }
                 />
             </LabeledInput>
-            <LabeledInput label='Units (meters)'>
-                <NumericInput
-                    value={ value }
-                    onValueChange={ onValueChange }
-                    formatOptions={ { style: "unit", unit: "meter" } }
-                />
-            </LabeledInput>
             <LabeledInput label='Custom formatting (readonly mode only)'>
                 <NumericInput
                     value={ value }
                     onValueChange={ onValueChange }
                     formatValue={ (value) => { return 'USD ' + value } }
-                    isReadonly
+                />
+            </LabeledInput>
+            <LabeledInput label='Units (meters)'>
+                <NumericInput
+                    value={ value }
+                    onValueChange={ onValueChange }
+                    formatOptions={ { style: "unit", unit: "meter" } }
                 />
             </LabeledInput>
         </FlexCell>

--- a/app/src/docs/_examples/numericInput/Formatting.example.tsx
+++ b/app/src/docs/_examples/numericInput/Formatting.example.tsx
@@ -31,7 +31,7 @@ export default function BasicExample() {
                 <NumericInput
                     value={ value }
                     onValueChange={ onValueChange }
-                    formatOptions={ { minimumFractionDigits: 2, maximumFractionDigits: 2 } }
+                    formatOptions={ { maximumFractionDigits: 2 } }
                 />
             </LabeledInput>
             <LabeledInput label='Exactly 2 fractional digits'>
@@ -48,7 +48,7 @@ export default function BasicExample() {
                     formatOptions={ { style: "currency", currency: "USD", currencyDisplay: "name" } }
                 />
             </LabeledInput>
-            <LabeledInput label='Custom formatting (readonly mode only)'>
+            <LabeledInput label='Custom formatting with max 2 fraction digits'>
                 <NumericInput
                     value={ value }
                     onValueChange={ onValueChange }

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,11 @@
+# 4.xx.x - xx.xx.2023
+
+What's Fixed
+- [Typography] Links now underlined in typography
+- [NumericInput] Label text highlighting prevented on clicking up/down arrow buttons
+- [NumericInput] `formatter` prop replaced with custom `formatValue` function which converts given input into text instead of number
+- [ButtonBase] `disabled` attribute applied according to buttons state
+
 # 4.10.0 - 06.02.2023
 
 **What's New**

--- a/uui-components/src/inputs/NumericInput.tsx
+++ b/uui-components/src/inputs/NumericInput.tsx
@@ -50,7 +50,7 @@ export interface NumericInputProps extends ICanFocus<HTMLInputElement>, IHasCX, 
     /**
      * A function to convert current input value to displayed text.
      * Overrides standard Intl-based formatting. If passed, formatOptions prop is ignored.
-     * Note, that formatting is used only in read-mode, when input is out of focus.
+     * Note, that formatting is used when input is out of focus.
      */
     formatValue?(value: number): string;
 }
@@ -84,13 +84,16 @@ export const NumericInput = (props: NumericInputProps) => {
 
     const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
         let newValue = event.target.value === "" ? null : +event.target.value;
-        const fractionDigits = getFractionDigits(formatOptions);
 
-        if (newValue !== null) {
-            newValue = toFixedWithoutRoundingUp(newValue, fractionDigits);
-        }
-        if (formatter) {
-            newValue = formatter(newValue);
+        // skip Intl-based formatting when custom formatter applied
+        if (!formatValue) {
+            const fractionDigits = getFractionDigits(formatOptions);
+            if (newValue !== null) {
+                newValue = toFixedWithoutRoundingUp(newValue, fractionDigits);
+            }
+            if (formatter) {
+                newValue = formatter(newValue);
+            }
         }
 
         props.onValueChange(newValue);
@@ -158,7 +161,8 @@ export const NumericInput = (props: NumericInputProps) => {
 
     const placeholderValue = React.useMemo(() => {
         if (!value && value !== 0) return props.placeholder || "0";
-        if (props.isReadonly && !!formatValue) return formatValue(value);
+        if (formatValue) return formatValue(value);
+
         return props.disableLocaleFormatting ? value.toString() : getSeparatedValue(value, formatOptions, i18n.locale);
     }, [props.placeholder, props.value, props.formatOptions, props.disableLocaleFormatting]);
 

--- a/uui-components/src/inputs/NumericInput.tsx
+++ b/uui-components/src/inputs/NumericInput.tsx
@@ -41,12 +41,6 @@ export interface NumericInputProps extends ICanFocus<HTMLInputElement>, IHasCX, 
     /** Number formatting options. See #{link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat} */
     formatOptions?: Intl.NumberFormatOptions;
 
-    // Obsolete! Made obsolete at 25-May-2022. TBD: Remove in next releases
-    /**
-     * [Obsolete]: Please rework this to change value in lens.onChange or onValueChange instead
-     */
-    formatter?(value: number): number;
-
     /**
      * A function to convert current input value to displayed text.
      * Overrides standard Intl-based formatting. If passed, formatOptions prop is ignored.
@@ -68,7 +62,7 @@ const getFractionDigits = (formatOptions: Intl.NumberFormatOptions) => {
 };
 
 export const NumericInput = (props: NumericInputProps) => {
-    let { value, min, max, step, formatter, formatValue, formatOptions } = props;
+    let { value, min, max, step, formatValue, formatOptions } = props;
 
     if (value != null) {
         value = +value;
@@ -85,15 +79,9 @@ export const NumericInput = (props: NumericInputProps) => {
     const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
         let newValue = event.target.value === "" ? null : +event.target.value;
 
-        // skip Intl-based formatting when custom formatter applied
-        if (!formatValue) {
-            const fractionDigits = getFractionDigits(formatOptions);
-            if (newValue !== null) {
-                newValue = toFixedWithoutRoundingUp(newValue, fractionDigits);
-            }
-            if (formatter) {
-                newValue = formatter(newValue);
-            }
+        const fractionDigits = getFractionDigits(formatOptions);
+        if (newValue !== null) {
+            newValue = toFixedWithoutRoundingUp(newValue, fractionDigits);
         }
 
         props.onValueChange(newValue);

--- a/uui-components/src/inputs/NumericInput.tsx
+++ b/uui-components/src/inputs/NumericInput.tsx
@@ -46,6 +46,13 @@ export interface NumericInputProps extends ICanFocus<HTMLInputElement>, IHasCX, 
      * [Obsolete]: Please rework this to change value in lens.onChange or onValueChange instead
      */
     formatter?(value: number): number;
+
+    /**
+     * A function to convert current input value to displayed text.
+     * Overrides standard Intl-based formatting. If passed, formatOptions prop is ignored.
+     * Note, that formatting is used only in read-mode, when input is out of focus.
+     */
+    formatValue?(value: number): string;
 }
 
 export const uuiNumericInput = {
@@ -61,7 +68,7 @@ const getFractionDigits = (formatOptions: Intl.NumberFormatOptions) => {
 };
 
 export const NumericInput = (props: NumericInputProps) => {
-    let { value, min, max, step, formatter, formatOptions } = props;
+    let { value, min, max, step, formatter, formatValue, formatOptions } = props;
 
     if (value != null) {
         value = +value;
@@ -151,6 +158,7 @@ export const NumericInput = (props: NumericInputProps) => {
 
     const placeholderValue = React.useMemo(() => {
         if (!value && value !== 0) return props.placeholder || "0";
+        if (props.isReadonly && !!formatValue) return formatValue(value);
         return props.disableLocaleFormatting ? value.toString() : getSeparatedValue(value, formatOptions, i18n.locale);
     }, [props.placeholder, props.value, props.formatOptions, props.disableLocaleFormatting]);
 

--- a/uui-components/src/inputs/NumericInput.tsx
+++ b/uui-components/src/inputs/NumericInput.tsx
@@ -43,7 +43,8 @@ export interface NumericInputProps extends ICanFocus<HTMLInputElement>, IHasCX, 
 
     /**
      * A function to convert current input value to displayed text.
-     * Overrides standard Intl-based formatting. If passed, formatOptions prop is ignored.
+     * Overrides standard Intl-based formatting.
+     * If passed, only maximumFractionDigits considered from formatOptions when both properties provided.
      * Note, that formatting is used when input is out of focus.
      */
     formatValue?(value: number): string;


### PR DESCRIPTION
## Summary

Closes #1010

This PR adds support of custom formatting in readonly mode for `NumericInput`.



https://user-images.githubusercontent.com/39378793/222702897-0f420941-2773-4d59-981b-dc868728739c.mp4



