### PR TITLE
[Modals]: controls are not visible if the modal window does not fit on the screen

### DIFF
--- a/uui/components/overlays/Modals.module.scss
+++ b/uui/components/overlays/Modals.module.scss
@@ -24,7 +24,7 @@
 
         @media (max-width: 640px) {
             min-width: 100vw;
-            max-height: 100vh;
+            max-height: 100dvh;
             border-radius: 0;
         }
 


### PR DESCRIPTION
### Issue:
https://github.com/epam/UUI/issues/1136 

### Description:
To avoid overlapping we used dynamic viewport, the size depending on whether the address bar is visible

|   |  |
| ------------- | ------------- |
| <img width="1071" alt="Screenshot 2023-08-31 at 19 06 17" src="https://github.com/epam/UUI/assets/26334961/002249bd-8363-4360-9612-e43bcdad0af0"> | <img width="948" alt="Screenshot 2023-08-31 at 19 11 18" src="https://github.com/epam/UUI/assets/26334961/8427e4a0-66d2-43a7-911d-3ec95ab77c7f"> |
| <img width="716" alt="Screenshot 2023-08-31 at 19 15 02" src="https://github.com/epam/UUI/assets/26334961/2ed671b8-1e08-4c2f-b31f-db66567032be">  | <img width="864" alt="Screenshot 2023-08-31 at 19 26 38" src="https://github.com/epam/UUI/assets/26334961/bf501076-8ed3-4c07-8262-5a51cc5b8df9">  |





