### PR TITLE
[1168] - Removed isInvalid prop from Rating component

### DIFF
--- a/app/src/docs/_examples/rating/Basic.example.tsx
+++ b/app/src/docs/_examples/rating/Basic.example.tsx
@@ -10,7 +10,6 @@ export default function BasicExample() {
             <Rating value={ value } onValueChange={ onValueChange } />
             <Rating isDisabled value={ value } onValueChange={ onValueChange } />
             <Rating isReadonly value={ value } onValueChange={ onValueChange } />
-            <Rating isInvalid value={ value } onValueChange={ onValueChange } />
         </FlexCell>
     );
 }

--- a/app/src/docs/_props/epam-promo/components/inputs/rating.props.ts
+++ b/app/src/docs/_props/epam-promo/components/inputs/rating.props.ts
@@ -1,10 +1,10 @@
 import { DocBuilder } from '@epam/uui-docs';
 import { RatingProps } from '@epam/uui-components';
 import { Rating, RatingMods } from '@epam/promo';
-import { isDisabledDoc, isInvalidDoc, iEditable, DefaultContext, FormContext } from '../../docs';
+import { isDisabledDoc, iEditable, DefaultContext, FormContext } from '../../docs';
 
 const RatingDoc = new DocBuilder<RatingProps & RatingMods>({ name: 'Rating', component: Rating })
-    .implements([isDisabledDoc, isInvalidDoc, iEditable])
+    .implements([isDisabledDoc, iEditable])
     .prop('size', { examples: [18, 24, 30], defaultValue: 18 })
     .prop('value', { examples: [0.5, 1, 1.5, 2, 2.5, 3, 3.5, 4, 4.5, 5] })
     .prop('step', { examples: [0.5, 1], defaultValue: 1 })

--- a/app/src/docs/_props/loveship/components/inputs/rating.props.ts
+++ b/app/src/docs/_props/loveship/components/inputs/rating.props.ts
@@ -1,10 +1,10 @@
 import { DocBuilder } from '@epam/uui-docs';
 import { RatingProps } from '@epam/uui-components';
 import { Rating, RatingMods } from '@epam/loveship';
-import { isDisabledDoc, isInvalidDoc, iEditable, DefaultContext, FormContext } from '../../docs';
+import { isDisabledDoc, iEditable, DefaultContext, FormContext } from '../../docs';
 
 const RatingDoc = new DocBuilder<RatingProps & RatingMods>({ name: 'Rating', component: Rating })
-    .implements([isDisabledDoc, isInvalidDoc, iEditable])
+    .implements([isDisabledDoc, iEditable])
     .prop('size', { examples: [18, 24, 30], defaultValue: 18 })
     .prop('value', { examples: [0.5, 1, 1.5, 2, 2.5, 3, 3.5, 4, 4.5, 5] })
     .prop('step', { examples: [0.5, 1], defaultValue: 1 })

--- a/uui-components/src/inputs/Rating/BaseRating.tsx
+++ b/uui-components/src/inputs/Rating/BaseRating.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
-import { cx, IDisableable, IEditable, ICanBeInvalid, ICanBeReadonly, IHasCX, uuiMod, IHasRawProps, IHasForwardedRef } from '@epam/uui-core';
+import { cx, IDisableable, IEditable, ICanBeReadonly, IHasCX, uuiMod, IHasRawProps, IHasForwardedRef } from '@epam/uui-core';
 import css from './BaseRating.scss';
 
-export interface BaseRatingProps<TValue> extends IHasCX, IDisableable, IEditable<TValue>, ICanBeInvalid, ICanBeReadonly, IHasRawProps<React.HTMLAttributes<HTMLDivElement>>, IHasForwardedRef<HTMLDivElement> {
+export interface BaseRatingProps<TValue> extends IHasCX, IDisableable, IEditable<TValue>, ICanBeReadonly, IHasRawProps<React.HTMLAttributes<HTMLDivElement>>, IHasForwardedRef<HTMLDivElement> {
     from?: number;
     to?: number;
     step?: 0.5 | 1;
@@ -129,7 +129,7 @@ export class BaseRating extends React.Component<BaseRatingProps<number>, BaseRat
                 aria-valuemin={ this.props.from }
                 tabIndex={ 0 }
                 onKeyDown={ (e) => !isReadonly && this.onKeyDown(e) }
-                className={ cx(css.container, this.props.isDisabled && uuiMod.disabled, this.props.isInvalid && uuiMod.invalid, isReadonly && css.containerReadonly, this.props.cx) }
+                className={ cx(css.container, this.props.isDisabled && uuiMod.disabled, isReadonly && css.containerReadonly, this.props.cx) }
                 onMouseMove={ (e) => !isReadonly && this.onMouseMove(e) }
                 onMouseLeave={ () => !isReadonly && this.onMouseLeave() }
                 onMouseUp={ (e) => !isReadonly && this.onMouseUp(e) }


### PR DESCRIPTION
Removed `isInvalid` prop from Rating component

Related to:
https://github.com/epam/UUI/issues/1168 - [Rating]: remove invalid state