### PR TITLE
[FilterPanel]: fixed height for mobile panel

### DIFF
--- a/app/src/docs/_props/epam-promo/components/datePickers/rangeDatePicker.props.tsx
+++ b/app/src/docs/_props/epam-promo/components/datePickers/rangeDatePicker.props.tsx
@@ -117,9 +117,7 @@ const RangeDatePickerDoc = new DocBuilder<RangeDatePickerProps>({ name: 'RangeDa
                     <div className={ css.container }>
                         <div>
                             <Text color="gray60" size="24">
-                                Days:
-                                {' '}
-                                {getRangeLength(value)}
+                                {`Days: ${getRangeLength(value)}`}
                             </Text>
                         </div>
                         <div className={ css.buttonGroup }>

--- a/app/src/docs/_props/loveship/components/datePickers/rangeDatePicker.props.tsx
+++ b/app/src/docs/_props/loveship/components/datePickers/rangeDatePicker.props.tsx
@@ -115,8 +115,7 @@ const RangeDatePickerDoc = new DocBuilder<RangeDatePickerProps>({ name: 'RangeDa
                     <div className={ css.container }>
                         <div>
                             <div className={ css.counter }>
-                                Days:
-                                {getRangeLength(value)}
+                                {`Days: ${getRangeLength(value)}`}
                             </div>
                         </div>
                         <div className={ css.buttonGroup }>

--- a/uui/components/filters/FiltersPanelItem.scss
+++ b/uui/components/filters/FiltersPanelItem.scss
@@ -11,3 +11,9 @@
         padding-left: 24px;
     }
 }
+
+.panel {
+    @media screen and (max-width: 720px) {
+        height: var(--app-mobile-height);
+    }
+}


### PR DESCRIPTION
### Description:

- Fixed height for filter panel and filter panel footer: 

| How it was  | Should be |
| ------------- | ------------- |
| <img width="428" alt="Screenshot at Apr 26 21-50-29" src="https://user-images.githubusercontent.com/26334961/234674316-4f4bd7b5-6e9d-482f-ac98-52149e92e8df.png"> | <img width="289" alt="Screenshot at Apr 26 21-41-06" src="https://user-images.githubusercontent.com/26334961/234674460-6353ae27-2461-4ad4-9f4c-a9f3625af2d5.png"> |
| <img width="441" alt="Screenshot at Apr 26 21-52-44" src="https://user-images.githubusercontent.com/26334961/234674715-09e0d01e-411f-47d8-a99f-c201a81d92d0.png">| <img width="299" alt="Screenshot at Apr 26 21-41-37" src="https://user-images.githubusercontent.com/26334961/234674788-41fce5d2-22ff-423a-a544-ed7df31b4583.png">|

- Small fix for space in RangeDatePicker footer