### PR TITLE
[Datasource]: fixed estimated children count.

### DIFF
--- a/uui-core/src/data/processing/views/BaseListView.tsx
+++ b/uui-core/src/data/processing/views/BaseListView.tsx
@@ -383,6 +383,8 @@ export abstract class BaseListView<TItem, TId, TFilter> implements IDataSourceVi
         if (!id) return undefined;
 
         const item = this.tree.getById(id);
+        if (!item) return undefined;
+
         const childCount = this.getChildCount(item);
         if (childCount === undefined) return undefined;
 


### PR DESCRIPTION
### Summary
Added safe code for `getEstimatedChildrenCount` if no item is present in the tree.