### PR TITLE
[VirtualList]: fixed scroll to more than rows count index.

### DIFF
--- a/app/src/docs/VirtualList.doc.tsx
+++ b/app/src/docs/VirtualList.doc.tsx
@@ -11,7 +11,7 @@ export class VirtualListDoc extends BaseDocsBlock {
                 <EditableDocContent fileName="virtual-list-descriptions" />
                 {this.renderSectionTitle('Examples')}
                 <DocExample title="Basic" path="./_examples/virtualList/Basic.example.tsx" />
-
+                <DocExample title="Scroll to index" path="./_examples/virtualList/ScrollTo.example.tsx" />
                 <DocExample title="Advanced" path="./_examples/virtualList/Advanced.example.tsx" />
             </>
         );

--- a/app/src/docs/_examples/dataSources/DataSourceStateIndexToScroll.example.tsx
+++ b/app/src/docs/_examples/dataSources/DataSourceStateIndexToScroll.example.tsx
@@ -1,29 +1,27 @@
 import React, { useState } from 'react';
 import { DataSourceState, useLazyDataSource, useUuiContext } from '@epam/uui-core';
 import { DataSourceViewer } from '@epam/uui-docs';
-import { Button } from '@epam/promo';
-
-// const items = Array(1000).fill(0).map((_, index) => ({ id: index, name: `Parent ${index}` }));
+import { Button, Panel, FlexRow } from '@epam/promo';
 
 export default function DataSourceStateVisibleCountExample() {
     const svc = useUuiContext();
 
-    const [value1, onValueChange1] = useState<DataSourceState>({
-        scrollTo: { index: 200 },
-    });
+    const [value1, onValueChange1] = useState<DataSourceState>({});
     const dataSource1 = useLazyDataSource({ 
         api: svc.api.demo.countries,
     }, []);
 
     return (
-        <>
-            <Button onClick={ () => onValueChange1({ ...value1, scrollTo: { index: 0 } }) } caption="Scroll top" />
-            <Button onClick={ () => onValueChange1({ ...value1, scrollTo: { index: 200 } }) } caption="Scroll bottom" />
+        <Panel>
+            <FlexRow spacing="12">
+                <Button onClick={ () => onValueChange1({ ...value1, scrollTo: { index: 0 } }) } caption="Scroll top" />
+                <Button onClick={ () => onValueChange1({ ...value1, scrollTo: { index: 200 } }) } caption="Scroll bottom" />
+            </FlexRow>
             <DataSourceViewer
                 value={ value1 }
                 onValueChange={ onValueChange1 }
                 dataSource={ dataSource1 }
             />
-        </>
+        </Panel>
     );
 }

--- a/app/src/docs/_examples/dataSources/DataSourceViewer.code.example.tsx
+++ b/app/src/docs/_examples/dataSources/DataSourceViewer.code.example.tsx
@@ -61,6 +61,7 @@ export function DataSourceViewer<TItem, TId>(props: Props<TItem, TId>) {
                     onValueChange={ onValueChange }
                     rows={ renderedRows }
                     { ...listProps }
+                    rowsSelector="[role=option]"
                 />
             </FlexRow>
             <FlexRow>

--- a/app/src/docs/_examples/virtualList/Advanced.example.tsx
+++ b/app/src/docs/_examples/virtualList/Advanced.example.tsx
@@ -40,7 +40,7 @@ export default function AdvancedVirtualList() {
             <div className={ css.mainContainerWrapper } style={ { minHeight: `${estimatedHeight}px` } }>
                 <ul ref={ listContainerRef } style={ { marginTop: `${offsetY}px` } } className={ css.mainContainerList }>
                     {getVisibleRows().map((row) => (
-                        <li className={ css.mainContainerListItem } key={ row.key + String(row.index) }>
+                        <li className={ css.mainContainerListItem } key={ row.key + String(row.index) } role="row">
                             {row.value ? (
                                 <>
                                     <Text font="museo-sans" size="36">

--- a/app/src/docs/_examples/virtualList/ScrollTo.example.tsx
+++ b/app/src/docs/_examples/virtualList/ScrollTo.example.tsx
@@ -1,13 +1,13 @@
-import React, { FC, useState } from 'react';
+import React, { useState } from 'react';
 import {
-    IconButton, FlexRow, Panel, Text, TextPlaceholder, VirtualList,
+    IconButton, FlexRow, Panel, Text, TextPlaceholder, VirtualList, NumericInput, Button,
 } from '@epam/promo';
 import { VirtualListState } from '@epam/uui-core';
 import { ReactComponent as UnfoldedIcon } from '@epam/assets/icons/common/navigation-chevron-down-18.svg';
 import { ReactComponent as FoldedIcon } from '@epam/assets/icons/common/navigation-chevron-up-18.svg';
 import css from './BasicExample.module.scss';
 
-const MyListItem: FC<{ index: number }> = (props) => {
+function MyListItem(props: { index: number }) {
     const [isFolded, setIsFolded] = useState<boolean>(true);
     return (
         <div className={ css.itemContainer } role="row">
@@ -27,7 +27,7 @@ const MyListItem: FC<{ index: number }> = (props) => {
             </Panel>
         </div>
     );
-};
+}
 
 // Generate some data. In the real app data items are retrieved from the server.
 const someData: number[] = [];
@@ -37,6 +37,7 @@ for (let n = 0; n < 1000; n++) {
 
 export default function VirtualListExample() {
     const [state, setState] = useState<VirtualListState>({ topIndex: 0, visibleCount: 10 });
+    const [tempScrollTo, setTempScrollTo] = useState(state.scrollTo?.index);
 
     // Extract visible part: starting from state.topIndex, and only state.visibleCount of items
     const visibleItems = someData.slice(state.topIndex, state.topIndex + state.visibleCount);
@@ -47,15 +48,32 @@ export default function VirtualListExample() {
     const visibleRows = visibleItems.map((index) => <MyListItem index={ index } key={ index } />);
 
     return (
-        <VirtualList
-            cx={ css.list } // User needs to define height for container, otherwise it would extend to fit the whole content
-            rows={ visibleRows }
-            role="listbox"
-            value={ state }
-            onValueChange={ setState }
-            // Total number of items, to estimate total height
-            // If total count in unknown, you can just pass knownCount + 1 to have some space to trigger loading
-            rowsCount={ someData.length }
-        />
+        <Panel style={ { width: '100%' } }>
+            <FlexRow vPadding="12" spacing="12">
+                <NumericInput
+                    placeholder="Type index"
+                    value={ tempScrollTo }
+                    onValueChange={ (index) => {
+                        setTempScrollTo(index);
+                    } }
+                /> 
+                <Button
+                    onClick={ () => {
+                        setState((current) => ({ ...current, scrollTo: { index: tempScrollTo } })); 
+                    } }
+                    caption="Scroll"
+                />
+            </FlexRow>
+            <VirtualList
+                cx={ css.list } // User needs to define height for container, otherwise it would extend to fit the whole content
+                rows={ visibleRows }
+                role="listbox"
+                value={ state }
+                onValueChange={ setState }
+                // Total number of items, to estimate total height
+                // If total count in unknown, you can just pass knownCount + 1 to have some space to trigger loading
+                rowsCount={ someData.length }
+            />
+        </Panel>
     );
 }

--- a/public/docs/content/dataSources-dataSource-state.json
+++ b/public/docs/content/dataSources-dataSource-state.json
@@ -1,104 +1,54 @@
-{
-  "object": "value",
-  "document": {
-    "object": "document",
+[
+  {
     "data": {},
-    "nodes": [
+    "type": "paragraph",
+    "children": [
       {
-        "object": "block",
-        "type": "paragraph",
-        "data": {},
-        "nodes": [
-          {
-            "object": "text",
-            "text": "This chapter contains an overview of a ",
-            "marks": []
-          },
-          {
-            "object": "text",
-            "text": "DataSource",
-            "marks": [
-              {
-                "object": "mark",
-                "type": "uui-richTextEditor-code",
-                "data": {}
-              }
-            ]
-          },
-          {
-            "object": "text",
-            "text": " state.",
-            "marks": []
-          }
-        ]
+        "text": "This chapter contains an overview of a "
       },
       {
-        "object": "block",
-        "type": "paragraph",
-        "data": {},
-        "nodes": [
-          {
-            "object": "text",
-            "text": "DataSource",
-            "marks": [
-              {
-                "object": "mark",
-                "type": "uui-richTextEditor-code",
-                "data": {}
-              }
-            ]
-          },
-          {
-            "object": "text",
-            "text": " state contains the current state of the displayed data: range of records to be displayed from some position, an index to be scrolled to, an index of a focused row, a search string, specified filter value, sorting configuration, selected rows ids, folded rows ids, current page, and page size.",
-            "marks": []
-          }
-        ]
+        "text": "DataSource",
+        "uui-richTextEditor-code": true
       },
       {
-        "object": "block",
-        "type": "paragraph",
-        "data": {},
-        "nodes": [
-          {
-            "object": "text",
-            "text": "It is usually held in the component's state. Changing the ",
-            "marks": []
-          },
-          {
-            "object": "text",
-            "text": "DataSource",
-            "marks": [
-              {
-                "object": "mark",
-                "type": "uui-richTextEditor-code",
-                "data": {}
-              }
-            ]
-          },
-          {
-            "object": "text",
-            "text": " state causes a change of rows, which are displayed (returned by ",
-            "marks": []
-          },
-          {
-            "object": "text",
-            "text": "DataSource",
-            "marks": [
-              {
-                "object": "mark",
-                "type": "uui-richTextEditor-code",
-                "data": {}
-              }
-            ]
-          },
-          {
-            "object": "text",
-            "text": "). ",
-            "marks": []
-          }
-        ]
+        "text": " state."
+      }
+    ]
+  },
+  {
+    "data": {},
+    "type": "paragraph",
+    "children": [
+      {
+        "text": "DataSource",
+        "uui-richTextEditor-code": true
+      },
+      {
+        "text": " state contains the current state of the displayed data: range of records to be displayed from some position, an index to be scrolled to, an index of a focused row, a search string, specified filter value, sorting configuration, selected rows ids, folded rows ids, current page, and page size."
+      }
+    ]
+  },
+  {
+    "data": {},
+    "type": "paragraph",
+    "children": [
+      {
+        "text": "It is usually held in the component's state. Changing the "
+      },
+      {
+        "text": "DataSource",
+        "uui-richTextEditor-code": true
+      },
+      {
+        "text": " state causes a change of rows, which are displayed (returned by "
+      },
+      {
+        "text": "DataSource",
+        "uui-richTextEditor-code": true
+      },
+      {
+        "text": "). "
       }
     ]
   }
-}
+]

--- a/public/docs/content/examples-virtualList-Advanced.json
+++ b/public/docs/content/examples-virtualList-Advanced.json
@@ -1,298 +1,180 @@
-{
-  "object": "value",
-  "document": {
-    "object": "document",
+[
+  {
     "data": {},
-    "nodes": [
+    "type": "paragraph",
+    "children": [
       {
-        "object": "block",
-        "type": "paragraph",
+        "text": "In case the standard "
+      },
+      {
+        "text": "VirtualList",
+        "uui-richTextEditor-code": true
+      },
+      {
+        "text": " doesn't fit you, we provide a separate "
+      },
+      {
+        "text": "useVirtualList",
+        "uui-richTextEditor-code": true
+      },
+      {
+        "text": "  ",
+        "uui-richTextEditor-italic": true
+      },
+      {
+        "text": "hook in case you would like to build something your own based on it."
+      }
+    ]
+  },
+  {
+    "data": {},
+    "type": "paragraph",
+    "children": [
+      {
+        "text": "\n"
+      },
+      {
+        "text": "useVirtualList",
+        "uui-richTextEditor-code": true
+      },
+      {
+        "text": " hook returns the following api:"
+      }
+    ]
+  },
+  {
+    "data": {},
+    "type": "paragraph",
+    "children": [
+      {
         "data": {},
-        "nodes": [
+        "type": "unordered-list",
+        "children": [
           {
-            "object": "text",
-            "text": "In case the standard ",
-            "marks": []
-          },
-          {
-            "object": "text",
-            "text": "VirtualList",
-            "marks": [
+            "data": {},
+            "type": "list-item",
+            "children": [
               {
-                "object": "mark",
-                "type": "uui-richTextEditor-code",
-                "data": {}
+                "data": {},
+                "type": "list-item-child",
+                "children": [
+                  {
+                    "text": "scrollContainerRef",
+                    "uui-richTextEditor-code": true
+                  },
+                  {
+                    "text": " - ref to scroll container. This should be a DOM Element with scrollbars inside. We'll use this ref to calculate the estimated height of the list precisely."
+                  }
+                ]
               }
             ]
           },
           {
-            "object": "text",
-            "text": " doesn't fit you, we provide a separate ",
-            "marks": []
-          },
-          {
-            "object": "text",
-            "text": "useVirtualList",
-            "marks": [
+            "data": {},
+            "type": "list-item",
+            "children": [
               {
-                "object": "mark",
-                "type": "uui-richTextEditor-code",
-                "data": {}
+                "data": {},
+                "type": "list-item-child",
+                "children": [
+                  {
+                    "text": "listContainerRef",
+                    "uui-richTextEditor-code": true
+                  },
+                  {
+                    "text": " - ref to the list wrapper that is going to be virtualized."
+                  }
+                ]
               }
             ]
           },
           {
-            "object": "text",
-            "text": "  ",
-            "marks": [
+            "data": {},
+            "type": "list-item",
+            "children": [
               {
-                "object": "mark",
-                "type": "uui-richTextEditor-italic",
-                "data": {}
+                "data": {},
+                "type": "list-item-child",
+                "children": [
+                  {
+                    "text": "estimatedHeight",
+                    "uui-richTextEditor-code": true
+                  },
+                  {
+                    "text": " - to measure the approximate height of the list."
+                  }
+                ]
               }
             ]
           },
           {
-            "object": "text",
-            "text": "hook in case you would like to build something your own based on it.",
-            "marks": []
+            "data": {},
+            "type": "list-item",
+            "children": [
+              {
+                "data": {},
+                "type": "list-item-child",
+                "children": [
+                  {
+                    "text": "offsetY",
+                    "uui-richTextEditor-code": true
+                  },
+                  {
+                    "text": " - must be provided in case listContainer and scrollContainer are different."
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "data": {},
+            "type": "list-item",
+            "children": [
+              {
+                "data": {},
+                "type": "list-item-child",
+                "children": [
+                  {
+                    "text": "handleScroll",
+                    "uui-richTextEditor-code": true
+                  },
+                  {
+                    "text": " - must be applied to the container as a scroll event handler."
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "data": {},
+            "type": "list-item",
+            "children": [
+              {
+                "data": {},
+                "type": "list-item-child",
+                "children": [
+                  {
+                    "text": "scrollToIndex",
+                    "uui-richTextEditor-code": true
+                  },
+                  {
+                    "text": " - to scroll to a particular item."
+                  }
+                ]
+              }
+            ]
           }
         ]
       },
       {
-        "object": "block",
-        "type": "paragraph",
         "data": {},
-        "nodes": [
-          {
-            "object": "text",
-            "text": "\n",
-            "marks": []
-          },
-          {
-            "object": "text",
-            "text": "useVirtualList",
-            "marks": [
-              {
-                "object": "mark",
-                "type": "uui-richTextEditor-code",
-                "data": {}
-              }
-            ]
-          },
-          {
-            "object": "text",
-            "text": " hook returns the following api:",
-            "marks": []
-          }
-        ]
-      },
-      {
-        "object": "block",
         "type": "paragraph",
-        "data": {},
-        "nodes": [
+        "children": [
           {
-            "object": "block",
-            "type": "unordered-list",
-            "data": {},
-            "nodes": [
-              {
-                "object": "block",
-                "type": "list-item",
-                "data": {},
-                "nodes": [
-                  {
-                    "object": "block",
-                    "type": "list-item-child",
-                    "data": {},
-                    "nodes": [
-                      {
-                        "object": "text",
-                        "text": "scrollContainerRef",
-                        "marks": [
-                          {
-                            "object": "mark",
-                            "type": "uui-richTextEditor-code",
-                            "data": {}
-                          }
-                        ]
-                      },
-                      {
-                        "object": "text",
-                        "text": " - ref to scroll container. This should be a DOM Element with scrollbars inside. We'll use this ref to calculate the estimated height of the list precisely.",
-                        "marks": []
-                      }
-                    ]
-                  }
-                ]
-              },
-              {
-                "object": "block",
-                "type": "list-item",
-                "data": {},
-                "nodes": [
-                  {
-                    "object": "block",
-                    "type": "list-item-child",
-                    "data": {},
-                    "nodes": [
-                      {
-                        "object": "text",
-                        "text": "listContainerRef",
-                        "marks": [
-                          {
-                            "object": "mark",
-                            "type": "uui-richTextEditor-code",
-                            "data": {}
-                          }
-                        ]
-                      },
-                      {
-                        "object": "text",
-                        "text": " - ref to the list wrapper that is going to be virtualized.",
-                        "marks": []
-                      }
-                    ]
-                  }
-                ]
-              },
-              {
-                "object": "block",
-                "type": "list-item",
-                "data": {},
-                "nodes": [
-                  {
-                    "object": "block",
-                    "type": "list-item-child",
-                    "data": {},
-                    "nodes": [
-                      {
-                        "object": "text",
-                        "text": "estimatedHeight",
-                        "marks": [
-                          {
-                            "object": "mark",
-                            "type": "uui-richTextEditor-code",
-                            "data": {}
-                          }
-                        ]
-                      },
-                      {
-                        "object": "text",
-                        "text": " - to measure the approximate height of the list.",
-                        "marks": []
-                      }
-                    ]
-                  }
-                ]
-              },
-              {
-                "object": "block",
-                "type": "list-item",
-                "data": {},
-                "nodes": [
-                  {
-                    "object": "block",
-                    "type": "list-item-child",
-                    "data": {},
-                    "nodes": [
-                      {
-                        "object": "text",
-                        "text": "offsetY",
-                        "marks": [
-                          {
-                            "object": "mark",
-                            "type": "uui-richTextEditor-code",
-                            "data": {}
-                          }
-                        ]
-                      },
-                      {
-                        "object": "text",
-                        "text": " - must be provided in case listContainer and scrollContainer are different.",
-                        "marks": []
-                      }
-                    ]
-                  }
-                ]
-              },
-              {
-                "object": "block",
-                "type": "list-item",
-                "data": {},
-                "nodes": [
-                  {
-                    "object": "block",
-                    "type": "list-item-child",
-                    "data": {},
-                    "nodes": [
-                      {
-                        "object": "text",
-                        "text": "handleScroll",
-                        "marks": [
-                          {
-                            "object": "mark",
-                            "type": "uui-richTextEditor-code",
-                            "data": {}
-                          }
-                        ]
-                      },
-                      {
-                        "object": "text",
-                        "text": " - must be applied to the container as a scroll event handler.",
-                        "marks": []
-                      }
-                    ]
-                  }
-                ]
-              },
-              {
-                "object": "block",
-                "type": "list-item",
-                "data": {},
-                "nodes": [
-                  {
-                    "object": "block",
-                    "type": "list-item-child",
-                    "data": {},
-                    "nodes": [
-                      {
-                        "object": "text",
-                        "text": "scrollToIndex",
-                        "marks": [
-                          {
-                            "object": "mark",
-                            "type": "uui-richTextEditor-code",
-                            "data": {}
-                          }
-                        ]
-                      },
-                      {
-                        "object": "text",
-                        "text": " - to scroll to a particular item.",
-                        "marks": []
-                      }
-                    ]
-                  }
-                ]
-              }
-            ]
-          },
-          {
-            "object": "block",
-            "type": "paragraph",
-            "data": {},
-            "nodes": [
-              {
-                "object": "text",
-                "text": "In this example, we show how to make a virtualized list when scrollContainer is a whole page with a header(which dont't need to be virtualized), with a list of items inside.",
-                "marks": []
-              }
-            ]
+            "text": "In this example, we show how to make a virtualized list when scrollContainer is a whole page with a header(which dont't need to be virtualized), with a list of items inside."
           }
         ]
       }
     ]
   }
-}
+]

--- a/public/docs/content/examples-virtualList-ScrollTo.json
+++ b/public/docs/content/examples-virtualList-ScrollTo.json
@@ -49,7 +49,7 @@
     ]
   },
   {
-    "type": "paragraph",
+    "type": "note-warning",
     "children": [
       {
         "text": "For accurate scrolling to the position of the expected row, it is required to provide rows of the same height."

--- a/public/docs/content/examples-virtualList-ScrollTo.json
+++ b/public/docs/content/examples-virtualList-ScrollTo.json
@@ -24,5 +24,13 @@
         "text": ". it accepts an object with an index of an element that you want to scroll to and updates the scroll position if a link to an object is updated."
       }
     ]
+  },
+  {
+    "type": "paragraph",
+    "children": [
+      {
+        "text": "For accurate scrolling to the position of the expected row, it is required to provide rows of the same height."
+      }
+    ]
   }
 ]

--- a/public/docs/content/examples-virtualList-ScrollTo.json
+++ b/public/docs/content/examples-virtualList-ScrollTo.json
@@ -21,7 +21,30 @@
         "text": "state"
       },
       {
-        "text": ". it accepts an object with an index of an element that you want to scroll to and updates the scroll position if a link to an object is updated."
+        "text": ". it accepts an object with an index of an element that you want to scroll to and updates the scroll position if a reference to an object is updated."
+      }
+    ]
+  },
+  {
+    "type": "paragraph",
+    "children": [
+      {
+        "text": "Note, that scroll will occur only once, after this setState. On further renderings, scrollTo will point to the same object, so no scrolling will occur. To trigger scroll again - assign a new object to this prop. It would trigger a scroll again, even if an index value is the same."
+      }
+    ]
+  },
+  {
+    "type": "paragraph",
+    "children": [
+      {
+        "text": "For example, to scroll to the element with index 100, call "
+      },
+      {
+        "text": "setState({ ...state, scrollTo: { index: 100 } })",
+        "uui-richTextEditor-code": true
+      },
+      {
+        "text": "."
       }
     ]
   },

--- a/public/docs/content/examples-virtualList-ScrollTo.json
+++ b/public/docs/content/examples-virtualList-ScrollTo.json
@@ -1,0 +1,28 @@
+[
+  {
+    "type": "paragraph",
+    "children": [
+      {
+        "text": "VirtualList",
+        "uui-richTextEditor-code": true
+      },
+      {
+        "text": " supports "
+      },
+      {
+        "text": "scrollTo",
+        "uui-richTextEditor-code": true
+      },
+      {
+        "text": " as a part of the "
+      },
+      {
+        "uui-richTextEditor-code": true,
+        "text": "state"
+      },
+      {
+        "text": ". it accepts an object with an index of an element that you want to scroll to and updates the scroll position if a link to an object is updated."
+      }
+    ]
+  }
+]

--- a/uui-components/src/layout/VirtualList.tsx
+++ b/uui-components/src/layout/VirtualList.tsx
@@ -31,6 +31,10 @@ interface BaseVirtualListProps<ScrollContainer extends HTMLElement = any>
     rowsCount?: number;
     role?: React.HTMLAttributes<HTMLDivElement>['role'];
     onScroll?(value: PositionValues): void;
+    /**
+     * Selector of `VirtualList` rows.
+     * @default '[role=row]'
+     */
     rowsSelector?: string;
 }
 

--- a/uui-core/src/hooks/useVirtualList/types.ts
+++ b/uui-core/src/hooks/useVirtualList/types.ts
@@ -35,6 +35,11 @@ export interface UseVirtualListProps extends IEditable<VirtualListState> {
     overdrawRows?: number;
 
     onScroll?(value: Partial<UuiScrollPositionValues>): void;
+
+    /**
+     * Selector of `VirtualList` rows.
+     * @default '[role=row]'
+     */
     rowsSelector?: string;
 }
 
@@ -57,5 +62,10 @@ export interface VirtualListInfo {
     listOffset: number | undefined | null;
     estimatedHeight?: number;
     averageRowHeight?: number;
+
+    /**
+     * Selector of `VirtualList` rows.
+     * @default '[role=row]'
+     */
     rowsSelector: string;
 }

--- a/uui-core/src/hooks/useVirtualList/useVirtualList.ts
+++ b/uui-core/src/hooks/useVirtualList/useVirtualList.ts
@@ -130,10 +130,15 @@ export function useVirtualList<List extends HTMLElement = any, ScrollContainer e
         (index: number, behavior?: ScrollBehavior) => {
             const [wasScrolled, ok] = scrollContainerToIndex(index, behavior);
             const topIndex = getTopIndexWithOffset(index, overdrawRows, blockSize);
+            const shouldScrollToUnknownIndex = value.topIndex === topIndex && rowsCount <= value.scrollTo?.index;
             if ((ok && !wasScrolled) || value.topIndex !== topIndex) {
-                onValueChange({ ...value, topIndex, scrollTo: value.scrollTo?.index === index ? value.scrollTo : { index } });
+                let scrollTo = value.scrollTo?.index === index ? value.scrollTo : { index };
+                if (shouldScrollToUnknownIndex) {
+                    scrollTo = { index: rowsCount - 1 };
+                }
+                onValueChange({ ...value, topIndex, scrollTo });
             }
-            if (ok && wasScrolled) {
+            if ((ok && wasScrolled) || (shouldScrollToUnknownIndex)) {
                 setScrolledTo(value.scrollTo?.index === index ? value.scrollTo : { index });
             }
         },

--- a/uui-docs/src/dataSources/DataSourceViewer.tsx
+++ b/uui-docs/src/dataSources/DataSourceViewer.tsx
@@ -63,6 +63,7 @@ export function DataSourceViewer<TItem, TId>(props: Props<TItem, TId>) {
                     rows={ renderedRows }
                     { ...listProps }
                     cx={ css.list }
+                    rowsSelector="[role=option]"
                 />
             </FlexRow>
             <FlexRow cx={ css.row }>

--- a/uui/components/pickers/__tests__/__snapshots__/PickerInput.test.tsx.snap
+++ b/uui/components/pickers/__tests__/__snapshots__/PickerInput.test.tsx.snap
@@ -37,7 +37,6 @@ exports[`PickerInput should open body 1`] = `
     data-no-focus-lock="true"
   >
     <div
-      aria-expanded="true"
       aria-hidden="false"
       class="uui-popper"
       data-placement="bottom-start"


### PR DESCRIPTION
### Summary
- FIxed bug, related to infinity loop while scrolling to the index, higher that rowsCount (ArrayListView).
- FIxed examples of dataSources and virtualList docs.
- Added example of scrollTo to VirtualList docs.
- Added example to scrollTo to DataSourceState docs.