### PR TITLE
[FilterPanel]: No possibility to close the filter modal window by clicking on the cross icon (mobile) #1019

### DIFF
--- a/uui-core/src/types/components/filterItemBody.ts
+++ b/uui-core/src/types/components/filterItemBody.ts
@@ -3,4 +3,5 @@ import { TableFiltersConfig } from '../tables';
 
 export type IFilterItemBodyProps<TFilter> = TableFiltersConfig<TFilter> & IEditable<any> & IDropdownBodyProps & {
     selectedPredicate?: string;
+    onClose?: () => void;
 };

--- a/uui/components/filters/FilterPickerBody.tsx
+++ b/uui/components/filters/FilterPickerBody.tsx
@@ -90,22 +90,17 @@ export class FilterPickerBody<TItem, TId> extends PickerInputBase<TItem, TId, Fi
                 rawProps={ { tabIndex: -1 } }
                 cx={ [uuiMarkers.lockFocus] }
             >
-                <MobileDropdownWrapper
-                    title={ this.props.entityName }
-                    close={ this.props?.onClose }
-                >
 
-                    <DataPickerBody
-                        { ...props }
-                        selectionMode={ this.props.selectionMode }
-                        rows={ renderedDataRows }
-                        maxHeight={ maxHeight }
-                        searchSize="36"
-                        editMode="dropdown"
-                        showSearch={ true }
-                    />
-                    { this.renderFooter(props.selectAll) }
-                </MobileDropdownWrapper>
+                <DataPickerBody
+                    { ...props }
+                    selectionMode={ this.props.selectionMode }
+                    rows={ renderedDataRows }
+                    maxHeight={ maxHeight }
+                    searchSize="36"
+                    editMode="dropdown"
+                    showSearch={ true }
+                />
+                { this.renderFooter(props.selectAll) }
             </Panel>
         );
     }

--- a/uui/components/filters/FilterPickerBody.tsx
+++ b/uui/components/filters/FilterPickerBody.tsx
@@ -92,7 +92,7 @@ export class FilterPickerBody<TItem, TId> extends PickerInputBase<TItem, TId, Fi
             >
                 <MobileDropdownWrapper
                     title={ this.props.entityName }
-                    close={ () => this.toggleBodyOpening(false) }
+                    close={ this.props?.onClose }
                 >
 
                     <DataPickerBody

--- a/uui/components/filters/FiltersPanelItem.scss
+++ b/uui/components/filters/FiltersPanelItem.scss
@@ -11,3 +11,9 @@
         padding-left: 24px;
     }
 }
+
+.panel {
+    @media screen and (max-width: 720px) {
+        height: var(--app-mobile-height);
+    }
+}

--- a/uui/components/filters/FiltersPanelItem.scss
+++ b/uui/components/filters/FiltersPanelItem.scss
@@ -11,9 +11,3 @@
         padding-left: 24px;
     }
 }
-
-.panel {
-    @media screen and (max-width: 720px) {
-        height: var(--app-mobile-height);
-    }
-}

--- a/uui/components/filters/FiltersPanelItem.tsx
+++ b/uui/components/filters/FiltersPanelItem.tsx
@@ -96,7 +96,7 @@ const FiltersToolbarItemImpl = (props: FiltersToolbarItemProps) => {
 
     const renderBody = (dropdownProps: DropdownBodyProps) => (
         <DropdownContainer>
-            <Panel>
+            <Panel cx={ css.panel }>
                 { renderHeader() }
                 { <FilterItemBody { ...props } { ...dropdownProps } selectedPredicate={ predicate } value={ getValue() } onValueChange={ onValueChange } onClose={ closeDropdown }/> }
             </Panel>

--- a/uui/components/filters/FiltersPanelItem.tsx
+++ b/uui/components/filters/FiltersPanelItem.tsx
@@ -1,7 +1,7 @@
-import React, { useCallback, useState, useEffect } from "react";
+import React, { useCallback, useState, useEffect, useMemo } from "react";
 import dayjs from "dayjs";
 import cx from "classnames";
-import { DropdownBodyProps, TableFiltersConfig, IDropdownToggler, IEditable, isMobile, useForceUpdate, FilterPredicateName, getSeparatedValue } from "@epam/uui-core";
+import { DropdownBodyProps, TableFiltersConfig, IDropdownToggler, IEditable, isMobile, useForceUpdate, FilterPredicateName, getSeparatedValue, mobilePopperModifier } from "@epam/uui-core";
 import { Dropdown } from "@epam/uui-components";
 import { i18n } from "../../i18n";
 import { FilterPanelItemToggler } from "./FilterPanelItemToggler";
@@ -13,6 +13,9 @@ import { FilterItemBody } from "./FilterItemBody";
 import { DropdownContainer } from "../overlays";
 import { ReactComponent as RemoveIcon } from "@epam/assets/icons/common/action-deleteforever-12.svg";
 import css from "./FiltersPanelItem.scss";
+import { MobileDropdownWrapper } from "../pickers";
+import { Modifier } from "react-popper";
+
 
 export type FiltersToolbarItemProps = TableFiltersConfig<any> & IEditable<any> & {
     autoFocus?: boolean;
@@ -20,6 +23,32 @@ export type FiltersToolbarItemProps = TableFiltersConfig<any> & IEditable<any> &
 };
 
 const FiltersToolbarItemImpl = (props: FiltersToolbarItemProps) => {
+    const isPickersType = props?.type === 'multiPicker' || props?.type === 'singlePicker';
+    const isMobileScreen = isMobile();
+
+    const popperModifiers: Modifier<any>[] = useMemo(() => {
+        const modifiers: Modifier<any>[] = [
+            {
+                name: 'offset',
+                options: { offset: (isPickersType && isMobileScreen) ? [0, 0] : [0, 6] },
+            },
+        ];
+
+        if (isPickersType && isMobileScreen) {
+            modifiers.push({
+                name: 'resetTransform',
+                enabled: true,
+                phase: 'beforeWrite',
+                requires: ['computeStyles'],
+                fn: ({ state }) => {
+                    state.styles.popper.transform = '';
+                },
+            });
+        }
+
+        return modifiers;
+    }, [isPickersType]);
+
 
     const getDefaultPredicate = () => {
         if (!props.predicates) {
@@ -38,10 +67,6 @@ const FiltersToolbarItemImpl = (props: FiltersToolbarItemProps) => {
             setPredicate(Object.keys(props.value || {})[0]);
         }
     }, [props.value]);
-
-    const closeDropdown = () => {
-        isOpenChange(false);
-    };
 
     const onValueChange = useCallback((value: any) => {
         if (props.predicates) {
@@ -95,10 +120,23 @@ const FiltersToolbarItemImpl = (props: FiltersToolbarItemProps) => {
     );
 
     const renderBody = (dropdownProps: DropdownBodyProps) => (
-        <DropdownContainer>
+        <DropdownContainer { ...dropdownProps }>
             <Panel cx={ css.panel }>
-                { renderHeader() }
-                { <FilterItemBody { ...props } { ...dropdownProps } selectedPredicate={ predicate } value={ getValue() } onValueChange={ onValueChange } onClose={ closeDropdown }/> }
+                <>
+                    {
+                        isPickersType ? (
+                            <MobileDropdownWrapper close={ () =>  isOpenChange(false) }>
+                                { renderHeader() }
+                                { <FilterItemBody { ...props } { ...dropdownProps } selectedPredicate={ predicate } value={ getValue() } onValueChange={ onValueChange } /> }
+                            </MobileDropdownWrapper>
+                        ) : (
+                            <>
+                                { renderHeader() }
+                                { <FilterItemBody { ...props } { ...dropdownProps } selectedPredicate={ predicate } value={ getValue() } onValueChange={ onValueChange } /> }
+                            </>
+                        )
+                    }
+                </>
             </Panel>
         </DropdownContainer>
     );
@@ -178,7 +216,7 @@ const FiltersToolbarItemImpl = (props: FiltersToolbarItemProps) => {
             closeBodyOnTogglerHidden={ !isMobile() }
             value={ isOpen }
             onValueChange={ isOpenChange }
-            modifiers={ [{ name: 'offset', options: { offset: [0, 6] } }] }
+            modifiers={ popperModifiers }
         />
     );
 };

--- a/uui/components/filters/FiltersPanelItem.tsx
+++ b/uui/components/filters/FiltersPanelItem.tsx
@@ -39,6 +39,9 @@ const FiltersToolbarItemImpl = (props: FiltersToolbarItemProps) => {
         }
     }, [props.value]);
 
+    const closeDropdown = () => {
+        isOpenChange(false);
+    };
 
     const onValueChange = useCallback((value: any) => {
         if (props.predicates) {
@@ -95,7 +98,7 @@ const FiltersToolbarItemImpl = (props: FiltersToolbarItemProps) => {
         <DropdownContainer>
             <Panel>
                 { renderHeader() }
-                { <FilterItemBody { ...props } { ...dropdownProps } selectedPredicate={ predicate } value={ getValue() } onValueChange={ onValueChange }/> }
+                { <FilterItemBody { ...props } { ...dropdownProps } selectedPredicate={ predicate } value={ getValue() } onValueChange={ onValueChange } onClose={ closeDropdown }/> }
             </Panel>
         </DropdownContainer>
     );

--- a/uui/components/pickers/PickerInput.tsx
+++ b/uui/components/pickers/PickerInput.tsx
@@ -11,6 +11,7 @@ import { DataPickerFooter } from './DataPickerFooter';
 import { MobileDropdownWrapper } from './MobileDropdownWrapper';
 import { EditMode, IHasEditMode, SizeMod } from '../types';
 import css from './PickerInput.scss';
+import { DropdownContainer } from '../overlays';
 
 export type PickerInputProps = SizeMod & IHasEditMode & {};
 
@@ -97,36 +98,38 @@ export class PickerInput<TItem, TId> extends PickerInputBase<TItem, TId, PickerI
         const minBodyWidth = isMobile() ? document.documentElement.clientWidth : (this.props.minBodyWidth || pickerWidth);
 
         return (
-            <Panel
-                shadow
-                style={ { width: props.togglerWidth > minBodyWidth ? props.togglerWidth : minBodyWidth } }
-                rawProps={ { tabIndex: -1 } }
-                cx={ [css.panel, uuiMarkers.lockFocus] }
-            >
-                <MobileDropdownWrapper
-                    title={ this.props.entityName }
-                    close={ () => {
-                        this.returnFocusToInput();
-                        this.toggleBodyOpening(false);
-                    } }
+            <DropdownContainer>
+                <Panel
+                    shadow
+                    style={ { width: props.togglerWidth > minBodyWidth ? props.togglerWidth : minBodyWidth } }
+                    rawProps={ { tabIndex: -1 } }
+                    cx={ [css.panel, uuiMarkers.lockFocus] }
                 >
-                    <DataPickerBody
-                        { ...props }
-                        rows={ renderedDataRows }
-                        maxHeight={ maxHeight }
-                        searchSize={ this.props.size }
-                        editMode='dropdown'
-                        selectionMode={ this.props.selectionMode }
-                        renderNotFound={ this.props.renderNotFound ?
-                            () => this.props.renderNotFound({
-                                search: this.state.dataSourceState.search,
-                                onClose: () => this.toggleBodyOpening(false),
-                            }) : undefined
-                    }
-                    />
-                    { !this.isSingleSelect() && this.renderFooter() }
-                </MobileDropdownWrapper>
-            </Panel>
+                    <MobileDropdownWrapper
+                        title={ this.props.entityName }
+                        close={ () => {
+                            this.returnFocusToInput();
+                            this.toggleBodyOpening(false);
+                        } }
+                    >
+                        <DataPickerBody
+                            { ...props }
+                            rows={ renderedDataRows }
+                            maxHeight={ maxHeight }
+                            searchSize={ this.props.size }
+                            editMode='dropdown'
+                            selectionMode={ this.props.selectionMode }
+                            renderNotFound={ this.props.renderNotFound ?
+                                () => this.props.renderNotFound({
+                                    search: this.state.dataSourceState.search,
+                                    onClose: () => this.toggleBodyOpening(false),
+                                }) : undefined
+                        }
+                        />
+                        { !this.isSingleSelect() && this.renderFooter() }
+                    </MobileDropdownWrapper>
+                </Panel>
+            </DropdownContainer>
         );
     }
 }


### PR DESCRIPTION
Info ℹ️ 
https://github.com/epam/UUI/issues/1019
Dropdown is not closing after clicking close button or `done` - on mobile view.
<img width="344" alt="Screenshot at Mar 03 15-43-02" src="https://user-images.githubusercontent.com/26334961/222735231-4491f49b-5577-4f38-9ee7-cff7d4ccfed2.png">
Added `popperModifiers` to Filter Panel