### PR TITLE
[Fix] add alert call in `Alert` and `NotificationCard` component docs

### DIFF
--- a/app/src/docs/_props/epam-promo/components/overlays/alert.props.tsx
+++ b/app/src/docs/_props/epam-promo/components/overlays/alert.props.tsx
@@ -45,7 +45,7 @@ const SnackbarCardDoc = new DocBuilder<AlertProps>({ name: 'Alert', component: A
     .prop('onClose', {
         examples: [
             {
-                value: () => {},
+                value: () => alert('close action'),
                 name: 'OnClose',
             },
         ],

--- a/app/src/docs/_props/epam-promo/components/overlays/notificationCard.props.tsx
+++ b/app/src/docs/_props/epam-promo/components/overlays/notificationCard.props.tsx
@@ -58,7 +58,7 @@ const SnackbarCardDoc = new DocBuilder<NotificationCardProps>({ name: 'Notificat
     .prop('onClose', {
         examples: [
             {
-                value: () => {},
+                value: () => alert('close action'),
                 name: 'OnClose',
             },
         ],

--- a/app/src/docs/_props/loveship/components/overlays/alert.props.tsx
+++ b/app/src/docs/_props/loveship/components/overlays/alert.props.tsx
@@ -51,7 +51,7 @@ const SnackbarCardDoc = new DocBuilder<AlertProps>({ name: 'Alert', component: A
     .prop('onClose', {
         examples: [
             {
-                value: () => {},
+                value: () => alert('close action'),
                 name: 'OnClose',
             },
         ],

--- a/app/src/docs/_props/loveship/components/overlays/notificationCard.props.tsx
+++ b/app/src/docs/_props/loveship/components/overlays/notificationCard.props.tsx
@@ -59,7 +59,7 @@ const SnackbarCardDoc = new DocBuilder<NotificationCardProps>({ name: 'Notificat
     .prop('onClose', {
         examples: [
             {
-                value: () => {},
+                value: () => alert('close action'),
                 name: 'OnClose',
             },
         ],

--- a/app/src/docs/_props/uui/components/overlays/notificationCard.props.tsx
+++ b/app/src/docs/_props/uui/components/overlays/notificationCard.props.tsx
@@ -54,7 +54,7 @@ const SnackbarCardDoc = new DocBuilder<NotificationCardProps>({ name: 'Notificat
     .prop('onClose', {
         examples: [
             {
-                value: () => {},
+                value: () => alert('close action'),
                 name: 'OnClose',
             },
         ],


### PR DESCRIPTION
#### Issue link: 
[#1551](https://github.com/epam/UUI/issues/1551)

### Description:
Added `alert` call in with `onClose` callbacks for `NotificationCard` and `Alert` components docs
