### PR TITLE
bugfix: fixed collapsing components and assets inside sidebar

### DIFF
--- a/app/src/common/sidebar/Sidebar.tsx
+++ b/app/src/common/sidebar/Sidebar.tsx
@@ -23,8 +23,7 @@ export function Sidebar<TItem extends TreeListItem>(props: SidebarProps<TItem>) 
     React.useEffect(() => {
         const { parentId } = props.items.find((i) => i.id === props.value);
         if (parentId != null) {
-            const parentKey = JSON.stringify(parentId);
-            setValue((stateValue) => ({ ...stateValue, folded: { ...stateValue.folded, [parentKey]: false } }));
+            setValue((stateValue) => ({ ...stateValue, folded: { ...stateValue.folded, [parentId]: false } }));
         }
     }, [props.value]);
 


### PR DESCRIPTION
### Issue link: 
https://github.com/epam/UUI/issues/1400

### Description:
We have differences between names of items and that's why we have incorrect value for `!row.isFolded`.

Should be:
<img width="827" alt="Screenshot at Jul 04 13-58-13" src="https://github.com/epam/UUI/assets/26334961/5cd725c8-9ef0-4aca-8d0b-31bd074f969f">
 