### PR TITLE
[fix] Avatar wrapped by button when it's clickable

### DIFF
--- a/app/src/docs/_examples/dropdownMenu/Basic.example.tsx
+++ b/app/src/docs/_examples/dropdownMenu/Basic.example.tsx
@@ -107,7 +107,7 @@ export default function BasicDropdownMenuExample() {
                 closeOnMouseLeave="boundary"
                 closeDelay={ 400 }
                 renderBody={ (props) => renderDropdownBody(props) }
-                renderTarget={ (props) => <Avatar img="https://avatars.dicebear.com/api/human/avatar12.svg?background=%23EBEDF5&radius=50" size="36" { ...props } /> }
+                renderTarget={ (props) => <Avatar img="https://avatars.dicebear.com/api/human/avatar12.svg?background=%23EBEDF5&radius=50" size="36" { ...props } rawProps={ { 'aria-label': 'Person' } } /> }
             />
             <ControlGroup>
                 <Button size="36" caption="Action with selected" fill="solid" onClick={ () => {} } />

--- a/uui-components/src/widgets/Avatar.module.scss
+++ b/uui-components/src/widgets/Avatar.module.scss
@@ -1,3 +1,9 @@
 .avatar {
     border-radius: 50%;
 }
+
+.avatarButton {
+    border-radius: 50%;
+    border-width: 0;
+    padding: 0;
+}

--- a/uui-components/src/widgets/Avatar.tsx
+++ b/uui-components/src/widgets/Avatar.tsx
@@ -21,7 +21,7 @@ export interface AvatarProps extends IHasCX, IHasRawProps<React.ImgHTMLAttribute
     onClick?: () => void;
 }
 
-function AvatarComponent(props: AvatarProps, ref: React.ForwardedRef<HTMLImageElement>) {
+function AvatarComponent(props: AvatarProps, ref: React.ForwardedRef<HTMLImageElement | HTMLButtonElement>) {
     const [isError, setIsError] = React.useState<boolean>(false);
 
     function onError() {
@@ -29,21 +29,40 @@ function AvatarComponent(props: AvatarProps, ref: React.ForwardedRef<HTMLImageEl
             setIsError(true);
         }
     }
+
+    const { 'aria-label': ariaLabel, ...rawProps } = props.rawProps;
+    const commonProps = {
+        className: cx(css.avatar, props.cx),
+        width: props.size,
+        height: props.size,
+        src: props.isLoading || !props.img || isError
+            ? 'https://static.cdn.epam.com/uploads/690afa39a93c88c4dd13758fe1d869d5/EPM-UUI/Images/avatar_placeholder.jpg'
+            : props.img,
+        alt: props.alt,
+        onError,
+        ...rawProps,
+    };
+
+    if (props.onClick) {
+        return (
+            <button
+                ref={ ref as React.ForwardedRef<HTMLButtonElement> }
+                type="button"
+                onClick={ props.onClick }
+                className={ cx(css.avatarButton, props.cx) }
+                style={ { height: `${props.size}px` } }
+                aria-label={ ariaLabel }
+            >
+                <img { ...commonProps } />
+            </button>
+        );
+    }
+
     return (
         <img
-            onClick={ props.onClick }
-            ref={ ref }
-            className={ cx(css.avatar, props.cx) }
-            width={ props.size }
-            height={ props.size }
-            src={
-                props.isLoading || !props.img || isError
-                    ? 'https://static.cdn.epam.com/uploads/690afa39a93c88c4dd13758fe1d869d5/EPM-UUI/Images/avatar_placeholder.jpg'
-                    : props.img
-            }
-            alt={ props.alt }
-            onError={ onError }
-            { ...props.rawProps }
+            ref={ ref as React.ForwardedRef<HTMLImageElement> }
+            aria-label={ ariaLabel }
+            { ...commonProps }
         />
     );
 }


### PR DESCRIPTION
<!-- **Before submitting your PR, ensure that you made the following:**

- Linked the issue(if exists)
- Lint and unit tests pass locally with my changes
- Changelog is updated or not needed
- Documentation is updated/provided or not needed
- Property explorer is updated/provided or not needed
- TSDoc comments for public interfaces is updated/provided or not needed 
 -->

#### Issue link(if exists): https://github.com/epam/UUI/issues/877 Case №1

### Description:
Fix possibility to click the avatar icon with options in the Dropdown Menu example using keyboard.

[Avatar](https://github.com/epam/UUI/blob/70562e0fe4f23bcce32e838f6c5ff147d97c360d/uui-components/src/widgets/Avatar.tsx) component is wrapped by `button` tag when `onClick` callback is passed.
Also `aria-label` support was added to button.


https://github.com/epam/UUI/assets/11524637/4549230d-9e4b-4c84-9255-84657a34e95f





Todo: (maybe in a separate PR)
- [ ] ? focus should stay on Avatar right after dropdown is opened
- [ ] dropdown menu should close by `Ecs` key
