### PR TITLE
[PresetsPanel]: input is not available for "Add Preset" action on mobile devices

### DIFF
--- a/uui/components/filters/PresetPanel/PresetInput.module.scss
+++ b/uui/components/filters/PresetPanel/PresetInput.module.scss
@@ -5,6 +5,7 @@
     .preset-input {
         padding-left: 3px;
         padding-right: 3px;
+        width: 213px;
 
         :global(.uui-icon-accept),
         :global(.uui-icon-cancel) {


### PR DESCRIPTION
### Issue link: 
https://github.com/epam/UUI/issues/1402

### Description:
Issue related to when we're changing the size of the elements in the ResizeObserver callback. In this case, the observer is called again and again, leading to an infinite loop. An then when're trying add some preset we're getting this error each time: 
<img width="428" alt="Screenshot at Jun 20 20-03-29" src="https://github.com/epam/UUI/assets/26334961/f47ad7cf-4aaa-4451-9dc4-8df26bc6326c">
