### PR TITLE
[Dropdown] Fix `renderTarget` props memoization

### DIFF
--- a/uui-components/src/overlays/Dropdown.tsx
+++ b/uui-components/src/overlays/Dropdown.tsx
@@ -183,9 +183,23 @@ export class Dropdown extends React.Component<DropdownProps, DropdownState> {
         else this.handleOpenedChange(false);
     };
 
-    private renderTarget(targetProps: ReferenceChildrenProps) {
+    private getTargetClickHandler = () => {
         const { openOnClick, openOnHover } = this.props;
-        const handleTargetClick = (openOnClick || (!openOnClick && !openOnHover)) ? this.handleTargetClick : undefined;
+
+        return (openOnClick || (!openOnClick && !openOnHover)) ? this.handleTargetClick : undefined;
+    };
+
+    private getIsInteractedOutside = (event: Event) => {
+        return isInteractedOutsideDropdown(
+            event,
+            [
+                this.bodyNode,
+                this.targetNode,
+            ],
+        );
+    };
+
+    private renderTarget(targetProps: ReferenceChildrenProps) {
         const innerRef = (node: HTMLElement | null) => {
             if (!node) return;
             this.targetNode = node;
@@ -193,12 +207,12 @@ export class Dropdown extends React.Component<DropdownProps, DropdownState> {
         };
 
         return this.props.renderTarget({
-            onClick: handleTargetClick,
+            onClick: this.getTargetClickHandler(),
             isOpen: this.isOpened(),
             isDropdown: true,
             ref: innerRef,
             toggleDropdownOpening: this.handleOpenedChange,
-            isInteractedOutside: (e) => isInteractedOutsideDropdown(e, [this.bodyNode, this.targetNode]),
+            isInteractedOutside: this.getIsInteractedOutside,
         });
     }
 

--- a/uui-components/src/overlays/Dropdown.tsx
+++ b/uui-components/src/overlays/Dropdown.tsx
@@ -186,7 +186,14 @@ export class Dropdown extends React.Component<DropdownProps, DropdownState> {
     private getTargetClickHandler = () => {
         const { openOnClick, openOnHover } = this.props;
 
-        return (openOnClick || (!openOnClick && !openOnHover)) ? this.handleTargetClick : undefined;
+        if (
+            openOnClick
+            || !openOnHover
+        ) {
+            return this.handleTargetClick;
+        }
+
+        return undefined;
     };
 
     private getIsInteractedOutside = (event: Event) => {
@@ -201,7 +208,10 @@ export class Dropdown extends React.Component<DropdownProps, DropdownState> {
 
     private renderTarget(targetProps: ReferenceChildrenProps) {
         const innerRef = (node: HTMLElement | null) => {
-            if (!node) return;
+            if (!node) {
+                return;
+            }
+
             this.targetNode = node;
             (targetProps.ref as React.RefCallback<HTMLElement>)(this.targetNode);
         };


### PR DESCRIPTION
### Description

Some properties (like `isInteractedOutside`), that are passed to `renderTarget` function, are created anew on each render, breaking user memoized components.

This pull request move the properties' getters to separate component's methods:
* `isInteractedOutside` (method `getIsInteractedOutside`)
* `onClick` (method `getTargetClickHandler`). Actually, the current version is safe enough, but I decided to move picking the handler to a separate method to make the code a bit cleaner

Additionally, I removed unnecessary condition part `!openOnClick` inside `getTargetClickHandler`, because it is always `true`:

```diff
if (
  openOnClick
+ || !openOnHover
- || (
-   !openOnClick
-   && !openOnHover
- )
) {
  return this.handleTargetClick;
}

return undefined;
```

### Further improvements

There is also `ref` property, but I left it untouched, because right now it is impossible to make it the component's property because its reference to `targetProps` object, returned by `Reference` component from “react-popper” library and updated on each render.

So the problem with memoization user's components is still here because of `ref`, but now it is not necessary to worry about other properties and spend time on fixing them.