### PR TITLE
bugfix/Rating-initial-value

### DIFF
--- a/uui-components/src/inputs/Rating/BaseRating.tsx
+++ b/uui-components/src/inputs/Rating/BaseRating.tsx
@@ -69,7 +69,7 @@ export class BaseRating extends React.Component<BaseRatingProps<number>, BaseRat
     checkRating(rating: number): number {
         if (!rating && rating !== 0) {
             return rating;
-        } else if (rating <= this.props.from - this.props.step) {
+        } else if (rating < this.props.from - this.props.step) {
             return this.props.from;
         } else if (rating > this.props.to) {
             return this.props.to;


### PR DESCRIPTION
#### Issue link(if exists): 
https://github.com/epam/UUI/issues/1411

### Description:
The problem lies in the "checkRating" function, where it replaces the "rating" value with the "from" value. When the "step" value is undefined (which is the case most of the time), there are no issues. However, when the "step" value is set to 0.5, a problem arises. This issue can be resolved by excluding the equality in the "checkRating" function.

### Demo video:
[Demo video](https://www.youtube.com/watch?v=SeOdyf72ljo) 
