### PR TITLE
[SlateEditor] Skip state updates when in readonly

### DIFF
--- a/uui-editor/src/SlateEditor.tsx
+++ b/uui-editor/src/SlateEditor.tsx
@@ -63,7 +63,7 @@ interface SlateEditorProps extends IEditable<any | null>, IHasCX, IHasRawProps<H
     scrollbars?: boolean;
 }
 
-const Editor = ({ initialValue, ...props }: any) => {
+const Editor = ({ initialValue, isReadonly: readOnly, ...props }: any) => {
     const editor = usePlateEditorState();
     const forceUpdate = useForceUpdate();
 
@@ -81,6 +81,7 @@ const Editor = ({ initialValue, ...props }: any) => {
             <Plate
                 { ...props }
                 id={ props.id }
+                readOnly={ readOnly }
             >
 
             </Plate>
@@ -148,6 +149,7 @@ export function SlateEditor(props: SlateEditorProps) {
     };
 
     const onChange = (value: any) => {
+        if (isReadonly) return;
         props?.onValueChange(value);
     };
 
@@ -172,6 +174,7 @@ export function SlateEditor(props: SlateEditorProps) {
             plugins={ plugins }
             initialValue={ value }
             id={ currentId.current }
+            readOnly={ props.isReadonly }
         >
             <Editor
                 onChange={ onChange }


### PR DESCRIPTION
## Summary 

This PR skips state updates when editor in readonly mode.