### PR TITLE
[SlateEditor] Hide toolbar when editor not in focus

### DIFF
--- a/uui-editor/src/SlateEditor.tsx
+++ b/uui-editor/src/SlateEditor.tsx
@@ -55,7 +55,7 @@ export const basePlugins: any = [
     ...defaultPlugins,
 ];
 
-interface SlateEditorProps extends IEditable<any | null>, IHasCX, IHasRawProps<HTMLDivElement>  {
+interface SlateEditorProps extends IEditable<any | null>, IHasCX, IHasRawProps<HTMLDivElement> {
     isReadonly?: boolean;
     plugins?: any[];
     autoFocus?: boolean;
@@ -77,8 +77,7 @@ const Editor = ({ initialValue, ...props }: any) => {
         if (initialValue) {
             editor.children = initialValue;
         }
-    },
-    [editor, initialValue, forceUpdate]);
+    }, [editor, initialValue, forceUpdate]);
 
     const renderEditor = () => (
         <DndProvider backend={ HTML5Backend }>
@@ -89,13 +88,13 @@ const Editor = ({ initialValue, ...props }: any) => {
 
             </Plate>
             <MarkBalloonToolbar />
-            <Toolbar style={ {
+            { isFocused && <Toolbar style={ {
                 position: 'sticky',
                 bottom: 12,
                 display: 'flex',
             } }>
                 <ToolbarButtons />
-            </Toolbar>
+            </Toolbar> }
         </DndProvider>
     );
 
@@ -182,6 +181,6 @@ export function SlateEditor(props: SlateEditorProps) {
                 plugins={ plugins }
                 { ...props }
             />
-    </PlateProvider>
+        </PlateProvider>
     );
 }

--- a/uui-editor/src/plate/plugins/Toolbars.tsx
+++ b/uui-editor/src/plate/plugins/Toolbars.tsx
@@ -4,6 +4,7 @@ import {
     useEventPlateId,
     usePlateEditorState,
     usePlateEditorRef,
+    isEditorFocused,
 } from '@udecode/plate';
 
 import { BoldButton, ItalicButton, UnderlineButton } from './baseMarksPlugin/baseMarksPlugin';
@@ -76,6 +77,11 @@ const BlockToolbarButtons = () => {
 
 export const ToolbarButtons = () => {
     const editor = usePlateEditorState(useEventPlateId());
+    const isActive = isEditorFocused(editor);
+
+    if (!isActive) {
+        return null;
+    }
 
     return (
         <Sidebar isReadonly={ false } >

--- a/uui-editor/src/plate/plugins/Toolbars.tsx
+++ b/uui-editor/src/plate/plugins/Toolbars.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 
 import {
-    isEditorFocused,
     useEventPlateId,
     usePlateEditorState,
     usePlateEditorRef,
@@ -77,11 +76,6 @@ const BlockToolbarButtons = () => {
 
 export const ToolbarButtons = () => {
     const editor = usePlateEditorState(useEventPlateId());
-    const isActive = isEditorFocused(editor);
-
-    if (!isActive) {
-        return null;
-    }
 
     return (
         <Sidebar isReadonly={ false } >


### PR DESCRIPTION
## Summary

This PR hides toolbar when editor not in focus.

**Before:**

<img src="https://user-images.githubusercontent.com/39378793/223166706-b472c5d1-20cb-49f6-aeb3-c3b22c37de3a.jpeg" width="500" >

**After:**

<img src="https://user-images.githubusercontent.com/39378793/223166745-5da95a40-35d4-429c-a952-8167b20de8f9.jpeg" width="500" >
