### PR TITLE
TimePickerBody minutesStep bugfix

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,9 @@
+# 5.0.2 - 22.06.2023
+
+**What's Fixed**
+* [TimePickerBody]: fixed the bug where `minutes` values that are not a multiple of  `minutesStep`, are not rounded up to a `step`
+
+
 # 5.0.1 - 13.06.2023
 
 **What's New**

--- a/uui-components/src/inputs/TimePickerBody.tsx
+++ b/uui-components/src/inputs/TimePickerBody.tsx
@@ -49,6 +49,20 @@ export class TimePickerBody extends React.Component<TimePickerBodyProps, TimePic
         this.setValue(dayjs().set(this.props.value).add(12, 'h'));
     };
 
+    handleMinutesUpClick = () => {
+        var minutesStep: number = this.props.minutesStep || 5;
+        var value: Dayjs = dayjs().set(this.props.value);
+        const minutesToAdd: number = minutesStep - (value.minute() % minutesStep);
+        this.onMinutesChange(value.add(minutesToAdd, 'm').minute());
+    };
+
+    handleMinutesDownClick = () => {
+        var minutesStep: number = this.props.minutesStep || 5;
+        var value: Dayjs = dayjs().set(this.props.value);
+        const minutesToSubtract: number = value.minute() % minutesStep == 0 ? minutesStep : value.minute() % minutesStep;
+        this.onMinutesChange(value.subtract(minutesToSubtract, 'm').minute());
+    };
+
     render() {
         const minutesStep = this.props.minutesStep || 5;
         const MIN_HOURS = this.props.format === FORMAT_12H ? 1 : 0;
@@ -83,11 +97,7 @@ export class TimePickerBody extends React.Component<TimePickerBodyProps, TimePic
                     <IconContainer
                         cx={ uuiTimePicker.iconUp }
                         icon={ this.props.addIcon }
-                        onClick={ () => {
-                            var value: Dayjs = dayjs().set(this.props.value);
-                            const minutesToAdd: number = minutesStep - (value.minute() % minutesStep);
-                            this.onMinutesChange(value.add(minutesToAdd, 'm').minute());
-                        } }
+                        onClick={ this.handleMinutesUpClick }
                     />
                     <NumericInput
                         cx={ uuiTimePicker.input }
@@ -99,11 +109,7 @@ export class TimePickerBody extends React.Component<TimePickerBodyProps, TimePic
                     <IconContainer
                         cx={ uuiTimePicker.iconDown }
                         icon={ this.props.subtractIcon }
-                        onClick={ () => {
-                            var value: Dayjs = dayjs().set(this.props.value);
-                            const minutesToSubtract: number = value.minute() % minutesStep == 0 ? minutesStep : value.minute() % minutesStep;
-                            this.onMinutesChange(value.subtract(minutesToSubtract, 'm').minute());
-                        } }
+                        onClick={ this.handleMinutesDownClick }
                     />
                 </div>
                 {MAX_HOURS === FORMAT_12H && (

--- a/uui-components/src/inputs/TimePickerBody.tsx
+++ b/uui-components/src/inputs/TimePickerBody.tsx
@@ -83,7 +83,11 @@ export class TimePickerBody extends React.Component<TimePickerBodyProps, TimePic
                     <IconContainer
                         cx={ uuiTimePicker.iconUp }
                         icon={ this.props.addIcon }
-                        onClick={ () => this.onMinutesChange(dayjs().set(this.props.value).add(minutesStep, 'm').minute()) }
+                        onClick={ () => {
+                            var value: Dayjs = dayjs().set(this.props.value);
+                            const minutesToAdd: number = minutesStep - (value.minute() % minutesStep);
+                            this.onMinutesChange(value.add(minutesToAdd, 'm').minute());
+                        } }
                     />
                     <NumericInput
                         cx={ uuiTimePicker.input }
@@ -95,7 +99,11 @@ export class TimePickerBody extends React.Component<TimePickerBodyProps, TimePic
                     <IconContainer
                         cx={ uuiTimePicker.iconDown }
                         icon={ this.props.subtractIcon }
-                        onClick={ () => this.onMinutesChange(dayjs().set(this.props.value).subtract(minutesStep, 'm').minute()) }
+                        onClick={ () => {
+                            var value: Dayjs = dayjs().set(this.props.value);
+                            const minutesToSubtract: number = value.minute() % minutesStep == 0 ? minutesStep : value.minute() % minutesStep;
+                            this.onMinutesChange(value.subtract(minutesToSubtract, 'm').minute());
+                        } }
                     />
                 </div>
                 {MAX_HOURS === FORMAT_12H && (


### PR DESCRIPTION
#### Issue link (if exists): #1424  

### Description:
[TimePickerBody]: fixed the bug where `minutes` values that are not a multiple of `minutesStep`, are not rounded up to the nearest multiple of `minutesStep`
