### PR TITLE
[SlateEditor] Disable auto focus

### DIFF
--- a/app/src/docs/_examples/richTextEditor/Basic.example.tsx
+++ b/app/src/docs/_examples/richTextEditor/Basic.example.tsx
@@ -89,7 +89,6 @@ export default function SlateEditorBasicExample() {
                 value={ value }
                 onValueChange={ setValue }
                 isReadonly={ isReadonly }
-                autoFocus={ true }
                 plugins={ plugins }
                 mode={ mode }
                 placeholder='Add description'

--- a/app/src/docs/_examples/richTextEditor/WithInnerScroll.example.tsx
+++ b/app/src/docs/_examples/richTextEditor/WithInnerScroll.example.tsx
@@ -62,7 +62,6 @@ export default function WithInnerScrollExample() {
                 value={ value }
                 onValueChange={ setValue }
                 isReadonly={ false }
-                autoFocus={ true }
                 plugins={ plugins }
                 mode='form'
                 placeholder='Add description'

--- a/next-app/pages/editor.tsx
+++ b/next-app/pages/editor.tsx
@@ -87,7 +87,6 @@ export default function SlateEditorBasicExample() {
                     value={ value }
                     onValueChange={ setValue }
                     isReadonly={ isReadonly }
-                    autoFocus={ true }
                     plugins={ plugins }
                     mode={ mode }
                     placeholder='Add description'

--- a/uui-editor/src/SlateEditor.tsx
+++ b/uui-editor/src/SlateEditor.tsx
@@ -149,7 +149,7 @@ export function SlateEditor(props: SlateEditorProps) {
     });
 
     const editableProps: TEditableProps = {
-        autoFocus,
+        autoFocus: false,
         readOnly: isReadonly,
         placeholder,
     };

--- a/uui-editor/src/SlateEditor.tsx
+++ b/uui-editor/src/SlateEditor.tsx
@@ -135,7 +135,7 @@ const Editor = ({ initialValue, ...props }: any) => {
 
 export function SlateEditor(props: SlateEditorProps) {
     const {
-        autoFocus,
+        autoFocus = false,
         isReadonly,
         placeholder,
     } = props;
@@ -149,7 +149,7 @@ export function SlateEditor(props: SlateEditorProps) {
     });
 
     const editableProps: TEditableProps = {
-        autoFocus: false,
+        autoFocus,
         readOnly: isReadonly,
         placeholder,
     };

--- a/uui-editor/src/SlateEditor.tsx
+++ b/uui-editor/src/SlateEditor.tsx
@@ -135,7 +135,7 @@ const Editor = ({ initialValue, ...props }: any) => {
 
 export function SlateEditor(props: SlateEditorProps) {
     const {
-        autoFocus = false,
+        autoFocus,
         isReadonly,
         placeholder,
     } = props;


### PR DESCRIPTION
## Summary

Disables auto focus to prevent jumps to the last editor when open page with multiple editor windows.  