### PR TITLE
[Fix] Icon style for Docs header link

### DIFF
--- a/app/src/common/docs/DocExample.module.scss
+++ b/app/src/common/docs/DocExample.module.scss
@@ -17,11 +17,9 @@
 
     .anchor {
         fill: transparent;
-    }
 
-    &:hover {
-        .anchor {
-            fill: $blue;
+        &:hover, &:focus {
+            fill: var(--uui-icon-btn-hover);
         }
     }
 }


### PR DESCRIPTION
<!-- **Before submitting your PR, ensure that you made the following:**

- Linked the issue(if exists)
- Lint and unit tests pass locally with my changes
- Changelog is updated or not needed
- Documentation is updated/provided or not needed
- Property explorer is updated/provided or not needed
- TSDoc comments for public interfaces is updated/provided or not needed 
 -->

#### Issue link(if exists): 

### Description:

Fix on focus style for link icon on Documentation page.

Before:

![image](https://github.com/epam/UUI/assets/11524637/717c8213-a8e4-4cd8-be03-80780e141fc5)


After:

![image](https://github.com/epam/UUI/assets/11524637/af28da4a-c4b1-497c-8d9f-18d386be49ab)

