### PR TITLE
[VirtualList]: changed default rows selector to children of listContainer

### DIFF
--- a/app/src/docs/_examples/dataSources/DataSourceViewer.code.example.tsx
+++ b/app/src/docs/_examples/dataSources/DataSourceViewer.code.example.tsx
@@ -61,7 +61,6 @@ export function DataSourceViewer<TItem, TId>(props: Props<TItem, TId>) {
                     onValueChange={ onValueChange }
                     rows={ renderedRows }
                     { ...listProps }
-                    rowsSelector="[role=option]"
                 />
             </FlexRow>
             <FlexRow>

--- a/uui-components/src/layout/VirtualList.tsx
+++ b/uui-components/src/layout/VirtualList.tsx
@@ -31,10 +31,6 @@ interface BaseVirtualListProps<ScrollContainer extends HTMLElement = any>
     rowsCount?: number;
     role?: React.HTMLAttributes<HTMLDivElement>['role'];
     onScroll?(value: PositionValues): void;
-    /**
-     * Selector of `VirtualList` rows.
-     * @default '[role=row]'
-     */
     rowsSelector?: string;
     disableScroll?: boolean;
 }

--- a/uui-core/src/hooks/__tests__/useVirtualList/utils.test.ts
+++ b/uui-core/src/hooks/__tests__/useVirtualList/utils.test.ts
@@ -22,7 +22,6 @@ describe('getUpdatedRowHeights', () => {
         rowHeights,
         rowOffsets: [],
         listOffset: 10,
-        rowsSelector: '[role=row]',
     });
 
     it('should update row heights, starting from topIndex', () => {
@@ -86,7 +85,6 @@ describe('getUpdatedRowOffsets', () => {
         listOffset: 50,
         estimatedHeight: undefined,
         averageRowHeight: 15,
-        rowsSelector: '[role=row]',
     };
 
     it('should update row offsets', () => {
@@ -129,7 +127,6 @@ describe('getUpdatedRowsInfo', () => {
         listOffset: 50,
         estimatedHeight: 20,
         averageRowHeight: 15,
-        rowsSelector: '[role=row]',
     };
     it('should return old values if scroll container is not defined', () => {
         const info = {
@@ -233,7 +230,6 @@ describe('getRowsToFetchForScroll', () => {
         listOffset: 50,
         estimatedHeight: 20,
         averageRowHeight: 15,
-        rowsSelector: '[role=row]',
     };
 
     it('should limit topIndex with rowsCount', () => {
@@ -338,7 +334,6 @@ describe('getTopCoordinate', () => {
         listOffset: 50,
         estimatedHeight: 20,
         averageRowHeight: 15,
-        rowsSelector: '[role=row]',
     };
     it('should get top coordinate for index to scroll by rowOffset', () => {
         const info: VirtualListInfo = {

--- a/uui-core/src/hooks/useVirtualList/types.ts
+++ b/uui-core/src/hooks/useVirtualList/types.ts
@@ -38,7 +38,6 @@ export interface UseVirtualListProps extends IEditable<VirtualListState> {
 
     /**
      * Selector of `VirtualList` rows.
-     * @default '[role=row]'
      */
     rowsSelector?: string;
 }
@@ -62,10 +61,5 @@ export interface VirtualListInfo {
     listOffset: number | undefined | null;
     estimatedHeight?: number;
     averageRowHeight?: number;
-
-    /**
-     * Selector of `VirtualList` rows.
-     * @default '[role=row]'
-     */
-    rowsSelector: string;
+    rowsSelector?: string;
 }

--- a/uui-core/src/hooks/useVirtualList/useVirtualList.ts
+++ b/uui-core/src/hooks/useVirtualList/useVirtualList.ts
@@ -17,7 +17,7 @@ export function useVirtualList<List extends HTMLElement = any, ScrollContainer e
         onScroll,
         blockSize = 20,
         overdrawRows = 20,
-        rowsSelector = '[role=row]',
+        rowsSelector,
     } = props;
     const [estimatedHeight, setEstimatedHeight] = React.useState<number>(0);
     const [listOffset, setListOffset] = React.useState<number>();

--- a/uui-core/src/hooks/useVirtualList/utils.ts
+++ b/uui-core/src/hooks/useVirtualList/utils.ts
@@ -3,9 +3,12 @@ import { RowsInfo, VirtualListInfo } from './types';
 
 export const getUpdatedRowHeights = (virtualListInfo: VirtualListInfo) => {
     const newRowHeights = [...virtualListInfo.rowHeights];
-    Array.from<Element>(
-        virtualListInfo.listContainer.querySelectorAll(virtualListInfo.rowsSelector),
-    ).forEach((node, index) => {
+    const { listContainer, rowsSelector } = virtualListInfo;
+    const rows = rowsSelector
+        ? listContainer.querySelectorAll(rowsSelector)
+        : listContainer.children;
+
+    Array.from<Element>(rows).forEach((node, index) => {
         const topIndex = virtualListInfo.value.topIndex || 0;
         const { height } = node.getBoundingClientRect();
         if (!height) return;

--- a/uui-docs/src/dataSources/DataSourceViewer.tsx
+++ b/uui-docs/src/dataSources/DataSourceViewer.tsx
@@ -63,7 +63,6 @@ export function DataSourceViewer<TItem, TId>(props: Props<TItem, TId>) {
                     rows={ renderedRows }
                     { ...listProps }
                     cx={ css.list }
-                    rowsSelector="[role=option]"
                 />
             </FlexRow>
             <FlexRow cx={ css.row }>

--- a/uui/components/pickers/DataPickerBody.tsx
+++ b/uui/components/pickers/DataPickerBody.tsx
@@ -70,7 +70,6 @@ export class DataPickerBody extends PickerBodyBase<DataPickerBodyProps> {
                             renderRows={ this.renderRowsContainer }
                             rawProps={ this.props.rawProps }
                             rowsCount={ this.props.rowsCount }
-                            rowsSelector="[role=option]"
                             disableScroll={ this.props.isReloading }
                         />
                     ) : (this.renderNotFound())}

--- a/uui/components/tables/DataTable.tsx
+++ b/uui/components/tables/DataTable.tsx
@@ -137,6 +137,7 @@ export function DataTable<TItem, TId>(props: React.PropsWithChildren<DataTablePr
                 renderRows={ renderRowsContainer }
                 cx={ cx(css.table) }
                 disableScroll={ props.isReloading }
+                rowsSelector="[role=row]"
                 rawProps={ {
                     role: 'table',
                     'aria-colcount': columns.length,


### PR DESCRIPTION
### Summary

Changed default rows selector to children of `listContainer` to prevent breaking of consumer's components.
