### PR TITLE
Bugfix/use scroll spy fix #1001

### DIFF
--- a/uui-components/src/navigation/ScrollSpy.tsx
+++ b/uui-components/src/navigation/ScrollSpy.tsx
@@ -42,15 +42,16 @@ export function useScrollSpy(props?: IScrollSpyProps): IScrollSpyApi {
 
         const observer = new IntersectionObserver(entries => {
             if (entries.length === 1) {
-                const elementName = (entries[0]?.target as HTMLElement)?.dataset?.spy;
-                setCurrentActive(
-                    (prev) =>
-                        entries[0].isIntersecting
-                            ? elementName
-                            : prev !== elementName
-                                ? prev
-                                : '',
-                );
+                const currentElementName = (entries[0]?.target as HTMLElement)?.dataset?.spy;
+                const isCurrentElementIntersecting = entries[0].isIntersecting;
+
+                setCurrentActive((prevElementName) => {
+                    if (isCurrentElementIntersecting) return currentElementName;
+
+                    if (prevElementName !== currentElementName) return prevElementName;
+
+                    return '';
+                });
             } else {
                 const intersectingElement = entries.find(entry => entry.isIntersecting);
                 setCurrentActive((intersectingElement?.target as HTMLElement)?.dataset?.spy);

--- a/uui-components/src/navigation/ScrollSpy.tsx
+++ b/uui-components/src/navigation/ScrollSpy.tsx
@@ -41,8 +41,20 @@ export function useScrollSpy(props?: IScrollSpyProps): IScrollSpyApi {
         if (observedNodes.length === 0) return;
 
         const observer = new IntersectionObserver(entries => {
-            const intersectingElement = entries.find(entry => entry.isIntersecting);
-            setCurrentActive((intersectingElement?.target as HTMLElement)?.dataset?.spy);
+            if (entries.length === 1) {
+                const elementName = (entries[0]?.target as HTMLElement)?.dataset?.spy;
+                setCurrentActive(
+                    (prev) =>
+                        entries[0].isIntersecting
+                            ? elementName
+                            : prev !== elementName
+                                ? prev
+                                : '',
+                );
+            } else {
+                const intersectingElement = entries.find(entry => entry.isIntersecting);
+                setCurrentActive((intersectingElement?.target as HTMLElement)?.dataset?.spy);
+            }
         }, {
             ...props.options,
             root: props?.options?.root || document.querySelector('body'),

--- a/uui-components/src/navigation/ScrollSpy.tsx
+++ b/uui-components/src/navigation/ScrollSpy.tsx
@@ -48,6 +48,7 @@ export function useScrollSpy(props?: IScrollSpyProps): IScrollSpyApi {
                 setCurrentActive((prevElementName) => {
                     if (isCurrentElementIntersecting) return currentElementName;
 
+                    // if previous 'currentActive' is not the one which exited the screen - don't change 'currentActive'
                     if (prevElementName !== currentElementName) return prevElementName;
 
                     return '';


### PR DESCRIPTION
Fixed a bug with ScrollSpy hook.

Root cause:
The bug appears if a new spied element appears on the screen before the last active one left it. Then if the last active lefts the screen hook sets the active element to '' even though a new element is on the screen.

Related to:
https://github.com/epam/UUI/issues/1001

Note for testers (will be copied to the issue):
Test it with the most possible variations of space between, before, and after the spied elements (different amounts of spied elements too)
