### PR TITLE
[SlateEditor] Make notes `Enter` key events behave like lists

### DIFF
--- a/uui-editor/src/plate/plugins/notePlugin/notePlugin.tsx
+++ b/uui-editor/src/plate/plugins/notePlugin/notePlugin.tsx
@@ -36,7 +36,7 @@ export const notePlugin = () => {
         handlers: {
             // TODO: potential handler improvement by https://github.com/ianstormtaylor/slate/issues/97
             onKeyDown: (editor) => (event) => {
-                if (event.key === 'Enter') {
+                if (event.key === 'Enter' && event.shiftKey) {
                     // do not prevent default behavior right here, it leads to bugs with insertData plugin
 
                     const noteEntry = getBlockAbove(editor, {


### PR DESCRIPTION
## Summary

Fixes notes `Enter` key events behaviour.