### PR TITLE
[SlateEditor] Fix table creation

### DIFF
--- a/uui-editor/src/implementation/Toolbar.tsx
+++ b/uui-editor/src/implementation/Toolbar.tsx
@@ -2,6 +2,7 @@ import React, { useRef } from 'react';
 import { Popper } from 'react-popper';
 import { usePlateEditorState, isEditorFocused, getSelectionBoundingClientRect } from '@udecode/plate';
 import { Portal } from '@epam/uui-components';
+import cx from "classnames";
 
 import { isImageSelected, isTextSelected } from '../helpers';
 import css from './Toolbar.scss';
@@ -40,10 +41,10 @@ export function Toolbar(props: ToolbarProps): any {
                     placement={ props.placement || 'top' }
                     modifiers={ [{ name: 'offset', options: { offset: [0, 12] } }] }
                 >
-                    { popperProps =>  (
+                    { popperProps => (
                         <div
                             onMouseDown={ e => e.preventDefault() }
-                            className={ css.container }
+                            className={ cx(css.container, 'slate-prevent-blur') }
                             style={ { ...popperProps.style, zIndex: 10 } }
                             ref={ node => {
                                 ref.current = node;

--- a/uui-editor/src/plate/plugins/tablePlugin/Table.scss
+++ b/uui-editor/src/plate/plugins/tablePlugin/Table.scss
@@ -5,6 +5,11 @@ table {
     position: relative;
     border-collapse: collapse;
     table-layout: fixed;
+
+    // hide remove button
+    & > div {
+        visibility: hidden;
+    }
 }
 
 .table-wrapper {

--- a/uui-editor/src/plate/plugins/tablePlugin/tablePlugin.tsx
+++ b/uui-editor/src/plate/plugins/tablePlugin/tablePlugin.tsx
@@ -218,9 +218,7 @@ const Table = (props: any) => {
     }, [element, cellPath, rowPath, cellEntries]);
 
     const colSizesRef = useRef(data.cellSizes);
-    colSizesRef.current = useTableColSizes(
-        colSizesRef.current ? { ...props.element, colSizes: colSizesRef.current } : props.element
-    );
+    colSizesRef.current = useTableColSizes({ ...props.element, colSizes: colSizesRef.current });
 
     const tableWidth = colSizesRef.current.reduce((acc: number, cur: number) => acc + cur, 0);
     return (

--- a/uui-editor/src/plate/plugins/tablePlugin/tablePlugin.tsx
+++ b/uui-editor/src/plate/plugins/tablePlugin/tablePlugin.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo } from 'react';
+import React, { useCallback, useMemo } from 'react';
 
 import {
     createTablePlugin,
@@ -12,15 +12,21 @@ import {
     insertTableRow,
     deleteTable,
     ToolbarButton as PlateToolbarButton,
-    getSelectionBoundingClientRect,
     deleteColumn,
     deleteRow,
     PlateEditor,
-    insertTable,
     getTableEntries,
     removeNodes,
     getTableGridAbove,
     insertElements,
+    insertNodes,
+    withoutNormalizing,
+    Value,
+    getPluginType,
+    someNode,
+    getBlockAbove,
+    selectEditor,
+    getStartPoint,
 } from "@udecode/plate";
 
 import { TableHeaderCell } from "./TableHeaderCell";
@@ -39,14 +45,10 @@ import { ReactComponent as RemoveTable } from "../../../icons/table-table_remove
 import { ReactComponent as TableIcon } from "../../../icons/table-add.svg";
 import { ReactComponent as TableMerge } from "../../../icons/table-merge.svg";
 import { ReactComponent as UnmergeCellsIcon } from "../../../icons/table-un-merge.svg";
-import { Dropdown } from "@epam/uui-components";
-import { uuiSkin } from "@epam/uui-core";
 import { isPluginActive, isTextSelected } from "../../../helpers";
 import { Toolbar } from '../../../implementation/Toolbar';
 
 import tableCSS from './Table.scss';
-
-const { FlexRow } = uuiSkin;
 
 const Table = (props: any) => {
     const editor = usePlateEditorState();
@@ -97,11 +99,11 @@ const Table = (props: any) => {
 
         Object.values(cols).forEach((paths: any) => {
             paths?.forEach((path: []) => {
-                removeNodes(editor, { at: paths[0]});
+                removeNodes(editor, { at: paths[0] });
             });
         });
 
-        insertElements(editor, emptyCol, {at: cellEntries[0][1]});
+        insertElements(editor, emptyCol, { at: cellEntries[0][1] });
     };
 
     const unmergeCells = () => {
@@ -147,9 +149,9 @@ const Table = (props: any) => {
             }
         });
 
-        removeNodes(editor, { at: item[1]});
+        removeNodes(editor, { at: item[1] });
         for (let i = 1; i < item[0].data.colSpan; i++) {
-            insertElements(editor, emptyColWithoutText, {at: item[1]});
+            insertElements(editor, emptyColWithoutText, { at: item[1] });
         }
         for (let i = 1; i < item[0].data.rowSpan; i++) {
             insertElements(editor, emptyColWithoutText, {
@@ -157,7 +159,7 @@ const Table = (props: any) => {
                 at: item[1].map((item: number, index: number) => index === 2 ? item + 1 : item),
             });
         }
-        insertElements(editor, emptyCol, {at: item[1]});
+        insertElements(editor, emptyCol, { at: item[1] });
     };
 
     const renderMergeToolbar = useCallback(() => {
@@ -187,7 +189,7 @@ const Table = (props: any) => {
                     icon={ RemoveColumn }
                 />
                 <ToolbarButton
-                    onClick={ () =>  insertTableRow(editor, { at: rowPath }) }
+                    onClick={ () => insertTableRow(editor, { at: rowPath }) }
                     icon={ InsertRowBefore }
                 />
                 <ToolbarButton
@@ -205,9 +207,10 @@ const Table = (props: any) => {
                 { cellEntries && cellEntries.length === 1
                     && ((cellEntries[0][0]?.data as any)?.colSpan > 1 || (cellEntries[0][0]?.data as any)?.rowSpan > 1)
                     && <ToolbarButton
-                    onClick={ unmergeCells }
-                    icon={ UnmergeCellsIcon }
-                /> }
+                        onClick={ unmergeCells }
+                        icon={ UnmergeCellsIcon }
+                    />
+                }
             </div>
         );
     }, [element, cellPath, rowPath, cellEntries]);
@@ -229,31 +232,6 @@ const Table = (props: any) => {
                 isTable={ !!cellEntries }
             /> }
         </div>
-    );
-    return (
-        <Dropdown
-            renderTarget={ (innerProps: any) => (
-                <div ref={ innerProps.ref } className={ cx(css.wrapper, tableCSS.tableWrapper) }>
-                    <TableElement
-                        { ...props }
-                        className={ tableCSS.table }
-                        element={ {
-                            ...element,
-                            ...(data?.cellSizes ? { colSizes: data?.cellSizes } : {}),
-                        } }
-                    />
-                </div>
-            ) }
-            renderBody={ () =>  <FlexRow cx={ css.imageToolbarWrapper }>
-                <Toolbar
-                    children={ cellEntries && cellEntries.length > 1 ? renderMergeToolbar() : renderToolbar() }
-                    editor={ editor }
-                    isImage={ false }
-                />
-            </FlexRow> }
-            value={ !!cellEntries?.length }
-            placement='bottom'
-        />
     );
 };
 
@@ -279,363 +257,77 @@ interface ITableButton {
     editor: PlateEditor;
 }
 
+const createEmptyTable = (editor: PlateEditor) => {
+    const rows = [
+        {
+            type: getPluginType(editor, ELEMENT_TR),
+            children: [{
+                type: getPluginType(editor, ELEMENT_TH),
+                children: [editor.blockFactory()],
+            },
+            {
+                type: getPluginType(editor, ELEMENT_TH),
+                children: [editor.blockFactory()],
+            }],
+        },
+        {
+            type: getPluginType(editor, ELEMENT_TR),
+            children: [{
+                type: getPluginType(editor, ELEMENT_TD),
+                children: [editor.blockFactory()],
+            },
+            {
+                type: getPluginType(editor, ELEMENT_TD),
+                children: [editor.blockFactory()],
+            }],
+        }
+    ];
+
+    return {
+        type: getPluginType(editor, ELEMENT_TABLE),
+        children: rows,
+    };
+}
+
+const createTableStructure = (editor: PlateEditor) => {
+    if (
+        !someNode(editor, {
+            match: { type: getPluginType(editor, ELEMENT_TABLE) },
+        })
+    ) {
+        insertNodes(editor, createEmptyTable(editor));
+
+        if (editor.selection) {
+            const tableEntry = getBlockAbove(editor, {
+                match: { type: getPluginType(editor, ELEMENT_TABLE) },
+            });
+            console.log('tableEntry', tableEntry);
+            if (!tableEntry) return;
+
+            selectEditor(editor, { at: getStartPoint(editor, tableEntry[1]) });
+        }
+    }
+}
 
 export const TableButton = ({
-                                editor,
-                            }: ITableButton) => {
+    editor,
+}: ITableButton) => {
 
     if (!isPluginActive(ELEMENT_TABLE)) return null;
 
     return (
         <PlateToolbarButton
-            styles={ { root: {width: 'auto', cursor: 'pointer', padding: '0px' }} }
-            onMouseDown={ async (event) => {
+            styles={ { root: { width: 'auto', cursor: 'pointer', padding: '0px' } } }
+            onMouseDown={ async () => {
                 if (!editor) return;
 
-                insertTable(editor, { colCount: 2, rowCount: 2 });
+                withoutNormalizing(editor, () => createTableStructure(editor));
             } }
             icon={ <ToolbarButton
                 isDisabled={ isTextSelected(editor, true) }
                 onClick={ () => {} }
                 icon={ TableIcon }
-                //isActive={ block?.length && block[0].type === 'image' }
             /> }
         />
     );
 };
-
-// import { Editor as CoreEditor } from "slate";
-// import EditTable from 'slate-uui-table-plugin';
-// import * as React from "react";
-// import { Table } from "./Table";
-// import { TableRow } from "./TableRow";
-// import { TableCell } from "./TableCell";
-// import { TableHeaderCell } from "./TableHeaderCell";
-// import { Editor } from "slate-react";
-// import { ReactComponent as TableIcon } from "../../icons/table-add.svg";
-// import { ToolbarButton } from '../../implementation/ToolbarButton';
-// import {getBlockDesirialiser, isTextSelected} from '../../helpers';
-// import { mergeCellsPlugin } from '../tableMergePlugin/tableMergePlugin';
-//
-// export const tablePlugin = () => {
-//     const editTable = EditTable();
-//
-//     const renderBlock = (props: any, editor: CoreEditor, next: () => any) => {
-//         switch (props.node.type) {
-//             case 'table': return <Table { ...props } editor={ editor } />;
-//             case 'table_row': return <TableRow { ...props } />;
-//             case 'table_cell': return <TableCell { ...props } editor={ editor } />;
-//             case 'table_header_cell': return <TableHeaderCell { ...props } editor={ editor } />;
-//         }
-//         return next();
-//     };
-//
-//     const onKeyDown = (event: KeyboardEvent, editor: Editor, next: () => any) => {
-//         let parentNode: any = editor.value.document.getParent(editor.value.focusBlock.key);
-//
-//         if ((event.key === 'Backspace' || event.key === 'Delete') && parentNode.type === 'table_cell' && parentNode.nodes.toArray().length === 1 && editor.value.focusBlock.text === '') {
-//             return;
-//         }
-//
-//         next();
-//     };
-//
-//     const getCellIndex = (editor: any, elem: any) => {
-//         let counter = 0;
-//         let elemPosition = 0;
-//         const elemParent = editor.value.document.getParent(elem.key);
-//
-//         (editor.value.document as any).getParent(elemParent.key).nodes.forEach((elem: any) => {
-//             elem.key === elemParent.key ? elemPosition = counter : counter += 1;
-//         });
-//
-//         return elemPosition;
-//     };
-//
-//     // Add new column to the table on correct new column position
-//     const addNewColumn = (editor: CoreEditor, props: any, position?: 'before' | 'after') => {
-//         let startBlockIndex = getCellIndex(editor, editor.value.startBlock);
-//         const parentElem: any = editor.value.document.getParent(editor.value.document.getPath(editor.value.startBlock.key));
-//
-//         if (position !== 'before') {
-//             startBlockIndex++;
-//         }
-//
-//         if (parentElem.data !== undefined && parentElem.data.get('colSpan') > 1 && position !== 'before') {
-//             startBlockIndex += parentElem.data.get('colSpan') - 1;
-//         }
-//         (editor as any).insertColumn(startBlockIndex, {typeHeaderCell: 'table_header_cell'});
-//     };
-//
-//     const removeSelectedColumn = (editor: CoreEditor, props: any) => {
-//         let startBlockIndex = getCellIndex(editor, editor.value.startBlock);
-//         const selectedCell: any = editor.value.document.getParent(editor.value.document.getPath(editor.value.startBlock.key));
-//         const selectedRow: any = editor.value.document.getParent(editor.value.document.getPath(selectedCell.key));
-//         const selectedTable: any = editor.value.document.getParent(editor.value.document.getPath(selectedRow.key));
-//         let cellColspan = selectedCell.data.get('colSpan');
-//
-//         if (selectedRow.nodes.size === 1) {
-//             return;
-//         }
-//
-//         if (cellColspan > 1) {
-//             for (let i = 0; i < cellColspan; i++) {
-//                 (editor as any).removeColumn(startBlockIndex);
-//             }
-//         } else {
-//             selectedTable.nodes.toArray().map((row: any) => {
-//                 row.nodes.toArray().map((cell: any, cellIndex: number, rows: any[]) => {
-//                     let colspan = cell.data.get('colSpan');
-//                     if (startBlockIndex === cellIndex && colspan > 1) {
-//                         let nextCell = rows[cellIndex + 1];
-//                         editor.setNodeByKey(nextCell.key, {
-//                             ...nextCell,
-//                             data: {
-//                                 colSpan: colspan - 1,
-//                             },
-//                         });
-//                     } else if (colspan > 1 && (startBlockIndex > cellIndex && startBlockIndex < cellIndex + colspan)) {
-//                         editor.setNodeByKey(cell.key, {
-//                             ...cell,
-//                             data: {
-//                                 colSpan: colspan - 1,
-//                             },
-//                         });
-//                     }
-//                 });
-//             });
-//             let cellSizes = selectedTable.data.get('cellSizes').filter((item: any, index: number) => index != startBlockIndex);
-//             const newData = selectedTable.data.set('cellSizes', cellSizes);
-//             editor.setNodeByKey(selectedTable.key, {
-//                 ...selectedTable as any,
-//                 data: newData,
-//             });
-//             (editor as any).removeColumn(startBlockIndex);
-//         }
-//     };
-//
-//     // Add new row to the table on correct new row position
-//     const getRowIndex = (editor: any) => {
-//         let rowSpanIndex = 0;
-//         let rowIndex = 0;
-//         const selectedCell: any = editor.value.document.getParent(editor.value.document.getPath(editor.value.startBlock.key));
-//         const selectedRow: any = editor.value.document.getParent(editor.value.document.getPath(selectedCell.key));
-//         const selectedTable: any = editor.value.document.getParent(editor.value.document.getPath(selectedRow.key));
-//
-//         for (let i = 0; i < selectedTable.nodes.toArray().length; i++) {
-//             if (selectedTable.nodes.toArray()[i].key === selectedRow.key) {
-//                 rowIndex = i;
-//             }
-//         }
-//
-//         for (let i = 0; i < selectedRow.nodes.toArray().length; i++) {
-//             if (selectedRow.nodes.toArray()[i].data !== undefined && selectedRow.nodes.toArray()[i].data.get('rowSpan') > 1 && selectedRow.nodes.toArray()[i].data.get('rowSpan') > rowSpanIndex) {
-//                 rowSpanIndex = selectedRow.nodes.toArray()[i].data.get('rowSpan');
-//             }
-//         }
-//
-//         return {
-//             rowIndex,
-//             rowSpanIndex,
-//         };
-//     };
-//
-//     // Add new row to the table on correct new row position
-//     const addNewRow = (editor: CoreEditor, props: any, position?: 'before' | 'after') => {
-//         let { rowIndex, rowSpanIndex } = getRowIndex(editor);
-//         const selectedCell: any = editor.value.document.getParent(editor.value.document.getPath(editor.value.startBlock.key));
-//         const selectedRow: any = editor.value.document.getParent(editor.value.document.getPath(selectedCell.key));
-//         const selectedTable: any = editor.value.document.getParent(editor.value.document.getPath(selectedRow.key));
-//         let currentRowIndex = rowIndex;
-//         let maxRowClospan = 1;
-//         let shouldHideCells = false;
-//
-//         if (position === 'before' && selectedCell.type === 'table_header_cell' && selectedTable.nodes.size === 1) {
-//             return;
-//         }
-//
-//         while (selectedTable.nodes.toArray()[currentRowIndex].nodes.toArray().some((item: any) => item.data.get('style') === 'none') && currentRowIndex > 0) {
-//             currentRowIndex--;
-//         }
-//
-//         if (currentRowIndex !== rowIndex) {
-//             selectedTable.nodes.toArray()[currentRowIndex].nodes.toArray().map((item: any) => {
-//                 let cellRowSpan = item.data.get('rowSpan');
-//                 let isArterPasteValid = position !== 'before' && cellRowSpan > rowIndex - currentRowIndex + 1;
-//                 let isBeforePasteValid = position === 'before' && cellRowSpan > rowIndex - currentRowIndex;
-//                 if (cellRowSpan && (isArterPasteValid || isBeforePasteValid)) {
-//                     editor.setNodeByKey(item.key, {
-//                         ...item,
-//                         data: {
-//                             rowSpan: cellRowSpan + 1,
-//                         },
-//                     });
-//                     shouldHideCells = true;
-//                 }
-//             });
-//         } else {
-//             selectedRow.nodes.toArray().map((item: any) => {
-//                 let cellRowSpan = item.data.get('rowSpan');
-//                 if (cellRowSpan && cellRowSpan > 1 && position !== 'before') {
-//                     editor.setNodeByKey(item.key, {
-//                         ...item,
-//                         data: {
-//                             rowSpan: cellRowSpan + 1,
-//                         },
-//                     });
-//                     shouldHideCells = true;
-//                 }
-//             });
-//         }
-//
-//         position !== 'before' ? rowIndex += rowSpanIndex : null;
-//         let insertIndex = position === 'before' ? rowIndex : rowIndex + 1;
-//
-//         let editorAfterInsert = insertIndex === 0 && selectedCell.type === 'table_cell'
-//             ? (editor as any).insertHeaderRow(insertIndex)
-//             : selectedCell.type === 'table_header_cell' && selectedTable.nodes.toArray()[rowIndex + 1]
-//                 ? (editor as any).insertHeaderRow(insertIndex)
-//                 : (editor as any).insertRow(insertIndex);
-//
-//         if (shouldHideCells) {
-//             const currentCell: any = editorAfterInsert.value.document.getParent(editorAfterInsert.value.document.getPath(editorAfterInsert.value.anchorBlock.key));
-//             const newRow: any = editorAfterInsert.value.document.getParent(editorAfterInsert.value.document.getPath(currentCell.key));
-//
-//             newRow.nodes.toArray().map((item: any, index: number) => {
-//                 if (index < maxRowClospan) {
-//                     editor.setNodeByKey(item.key, {
-//                         ...item,
-//                         data: {
-//                             style: 'none',
-//                         },
-//                     });
-//                 }
-//             });
-//
-//         }
-//     };
-//
-//     const removeSelectedRow = (editor: CoreEditor, props: any) => {
-//         let { rowIndex } = getRowIndex(editor);
-//         const selectedCell: any = editor.value.document.getParent(editor.value.document.getPath(editor.value.startBlock.key));
-//         let rowSpanIndex = selectedCell.data.get('rowSpan');
-//         const selectedRow: any = editor.value.document.getParent(editor.value.document.getPath(selectedCell.key));
-//         const selectedTable: any = editor.value.document.getParent(editor.value.document.getPath(selectedRow.key));
-//
-//         if (selectedTable.nodes.size === 1) {
-//             return;
-//         }
-//
-//         if (rowSpanIndex > 1) {
-//             for (let i = 0; i < rowSpanIndex; i++) {
-//                 (editor as any).removeRow(rowIndex);
-//             }
-//         } else {
-//             let currentRowIndex = rowIndex;
-//             while (selectedTable.nodes.toArray()[currentRowIndex].nodes.toArray().some((item: any) => item.data.get('style') === 'none')) {
-//                 currentRowIndex--;
-//             }
-//
-//             if (currentRowIndex !== rowIndex) {
-//                 selectedTable.nodes.toArray()[currentRowIndex].nodes.toArray().map((item: any) => {
-//                     let cellRowSpan = item.data.get('rowSpan');
-//                     cellRowSpan && cellRowSpan > 1 ? editor.setNodeByKey(item.key, {
-//                         ...item,
-//                         data: {
-//                             rowSpan: cellRowSpan - 1,
-//                         },
-//                     }) : null;
-//                 });
-//             } else {
-//                 let rowSpansInRow: any[] = [];
-//                 let rowSpansInRowIndex: any[] = [];
-//                 selectedRow.nodes.toArray().map((item: any, index: number) => {
-//                     let cellRowSpan = item.data.get('rowSpan');
-//                     if (cellRowSpan > 1) {
-//                         rowSpansInRow.push(cellRowSpan);
-//                         rowSpansInRowIndex.push(index);
-//                     }
-//                 });
-//                 if (rowSpansInRow.length > 0) {
-//                     let nextRow = selectedTable.nodes.toArray()[rowIndex + 1];
-//                     rowSpansInRowIndex.map((rowIndex: any, arrayIndex: number) => {
-//                         editor.setNodeByKey(nextRow.nodes.toArray()[rowIndex].key, {
-//                             ...nextRow.nodes.toArray()[rowIndex],
-//                             data: {
-//                                 rowSpan: rowSpansInRow[arrayIndex] - 1,
-//                             },
-//                         });
-//                     });
-//                 }
-//             }
-//             (editor as any).removeRow(rowIndex);
-//         }
-//     };
-//
-//     const insertTableIn = (editor: CoreEditor) => {
-//         const currentKey = editor.value.focusBlock.key;
-//         (editor as any).insertEmptyBlock();
-//         (editor as any).insertTableByKey(currentKey, 0, 2, 2);
-//     };
-//
-//
-//
-//     return {
-//         ...editTable,
-//         ...mergeCellsPlugin(),
-//         normalizeNode: null,
-//         schema: null,
-//         renderBlock,
-//         sidebarButtons: [TableButton],
-//         onKeyDown,
-//         commands: {
-//             ...editTable.commands,
-//             addNewColumn,
-//             addNewRow,
-//             removeSelectedRow,
-//             removeSelectedColumn,
-//             insertTableIn,
-//         },
-//         serializers: [tableCellDesializer, tableDesializer, tableHeaderCellDesializer],
-//         makeSerializerRules: null,
-//     };
-// };
-//
-// export const TableButton = (props: { editor: Editor }) => {
-//     return <ToolbarButton isDisabled={ isTextSelected(props.editor) } onClick={ () => ((props.editor as any).insertTableIn()) } icon={ TableIcon } />;
-// };
-//
-// const TABLE_TAGS: any = {
-//     table: 'table',
-//     tr: 'table_row',
-// };
-//
-// const tableCellDesializer = (el: any, next: any) => {
-//     if (el.tagName.toLowerCase() === 'td') {
-//         return {
-//             object: 'block',
-//             type: 'table_cell',
-//             nodes: next(el.childNodes),
-//             data: {
-//                 colSpan: el.getAttribute('colspan'),
-//                 rowSpan: el.getAttribute('rowspan'),
-//             },
-//         };
-//     }
-// };
-//
-// const tableHeaderCellDesializer = (el: any, next: any) => {
-//     if (el.tagName.toLowerCase() === 'th') {
-//         return {
-//             object: 'block',
-//             type: 'table_header_cell',
-//             nodes: next(el.childNodes),
-//             data: {
-//                 colSpan: el.getAttribute('colspan'),
-//                 rowSpan: el.getAttribute('rowspan'),
-//             },
-//         };
-//     }
-// };
-//
-// const tableDesializer = getBlockDesirialiser(TABLE_TAGS);

--- a/uui-editor/src/plate/plugins/tablePlugin/tablePlugin.tsx
+++ b/uui-editor/src/plate/plugins/tablePlugin/tablePlugin.tsx
@@ -228,7 +228,7 @@ const Table = (props: any) => {
         <div className={ cx(tableCSS.tableWrapper) }>
             <TableElement
                 { ...props }
-                styles={ { root: { width: tableWidth } } }
+                styles={ { root: { width: tableWidth, "& > div": { visibility: 'hidden' } } } }
                 className={ tableCSS.table }
                 element={ {
                     ...element,

--- a/uui-editor/src/plate/plugins/tablePlugin/tablePlugin.tsx
+++ b/uui-editor/src/plate/plugins/tablePlugin/tablePlugin.tsx
@@ -225,7 +225,7 @@ const Table = (props: any) => {
         <div className={ cx(tableCSS.tableWrapper) }>
             <TableElement
                 { ...props }
-                styles={ { root: { width: tableWidth, "& > div": { visibility: 'hidden' } } } }
+                styles={ { root: { width: tableWidth } } }
                 className={ tableCSS.table }
                 element={ {
                     ...element,

--- a/uui-editor/src/plate/plugins/tablePlugin/tablePlugin.tsx
+++ b/uui-editor/src/plate/plugins/tablePlugin/tablePlugin.tsx
@@ -218,10 +218,9 @@ const Table = (props: any) => {
     }, [element, cellPath, rowPath, cellEntries]);
 
     const colSizesRef = useRef(data.cellSizes);
-    const updatedColSizes = useTableColSizes(
+    colSizesRef.current = useTableColSizes(
         colSizesRef.current ? { ...props.element, colSizes: colSizesRef.current } : props.element
     );
-    colSizesRef.current = updatedColSizes;
 
     const tableWidth = colSizesRef.current.reduce((acc: number, cur: number) => acc + cur, 0);
     return (

--- a/uui-editor/src/plate/plugins/tablePlugin/tablePlugin.tsx
+++ b/uui-editor/src/plate/plugins/tablePlugin/tablePlugin.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, useRef } from 'react';
+import React, { Fragment, useCallback, useMemo, useRef } from 'react';
 
 import {
     createTablePlugin,
@@ -33,7 +33,6 @@ import { TableHeaderCell } from "./TableHeaderCell";
 import { TableRow } from "./TableRow";
 import { TableCell } from "./TableCell";
 import cx from "classnames";
-import imageBlockCss from "../imagePlugin/ImageBlock.scss";
 import { ToolbarButton } from "../../../implementation/ToolbarButton";
 import { ReactComponent as InsertColumnBefore } from "../../icons/table-add-column-left.svg";
 import { ReactComponent as InsertColumnAfter } from "../../../icons/table-add-column-right.svg";
@@ -166,18 +165,16 @@ const Table = (props: any) => {
 
     const renderMergeToolbar = useCallback(() => {
         return (
-            <div className={ cx(imageBlockCss.imageToolbar, 'slate-prevent-blur') }>
-                <ToolbarButton
-                    onClick={ mergeCells }
-                    icon={ TableMerge }
-                />
-            </div>
+            <ToolbarButton
+                onClick={ mergeCells }
+                icon={ TableMerge }
+            />
         );
     }, [cellEntries]);
 
     const renderToolbar = useCallback(() => {
         return (
-            <div className={ cx(imageBlockCss.imageToolbar, 'slate-prevent-blur') }>
+            <Fragment>
                 <ToolbarButton
                     onClick={ () => insertTableColumn(editor, { at: cellPath }) }
                     icon={ InsertColumnBefore }
@@ -213,7 +210,7 @@ const Table = (props: any) => {
                         icon={ UnmergeCellsIcon }
                     />
                 }
-            </div>
+            </Fragment>
         );
     }, [element, cellPath, rowPath, cellEntries]);
 


### PR DESCRIPTION
## Summary

Fix table in SlateEditor:
- Adds header row on creation
- Now first cell selected after creation
- Preserves initial table width
- Now resizing works  
- Hides `remove table` button from plate lib
- Now horizontal scroll displayed only when needed (on squeezing browser window)