### PR TITLE
[Fix] Picker Input single selection toggler opened

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,7 @@
 **What's Fixed**
 * Added focus state styles for Accordion, AvatarStack, Anchor, Badge, Button, Burger, Checkbox, Control Group, IconButton, LinkButton, MainMenu, RadioInput, Switch, TabButton, Tag.
 * [PickerInput]: when `searchPosition=input` a cursor is placed in textbox once PickerInput is focused via Tab key.
+* [PickerInput]: fix `searchPosition` when `editMode=modal`, it cannot be `input`.
 
 
 # 5.1.2 - 10.08.2023
@@ -68,8 +69,8 @@
 
 **Rich Text Editor component update and improvements**
 
-UUI `SlateEditor` was reworked and updated to the actual version of Slate.js framework. 
-During the update the previous code based of RTE almost completely rewritten due to a lot of breaking changes from Slate.js side. However, we put significant efforts to minimize breaking changes for our users. Therefore, update to the new version of `uui-editor` package should be seamless and easy. 
+UUI `SlateEditor` was reworked and updated to the actual version of Slate.js framework.
+During the update the previous code based of RTE almost completely rewritten due to a lot of breaking changes from Slate.js side. However, we put significant efforts to minimize breaking changes for our users. Therefore, update to the new version of `uui-editor` package should be seamless and easy.
 
 List of changes:
 * [Breaking change]: Changed RTE value format, now it's works with array instead of immutable.js object. Also, there are some additional changes inside slate value structure.

--- a/changelog.md
+++ b/changelog.md
@@ -69,8 +69,8 @@
 
 **Rich Text Editor component update and improvements**
 
-UUI `SlateEditor` was reworked and updated to the actual version of Slate.js framework.
-During the update the previous code based of RTE almost completely rewritten due to a lot of breaking changes from Slate.js side. However, we put significant efforts to minimize breaking changes for our users. Therefore, update to the new version of `uui-editor` package should be seamless and easy.
+UUI `SlateEditor` was reworked and updated to the actual version of Slate.js framework. 
+During the update the previous code based of RTE almost completely rewritten due to a lot of breaking changes from Slate.js side. However, we put significant efforts to minimize breaking changes for our users. Therefore, update to the new version of `uui-editor` package should be seamless and easy. 
 
 List of changes:
 * [Breaking change]: Changed RTE value format, now it's works with array instead of immutable.js object. Also, there are some additional changes inside slate value structure.

--- a/uui-components/src/pickers/PickerInputBase.tsx
+++ b/uui-components/src/pickers/PickerInputBase.tsx
@@ -48,7 +48,12 @@ IHasIcon & {
     /** Disallow to clear Picker value (cross icon) */
     disableClear?: boolean;
 
-    /** Minimum characters to type, before search will trigger (default is 1) */
+    /**
+     * Minimum characters to type, before search will trigger. If input characters number is less then 'minCharsToSearch', it will disable opening dropdown body.
+     * By default search triggers after input value is changed.
+     *
+     * Note: defined minCharsToSearch isn't compatible with searchPosition=body.
+     */
     minCharsToSearch?: number;
 
     /** Overrides default height of the dropdown body */

--- a/uui-components/src/pickers/PickerInputBase.tsx
+++ b/uui-components/src/pickers/PickerInputBase.tsx
@@ -173,14 +173,14 @@ export abstract class PickerInputBase<TItem, TId, TProps> extends PickerBase<TIt
 
     getSearchPosition() {
         if (isMobile() && this.props.searchPosition !== 'none') return 'body';
-        let searchPosition: any = this.props.searchPosition;
-        if (!searchPosition) {
-            searchPosition = this.props.selectionMode === 'multi' ? 'body' : 'input';
-        } else {
-            searchPosition = this.props.searchPosition;
-        }
 
-        return searchPosition === 'input' && this.props.editMode === 'modal' ? 'body' : searchPosition;
+        if (this.props.editMode === 'modal' && this.props.searchPosition !== 'none') return 'body';
+
+        if (!this.props.searchPosition) {
+            return this.props.selectionMode === 'multi' ? 'body' : 'input';
+        } else {
+            return this.props.searchPosition;
+        }
     }
 
     getPlaceholder() {

--- a/uui-components/src/pickers/PickerInputBase.tsx
+++ b/uui-components/src/pickers/PickerInputBase.tsx
@@ -291,7 +291,7 @@ export abstract class PickerInputBase<TItem, TId, TProps> extends PickerBase<TIt
             pickerMode: this.isSingleSelect() ? 'single' : 'multi',
             searchPosition,
             onKeyDown: (e) => this.handlePickerInputKeyboard(rows, e),
-            disableSearch: this.props.editMode === 'modal' || searchPosition !== 'input',
+            disableSearch: searchPosition !== 'input',
             disableClear: disableClear,
             toggleDropdownOpening: this.toggleDropdownOpening,
             closePickerBody: this.closePickerBody,

--- a/uui-components/src/pickers/PickerInputBase.tsx
+++ b/uui-components/src/pickers/PickerInputBase.tsx
@@ -40,6 +40,8 @@ IHasIcon & {
       * 'input' - try to place search inside the toggler (default for single-select),
       * 'body' - put search inside the dropdown (default for multi-select)
       * 'none' - disables search completely
+      *
+      * Note: 'searchPosition' cannot be 'input' if 'editMode' is 'modal'
       */
     searchPosition?: 'input' | 'body' | 'none';
 
@@ -171,11 +173,14 @@ export abstract class PickerInputBase<TItem, TId, TProps> extends PickerBase<TIt
 
     getSearchPosition() {
         if (isMobile() && this.props.searchPosition !== 'none') return 'body';
-        if (!this.props.searchPosition) {
-            return this.props.selectionMode === 'multi' ? 'body' : 'input';
+        let searchPosition: any = this.props.searchPosition;
+        if (!searchPosition) {
+            searchPosition = this.props.selectionMode === 'multi' ? 'body' : 'input';
         } else {
-            return this.props.searchPosition;
+            searchPosition = this.props.searchPosition;
         }
+
+        return searchPosition === 'input' && this.props.editMode === 'modal' ? 'body' : searchPosition;
     }
 
     getPlaceholder() {
@@ -286,7 +291,7 @@ export abstract class PickerInputBase<TItem, TId, TProps> extends PickerBase<TIt
             pickerMode: this.isSingleSelect() ? 'single' : 'multi',
             searchPosition,
             onKeyDown: (e) => this.handlePickerInputKeyboard(rows, e),
-            disableSearch: !minCharsToSearch && searchPosition !== 'input',
+            disableSearch: this.props.editMode === 'modal' || searchPosition !== 'input',
             disableClear: disableClear,
             toggleDropdownOpening: this.toggleDropdownOpening,
             closePickerBody: this.closePickerBody,

--- a/uui-components/src/pickers/PickerToggler.tsx
+++ b/uui-components/src/pickers/PickerToggler.tsx
@@ -139,7 +139,7 @@ function PickerTogglerComponent<TItem, TId>(props: PickerTogglerProps<TItem, TId
     const togglerPickerOpened = (e: React.MouseEvent<HTMLDivElement>) => {
         if (props.isDisabled || props.isReadonly) return;
         e.preventDefault();
-        if (inFocus && props.value && !props.disableSearch) return;
+        if (inFocus && props.value && (!props.disableSearch && props.searchPosition !== 'input')) return;
         props.onClick?.();
     };
 

--- a/uui-components/src/pickers/PickerToggler.tsx
+++ b/uui-components/src/pickers/PickerToggler.tsx
@@ -139,7 +139,7 @@ function PickerTogglerComponent<TItem, TId>(props: PickerTogglerProps<TItem, TId
     const togglerPickerOpened = (e: React.MouseEvent<HTMLDivElement>) => {
         if (props.isDisabled || props.isReadonly) return;
         e.preventDefault();
-        if (inFocus && props.value && (!props.disableSearch && props.searchPosition !== 'input')) return;
+        if (inFocus && props.value && props.minCharsToSearch) return;
         props.onClick?.();
     };
 


### PR DESCRIPTION
<!-- **Before submitting your PR, ensure that you made the following:**

- Linked the issue(if exists)
- Lint and unit tests pass locally with my changes
- Changelog is updated or not needed
- Documentation is updated/provided or not needed
- Property explorer is updated/provided or not needed
- TSDoc comments for public interfaces is updated/provided or not needed 
 -->

#### Issue link(if exists): 

### Description:
Fix the issue: Single selection Picker doesn't open by click.

Additionally a fix was applied when `editMode=modal` , a `searchPosition` cannot be `input`.
