### PR TITLE
[fix] keyboard accessibility for the avatar icon with options in the Dropdown Menu

### DIFF
--- a/app/src/docs/_examples/dropdownMenu/Basic.example.tsx
+++ b/app/src/docs/_examples/dropdownMenu/Basic.example.tsx
@@ -107,7 +107,14 @@ export default function BasicDropdownMenuExample() {
                 closeOnMouseLeave="boundary"
                 closeDelay={ 400 }
                 renderBody={ (props) => renderDropdownBody(props) }
-                renderTarget={ (props) => <AvatarButton img="https://avatars.dicebear.com/api/human/avatar12.svg?background=%23EBEDF5&radius=50" size="36" { ...props } /> }
+                renderTarget={ (props) => (
+                    <AvatarButton
+                        img="https://avatars.dicebear.com/api/human/avatar12.svg?background=%23EBEDF5&radius=50"
+                        size="36"
+                        aria-label="Person"
+                        { ...props }
+                    />
+                ) }
             />
             <ControlGroup>
                 <Button size="36" caption="Action with selected" fill="solid" onClick={ () => {} } />

--- a/app/src/docs/_examples/dropdownMenu/Basic.example.tsx
+++ b/app/src/docs/_examples/dropdownMenu/Basic.example.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import {
-    Avatar,
+    AvatarButton,
     DropdownMenuBody,
     DropdownMenuButton,
     DropdownMenuSwitchButton,
@@ -107,7 +107,7 @@ export default function BasicDropdownMenuExample() {
                 closeOnMouseLeave="boundary"
                 closeDelay={ 400 }
                 renderBody={ (props) => renderDropdownBody(props) }
-                renderTarget={ (props) => <Avatar img="https://avatars.dicebear.com/api/human/avatar12.svg?background=%23EBEDF5&radius=50" size="36" { ...props } /> }
+                renderTarget={ (props) => <AvatarButton img="https://avatars.dicebear.com/api/human/avatar12.svg?background=%23EBEDF5&radius=50" size="36" { ...props } /> }
             />
             <ControlGroup>
                 <Button size="36" caption="Action with selected" fill="solid" onClick={ () => {} } />

--- a/epam-promo/components/index.ts
+++ b/epam-promo/components/index.ts
@@ -13,6 +13,6 @@ export { FiltersPanel, PresetsPanel, defaultPredicates, TabButton, VerticalTabBu
     Accordion, Form, useForm, PickerInput, PickerItem, DataPickerRow, PickerToggler, PickerList, Blocker, CheckboxGroup, ControlGroup,
     ConfirmationModal, RadioGroup, Anchor, Avatar, AvatarStack, Paginator, DataTable, DataTableCell, DataTableRow, DataTableHeaderRow, ColumnsConfigurationModal,
     WarningNotification, SuccessNotification, HintNotification, ErrorNotification, ClearNotification, DatePicker, RangeDatePicker, Checkbox, FlexSpacer, FlexCell,
-    Spinner, DataPickerBody, PickerModal, ModalBlocker, ModalHeader, ModalFooter,
+    Spinner, DataPickerBody, PickerModal, ModalBlocker, ModalHeader, ModalFooter, AvatarButton,
 } from '@epam/uui';
 export { MainMenuLogo, MainMenuCustomElement } from '@epam/uui-components';

--- a/uui-components/src/widgets/Avatar.tsx
+++ b/uui-components/src/widgets/Avatar.tsx
@@ -16,12 +16,9 @@ export interface AvatarProps extends IHasCX, IHasRawProps<React.ImgHTMLAttribute
 
     /** True to show placeholder */
     isLoading?: boolean;
-
-    /** Click handler */
-    onClick?: () => void;
 }
 
-function AvatarComponent(props: AvatarProps, ref: React.ForwardedRef<HTMLImageElement>) {
+export function Avatar(props: AvatarProps) {
     const [isError, setIsError] = React.useState<boolean>(false);
 
     function onError() {
@@ -31,8 +28,6 @@ function AvatarComponent(props: AvatarProps, ref: React.ForwardedRef<HTMLImageEl
     }
     return (
         <img
-            onClick={ props.onClick }
-            ref={ ref }
             className={ cx(css.avatar, props.cx) }
             width={ props.size }
             height={ props.size }
@@ -47,5 +42,3 @@ function AvatarComponent(props: AvatarProps, ref: React.ForwardedRef<HTMLImageEl
         />
     );
 }
-
-export const Avatar = React.forwardRef(AvatarComponent) as <AvatarComponent>(props: AvatarProps, ref: React.ForwardedRef<HTMLImageElement>) => JSX.Element;

--- a/uui-components/src/widgets/AvatarButton.module.scss
+++ b/uui-components/src/widgets/AvatarButton.module.scss
@@ -1,0 +1,5 @@
+.avatarButton {
+    border-radius: 50%;
+    border-width: 0;
+    padding: 0;
+}

--- a/uui-components/src/widgets/AvatarButton.tsx
+++ b/uui-components/src/widgets/AvatarButton.tsx
@@ -8,11 +8,12 @@ export interface AvatarButtonProps extends AvatarProps {
     onClick?: () => void;
 }
 
-function AvatarButtonComponent(props: AvatarButtonProps, ref: React.ForwardedRef<HTMLImageElement>) {
+function AvatarButtonComponent(props: AvatarButtonProps, ref: React.ForwardedRef<HTMLButtonElement>) {
     return (
         <button
             type="button"
             onClick={ props.onClick }
+            ref = { ref }
             className={ cx(css.avatarButton, props.cx) }
             style={ { height: `${props.size}px` } }
         >
@@ -23,5 +24,5 @@ function AvatarButtonComponent(props: AvatarButtonProps, ref: React.ForwardedRef
 
 export const AvatarButton = React.forwardRef(AvatarButtonComponent) as <AvatarButtonComponent>(
     props: AvatarButtonProps,
-    ref: React.ForwardedRef<HTMLImageElement>
+    ref: React.ForwardedRef<HTMLButtonElement>
 ) => JSX.Element;

--- a/uui-components/src/widgets/AvatarButton.tsx
+++ b/uui-components/src/widgets/AvatarButton.tsx
@@ -6,6 +6,9 @@ import css from './AvatarButton.module.scss';
 export interface AvatarButtonProps extends AvatarProps {
     /** Click handler */
     onClick?: () => void;
+
+    /** Defines a string value that labels the current element */
+    'aria-label'?: string;
 }
 
 function AvatarButtonComponent(props: AvatarButtonProps, ref: React.ForwardedRef<HTMLButtonElement>) {
@@ -16,6 +19,7 @@ function AvatarButtonComponent(props: AvatarButtonProps, ref: React.ForwardedRef
             ref = { ref }
             className={ cx(css.avatarButton, props.cx) }
             style={ { height: `${props.size}px` } }
+            aria-label={ props['aria-label'] }
         >
             <Avatar { ...props } />
         </button>

--- a/uui-components/src/widgets/AvatarButton.tsx
+++ b/uui-components/src/widgets/AvatarButton.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { cx } from '@epam/uui-core';
+import { AvatarProps, Avatar } from './Avatar';
+import css from './AvatarButton.module.scss';
+
+export interface AvatarButtonProps extends AvatarProps {
+    /** Click handler */
+    onClick?: () => void;
+}
+
+function AvatarButtonComponent(props: AvatarButtonProps, ref: React.ForwardedRef<HTMLImageElement>) {
+    return (
+        <button
+            type="button"
+            onClick={ props.onClick }
+            className={ cx(css.avatarButton, props.cx) }
+            style={ { height: `${props.size}px` } }
+        >
+            <Avatar { ...props } />
+        </button>
+    );
+}
+
+export const AvatarButton = React.forwardRef(AvatarButtonComponent) as <AvatarButtonComponent>(
+    props: AvatarButtonProps,
+    ref: React.ForwardedRef<HTMLImageElement>
+) => JSX.Element;

--- a/uui-components/src/widgets/index.ts
+++ b/uui-components/src/widgets/index.ts
@@ -1,4 +1,5 @@
 export * from './Avatar';
+export * from './AvatarButton';
 export * from './AvatarStack';
 export * from './Spinner';
 export * from './Carousel';

--- a/uui/components/widgets/Avatar.tsx
+++ b/uui/components/widgets/Avatar.tsx
@@ -1,4 +1,3 @@
-import { withMods } from '@epam/uui-core';
 import { Avatar as uuiAvatar, AvatarProps } from '@epam/uui-components';
 
-export const Avatar = withMods<AvatarProps>(uuiAvatar, () => []);
+export const Avatar = uuiAvatar;

--- a/uui/components/widgets/AvatarButton.tsx
+++ b/uui/components/widgets/AvatarButton.tsx
@@ -1,0 +1,4 @@
+import { withMods } from '@epam/uui-core';
+import { AvatarButton as uuiAvatarButton, AvatarButtonProps } from '@epam/uui-components';
+
+export const AvatarButton = withMods<AvatarButtonProps>(uuiAvatarButton, () => []);

--- a/uui/components/widgets/index.ts
+++ b/uui/components/widgets/index.ts
@@ -1,4 +1,5 @@
 export * from './Avatar';
+export * from './AvatarButton';
 export * from './AvatarStack';
 export * from './Badge';
 export * from './Tag';


### PR DESCRIPTION
<!-- **Before submitting your PR, ensure that you made the following:**

- Linked the issue(if exists)
- Lint and unit tests pass locally with my changes
- Changelog is updated or not needed
- Documentation is updated/provided or not needed
- Property explorer is updated/provided or not needed
- TSDoc comments for public interfaces is updated/provided or not needed 
 -->

#### Issue link(if exists): https://github.com/epam/UUI/issues/877 Case №1

### Description:
Fix possibility to click the avatar icon with options in the Dropdown Menu example using keyboard.

Since it's needed to get focus to open menu using keyboard ([doc](https://www.w3.org/WAI/ARIA/apg/patterns/menu-button/)) I wrapped `Avatar` component into `button` element. I separated it into a new component [AvatorButton](uui-components/src/widgets/AvatarButton.tsx) for now, but we can discuss it.
Also I added `arria-label` prop for `AvatorButton`  for announcing by screen reader.

In the video below we can navigate by `Tab` key to `Avatar` icon and open a dropdown, as well as navigating through options by arrow keys.

https://github.com/epam/UUI/assets/11524637/7792336f-0efe-4d2d-8a19-0866d1aa63b8



Todo: (maybe in a separate PR)
- [ ] dd menu should close by `Ecs` key



