### PR TITLE
useForm - smarter undo checkpoints

### DIFF
--- a/app/src/data/codesandbox/index.tsx
+++ b/app/src/data/codesandbox/index.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { render } from "react-dom";
+import { createBrowserHistory } from "history";
 import { ErrorHandler, FlexRow, skinContext as promoSkinContext } from "@epam/promo";
 import { ApiCallOptions, ContextProvider, UuiContexts } from "@epam/uui";
 import { Modals, Snackbar } from "@epam/uui-components";
@@ -14,6 +15,8 @@ type TApi = ReturnType<typeof getApi>;
 const rootElement = document.getElementById("root");
 const origin = process.env.REACT_APP_PUBLIC_URL;
 
+const history = createBrowserHistory();
+
 render(
     <ContextProvider<TApi, UuiContexts>
         apiDefinition={ (processRequest) =>
@@ -24,6 +27,7 @@ render(
         }
         onInitCompleted={ (context) => Object.assign(svc, context) }
         skinContext={ promoSkinContext }
+        history={ history }
     >
         <ErrorHandler>
             <FlexRow vPadding='48' padding='24' borderBottom='gray40' alignItems='top' spacing='12'>

--- a/uui-core/src/data/forms/__tests__/shouldCreateUndoCheckpoint.test.tsx
+++ b/uui-core/src/data/forms/__tests__/shouldCreateUndoCheckpoint.test.tsx
@@ -1,0 +1,95 @@
+import { shouldCreateUndoCheckpoint } from '../shouldCreateUndoCheckpoint';
+
+describe('shouldCreateUndoCheckpoint', () => {
+    it('scalar change', () => {
+        // The field is changed again. No need to checkpoint - we already created it previously
+        expect(shouldCreateUndoCheckpoint('a', 'aa', 'aaa')).toBe(false);
+    });
+
+    it('scalar change from null', () => {
+        // undo should return directly to null, skipping 'a'
+        expect(shouldCreateUndoCheckpoint(null, 'a', 'aa')).toBe(false);
+    });
+
+    it('same field change', () => {
+        // undo should return to 'a', skipping 'ab'
+        expect(shouldCreateUndoCheckpoint(
+            { name: 'a' },
+            { name: 'ab' },
+            { name: 'abc' },
+        )).toBe(false);
+    });
+
+    it('object created', () => {
+        expect(shouldCreateUndoCheckpoint(
+            null,
+            null,
+            { name: 'a'  },
+        )).toBe(true);
+    });
+
+    it('object created and then field updated', () => {
+        expect(shouldCreateUndoCheckpoint(
+            null,
+            { name: 'a' },
+            { name: 'b' },
+        )).toBe(false);
+    });
+
+    it('object created and then is not changed', () => {
+        expect(shouldCreateUndoCheckpoint(
+            null,
+            { name: 'a' },
+            { name: 'a' },
+        )).toBe(false);
+    });
+
+    it('new field added', () => {
+        expect(shouldCreateUndoCheckpoint(
+            { name: 'a' },
+            { name: 'b' },
+            { name: 'b', title: 'a' },
+        )).toBe(true);
+    });
+
+    it('same field changed', () => {
+        expect(shouldCreateUndoCheckpoint(
+            { name: 'a', title: 'a' },
+            { name: 'a', title: 'b' },
+            { name: 'a', title: 'c' },
+        )).toBe(false);
+    });
+
+    it('different field changed', () => {
+        expect(shouldCreateUndoCheckpoint(
+            { name: 'a', title: 'a' },
+            { name: 'b', title: 'a' },
+            { name: 'b', title: 'b' },
+        )).toBe(true);
+    });
+
+    it('Field is removed', () => {
+        expect(shouldCreateUndoCheckpoint(
+            { name: 'a', title: 'a' },
+            { name: 'b', title: 'a' },
+            { name: 'b' },
+        )).toBe(true);
+    });
+
+    it('new item added to array', () => {
+        expect(shouldCreateUndoCheckpoint(
+            [],
+            [],
+            [1],
+        )).toBe(true);
+    });
+
+    it('new item added and then edited', () => {
+        expect(shouldCreateUndoCheckpoint(
+            [],
+            [1],
+            [2],
+        )).toBe(false);
+    });
+
+})

--- a/uui-core/src/data/forms/shouldCreateUndoCheckpoint.ts
+++ b/uui-core/src/data/forms/shouldCreateUndoCheckpoint.ts
@@ -1,0 +1,34 @@
+/**
+ * Determines if useForm should create a new undo checkpoint.
+ * c is the new change, a and b are previous checkpoints.
+ * Returns false only if:
+ * - a and b has exactly the same structure (types of fields recursively)
+ * - scalar fields changed between b and c, are the same as between a and b.
+ * In other words, it returns true only if user just edited the very same scalar field, as he did the last time
+ */
+export function shouldCreateUndoCheckpoint(a: any, b: any, c: any): boolean {
+    // The field type is changed this time. Probably is was null and became an object
+    // Consider this a major change (adding row, creating some object for the first time)
+    if (typeof b !== typeof c) {
+        return true;
+    }
+
+    // The field is an object of array - need to recurse thru it
+    if (typeof c === 'object') {
+        // Ignore that the field might be an empty array.
+        // If it's type changed, we already exited with 'true' on the first step
+        a = a || {};
+        b = b || {};
+        const keys: any[] = Object.keys({ ...a, ...b, ...c });
+        return keys.some(key => shouldCreateUndoCheckpoint(a[key], b[key], c[key]));
+    }
+
+    // The field is scalar (null, undefined, string, number)
+    // In this case, we only need a checkpoint if it's changed for the first time.
+    // E.g.
+    // 'a' => 'ab' && 'ab' => 'abc' - false, we created checkpoint last time
+    // 'a' => 'ab' && 'ab' => 'ab' - false, this field wasn't changed this time
+    // 'a' => 'a' && 'a' => 'a'  - false, this field wasn't changed at all
+    // 'a' => 'a' && 'a' => 'ab' - true, this field is changed for the first time
+    return a === b && b !== c;
+}


### PR DESCRIPTION
Undo checkpoints are created intelligently now. 

Instead of creating them on each change (i.e. character typed in an input field), we create them only on significant changes.