### PR TITLE
add-0-value-in-property-explorer-rating

### DIFF
--- a/app/src/docs/_props/epam-promo/components/inputs/rating.props.ts
+++ b/app/src/docs/_props/epam-promo/components/inputs/rating.props.ts
@@ -15,7 +15,7 @@ const RatingDoc = new DocBuilder<RatingProps & RatingMods>({ name: 'Rating', com
     })
     .prop('value', {
         examples: [
-            0.5, 1, 1.5, 2, 2.5, 3, 3.5, 4, 4.5, 5,
+            0, 0.5, 1, 1.5, 2, 2.5, 3, 3.5, 4, 4.5, 5,
         ],
     })
     .prop('step', { examples: [0.5, 1], defaultValue: 1 })


### PR DESCRIPTION
<!-- **Before submitting your PR, ensure that you made the following:**

- Linked the issue(if exists)
- Lint and unit tests pass locally with my changes
- Changelog is updated or not needed
- Documentation is updated/provided or not needed
- Property explorer is updated/provided or not needed
- TSDoc comments for public interfaces is updated/provided or not needed 
 -->

#### Issue link: 
https://github.com/epam/UUI/issues/1411

### Description:

Include 0 value in Property Explorer for Rating component.
