### PR TITLE
Feature/add new prop rangedatepicker #1244

### DIFF
--- a/app/src/docs/_props/epam-promo/components/datePickers/rangeDatePicker.props.tsx
+++ b/app/src/docs/_props/epam-promo/components/datePickers/rangeDatePicker.props.tsx
@@ -132,6 +132,7 @@ const RangeDatePickerDoc = new DocBuilder<RangeDatePickerProps>({ name: 'RangeDa
     })
     .prop('disableClear', { examples: [true], defaultValue: false })
     .prop('isHoliday', { examples: [{ name: 'without Holidays', value: () => false }] })
+    .prop('onOpenChange', { examples: (ctx) => [ctx.getCallback('onOpenChange')] })
     .withContexts(DefaultContext, FormContext, ResizableContext);
 
 export default RangeDatePickerDoc;

--- a/app/src/docs/_props/loveship/components/datePickers/rangeDatePicker.props.tsx
+++ b/app/src/docs/_props/loveship/components/datePickers/rangeDatePicker.props.tsx
@@ -129,6 +129,7 @@ const RangeDatePickerDoc = new DocBuilder<RangeDatePickerProps>({ name: 'RangeDa
     })
     .prop('disableClear', { examples: [true], defaultValue: false })
     .prop('isHoliday', { examples: [{ name: 'without Holidays', value: () => false }] })
+    .prop('onOpenChange', { examples: (ctx) => [ctx.getCallback('onOpenChange')] })
     .withContexts(DefaultContext, FormContext, ResizableContext);
 
 export default RangeDatePickerDoc;

--- a/changelog.md
+++ b/changelog.md
@@ -24,6 +24,7 @@
 * [FiltersPanel]: hide 'Add filter' button, if all filters `isAlwaysVisible`
 * [TimePicker]: added max values to hours and minutes inputs
 * [Tooltip]: added possibility to pass raw-props to the tooltip body
+* [RangeDatePicker]: added new 'onOpenChange' prop
 
 
 **What's Fixed**

--- a/uui-components/src/inputs/DatePicker/BaseRangeDatePicker.tsx
+++ b/uui-components/src/inputs/DatePicker/BaseRangeDatePicker.tsx
@@ -153,6 +153,8 @@ export abstract class BaseRangeDatePicker<TProps extends BaseRangeDatePickerProp
             inFocus: value ? focus : null,
         });
 
+        this.props?.onOpenChange?.(value);
+
         // if (this.props.getValueChangeAnalyticsEvent) {
         //     const event = this.props.getValueChangeAnalyticsEvent(value, this.state.isOpen);
         //     this.context.uuiAnalytics.sendEvent(event);

--- a/uui-core/src/types/components/datePicker/BaseRangeDatePicker.ts
+++ b/uui-core/src/types/components/datePicker/BaseRangeDatePicker.ts
@@ -62,6 +62,9 @@ export interface BaseRangeDatePickerProps extends IEditable<RangeDatePickerValue
     /** Called when component looses input focus */
     onBlur?: (e: React.FocusEvent<HTMLInputElement>, inputType: 'from' | 'to') => void;
 
+    /** Called when component is opened/closed */
+    onOpenChange?: (isOpen: boolean) => void
+
     /** rawProps as HTML attributes */
     rawProps?: {
         from?: IHasRawProps<React.HTMLAttributes<HTMLDivElement>>['rawProps'];

--- a/uui/components/datePickers/__tests__/RangeDatePicker.test.tsx
+++ b/uui/components/datePickers/__tests__/RangeDatePicker.test.tsx
@@ -29,6 +29,7 @@ async function setupRangeDatePicker(params: { value: { from: string; to: string 
             onValueChange: jest.fn().mockImplementation((newValue) => {
                 context.current.setProperty('value', newValue);
             }),
+            onOpenChange: jest.fn(),
         }),
         (props) => <RangeDatePicker { ...props } />,
     );
@@ -40,7 +41,7 @@ async function setupRangeDatePicker(params: { value: { from: string; to: string 
     return {
         result,
         dom: { from, to, clear },
-        mocks: { onValueChange: mocks.onValueChange },
+        mocks: { onValueChange: mocks.onValueChange, onOpenChange: mocks.onOpenChange },
     };
 }
 
@@ -167,5 +168,14 @@ describe('RangeDataPicker', () => {
         const { dom } = await setupRangeDatePicker({ value });
         expect(dom.from.value).toBe('Sep 10, 2019');
         expect(dom.to.value).toBe('Sep 10, 2019');
+    });
+
+    it('should fire onOpenChange event on open state change', async () => {
+        const value = { from: '2017-01-22', to: '2017-01-28' };
+        const { dom, mocks } = await setupRangeDatePicker({ value });
+        fireEvent.focus(dom.from);
+        expect(mocks.onOpenChange).toBeCalledWith(true);
+        fireEvent.blur(dom.from);
+        expect(mocks.onOpenChange).toBeCalledWith(false);
     });
 });


### PR DESCRIPTION
<!-- **Before submitting your PR, ensure that you made the following:**

- Linked the issue(if exists)
- Lint and unit tests pass locally with my changes
- Changelog is updated or not needed
- Documentation is updated/provided or not needed
- Property explorer is updated/provided or not needed
- TSDoc comments for public interfaces is updated/provided or not needed 
 -->

#### Issue link(if exists): 
https://github.com/epam/UUI/issues/1244

### Description:
Added new prop "onOpenChange" to RangeDatePicker that calls a callback with current open state

![image](https://user-images.githubusercontent.com/129158559/234573599-583a3f13-88eb-4087-8cce-694ce493bd8e.png)

