### PR TITLE
[ComponentEditor] Fix `NumericInput` Property Explorer 

### DIFF
--- a/app/src/common/docs/ComponentEditor.tsx
+++ b/app/src/common/docs/ComponentEditor.tsx
@@ -90,7 +90,7 @@ export class ComponentEditor extends React.Component<ComponentEditorProps<any>, 
                     }
 
                     if (prop.type === 'string') {
-                        this.state.inputValues[prop.name] = defaultExample?.value || '';
+                        this.state.inputValues[prop.name] = defaultExample?.value;
                     }
                 });
                 this.initialProps = this.state.selectedPropsIds;

--- a/app/src/common/docs/ComponentEditor.tsx
+++ b/app/src/common/docs/ComponentEditor.tsx
@@ -52,7 +52,11 @@ export class ComponentEditor extends React.Component<ComponentEditorProps<any>, 
             return callback;
         },
         getChangeHandler: (name) => {
-            const cb: any = (newValue: string) => this.setState({ ...this.state, inputValues: { ...this.state.inputValues, value: newValue } });
+            const cb: any = (newValue: string) => this.setState({
+                ...this.state,
+                inputValues: { ...this.state.inputValues, value: newValue },
+                selectedPropsIds: { ...this.state.selectedPropsIds, value: newValue }
+            });
             cb.displayName = "(newValue) => { ... }";
             return cb;
         },


### PR DESCRIPTION
## Summary

Fixes #1088

Now `NumericInput` property explorer should chnage the value while typing in it. 