### PR TITLE
Bugfix/epam/column filter fix #1182

### DIFF
--- a/uui/components/pickers/DataPickerHeader.tsx
+++ b/uui/components/pickers/DataPickerHeader.tsx
@@ -11,7 +11,9 @@ interface DataPickerHeaderProps {
 }
 
 const DataPickerHeaderImpl: React.FC<DataPickerHeaderProps> = props => {
-    const title = props.title ? props.title.charAt(0).toUpperCase() + props.title.slice(1) : '';
+    const title = props.title && typeof props.title === 'string'
+        ? props.title.charAt(0).toUpperCase() + props.title.slice(1)
+        : '';
     
     return (
         <FlexRow alignItems='center' borderBottom size="48" cx={ css.header }>


### PR DESCRIPTION
Fixed a crash if you provide non-string to DataPickerHeader as title

Related to:
https://github.com/epam/UUI/issues/1182