### PR TITLE
[Fix] Button - fix focus styles

### DIFF
--- a/uui/components/buttons/Button/Button.module.scss
+++ b/uui/components/buttons/Button/Button.module.scss
@@ -41,11 +41,6 @@
             border-color: var(--uui-btn-bg-hover);
         }
 
-        &:focus {
-            background-color: var(--uui-btn-bg-hover);
-            border-color: var(--uui-btn-bg-hover);
-        }
-
         &:active {
             background-color: var(--uui-btn-bg-active);
             border-color: var(--uui-btn-bg-active);


### PR DESCRIPTION
<!-- **Before submitting your PR, ensure that you made the following:**

- Linked the issue(if exists)
- Lint and unit tests pass locally with my changes
- Changelog is updated or not needed
- Documentation is updated/provided or not needed
- Property explorer is updated/provided or not needed
- TSDoc comments for public interfaces is updated/provided or not needed 
 -->

#### Issue link(if exists): 

### Description:

Remove hover color style for focus state for `Button` component.

Before:
![image](https://github.com/epam/UUI/assets/11524637/9b8ce959-e990-4547-9eb5-90a77382328c)



After:

![image](https://github.com/epam/UUI/assets/11524637/2af98d9d-6d7a-47ae-8e8f-5fbe964c068b)
