### PR TITLE
[PickerInput]: Unexpected 'v' icon is displayed and  Incorrect top and bottom padding in drop-down list with two lines text 

### DIFF
--- a/uui-components/src/pickers/PickerToggler.tsx
+++ b/uui-components/src/pickers/PickerToggler.tsx
@@ -199,7 +199,7 @@ function PickerTogglerComponent<TItem, TId>(props: PickerTogglerProps<TItem, TId
                             rawProps={ { role: 'button', 'aria-label': 'Clear' } }
                         />
                     )}
-                    {props.isDropdown && <IconContainer icon={ props.dropdownIcon } flipY={ props.isOpen } cx="uui-icon-dropdown" onClick={ closeOpenedPickerBody } />}
+                    {props.isDropdown && !props?.minCharsToSearch && <IconContainer icon={ props.dropdownIcon } flipY={ props.isOpen } cx="uui-icon-dropdown" onClick={ closeOpenedPickerBody } />}
                 </div>
             )}
         </div>

--- a/uui/components/pickers/PickerItem.module.scss
+++ b/uui/components/pickers/PickerItem.module.scss
@@ -23,8 +23,4 @@
         padding-top: 9px;
         padding-bottom: 9px;
     }
-
-    .text {
-        padding: 0;
-    }
 }

--- a/uui/components/pickers/__tests__/PickerInput.test.tsx
+++ b/uui/components/pickers/__tests__/PickerInput.test.tsx
@@ -3,7 +3,7 @@ import { ArrayDataSource, CascadeSelection } from '@epam/uui-core';
 import {
     renderSnapshotWithContextAsync, setupComponentForTest, screen, within, fireEvent, waitFor, userEvent, PickerInputTestObject,
 } from '@epam/uui-test-utils';
-import { Modals, PickerInputBaseProps } from '@epam/uui-components';
+import { Modals, PickerInputBaseProps, PickerToggler } from '@epam/uui-components';
 import { Button, DataPickerRow, FlexCell, PickerItem, Text } from '@epam/promo';
 import { PickerInput, PickerInputProps } from '../PickerInput';
 import { IHasEditMode } from '../../types';
@@ -137,7 +137,7 @@ describe('PickerInput', () => {
             fireEvent.click(clear);
             expect(screen.queryByText('C2')).not.toBeInTheDocument();
         });
-        
+
         it('[valueType entity] should select & clear option', async () => {
             const { dom, mocks } = await setupPickerInputForTest({
                 value: undefined,
@@ -208,7 +208,7 @@ describe('PickerInput', () => {
                 dataSource: mockTreeLikeDataSourceAsync,
             });
             fireEvent.click(dom.input);
- 
+
             await PickerInputTestObject.waitForOptionsToBeReady();
 
             // Check parent
@@ -509,7 +509,7 @@ describe('PickerInput', () => {
             await PickerInputTestObject.clickClearAllOptions();
             expect(PickerInputTestObject.getSelectedTagsText(dom.input)).toEqual([]);
         });
- 
+
         it('should show only selected', async () => {
             const { dom } = await setupPickerInputForTest<TestItemType, number>({
                 value: [4, 2, 6, 8],
@@ -520,12 +520,12 @@ describe('PickerInput', () => {
 
             const dialog = await screen.findByRole('dialog');
             expect(dialog).toBeInTheDocument();
-            
+
             await PickerInputTestObject.waitForOptionsToBeReady();
 
             expect(await PickerInputTestObject.findCheckedOptions()).toEqual(['A1', 'A2', 'B1', 'B2']);
             expect(await PickerInputTestObject.findUncheckedOptions()).toEqual(['A1+', 'A2+', 'B1+', 'B2+', 'C1', 'C1+', 'C2']);
-            
+
             await PickerInputTestObject.clickShowOnlySelected();
 
             expect(await PickerInputTestObject.findCheckedOptions()).toEqual(['A2', 'A1', 'B1', 'B2']);
@@ -739,18 +739,43 @@ describe('PickerInput', () => {
         expect(screen.getByTestId('test-toggler').textContent?.trim()).toEqual('Elementary, Elementary+');
     });
 
+    it('Should render toggler without arrow icon', async () => {
+        const { dom } = await setupPickerInputForTest({
+            value: undefined,
+            selectionMode: 'single',
+            entityName: 'Language Level',
+            searchPosition: 'input',
+            renderToggler: () => <PickerToggler dropdownIcon={ () => <div data-testid = "arrow-icon" /> } pickerMode="single" searchPosition="none" closePickerBody={ () => {} } />,
+            minCharsToSearch: 3,
+        });
+
+        expect(within(dom.container).queryByTestId('arrow-icon')).not.toBeInTheDocument();
+    });
+
+    it('Should render toggler with arrow icon', async () => {
+        const { dom } = await setupPickerInputForTest({
+            value: undefined,
+            selectionMode: 'single',
+            entityName: 'Language Level',
+            renderToggler: () => <PickerToggler isDropdown dropdownIcon={ () => <div data-testid = "arrow-icon" /> } pickerMode="single" searchPosition="none" closePickerBody={ () => {} } />,
+            minCharsToSearch: undefined,
+        });
+
+        expect(within(dom.container).getByTestId('arrow-icon')).toBeInTheDocument();
+    });
+
     it('should render search in input', async () => {
         const { dom } = await setupPickerInputForTest({
             value: undefined,
             selectionMode: 'multi',
             searchPosition: 'input',
         });
-        
+
         expect(dom.input.getAttribute('readonly')).toBeNull();
         fireEvent.click(dom.input);
         const dialog = await screen.findByRole('dialog');
         expect(dialog).toBeInTheDocument();
-        
+
         const bodyInput = within(dialog).queryByPlaceholderText('Search');
         expect(bodyInput).not.toBeInTheDocument();
     });
@@ -844,7 +869,7 @@ describe('PickerInput', () => {
             'Proficiency',
         ]);
     });
-    
+
     it('should search items', async () => {
         const { dom } = await setupPickerInputForTest<TestItemType, number>({
             value: undefined,
@@ -858,7 +883,7 @@ describe('PickerInput', () => {
 
         const dialog = await screen.findByRole('dialog');
         expect(dialog).toBeInTheDocument();
-        
+
         await PickerInputTestObject.waitForOptionsToBeReady();
 
         expect(await PickerInputTestObject.findOptionsText({ busy: false })).toEqual([

--- a/uui/components/pickers/__tests__/__snapshots__/PickerInput.test.tsx.snap
+++ b/uui/components/pickers/__tests__/__snapshots__/PickerInput.test.tsx.snap
@@ -466,15 +466,6 @@ exports[`PickerInput should render with maximum props 1`] = `
         className=""
       />
     </div>
-    <div
-      className="container uui-icon uui-enabled -clickable uui-icon-dropdown"
-      onClick={[Function]}
-      style={Object {}}
-    >
-      <svg
-        className=""
-      />
-    </div>
   </div>
 </div>
 `;


### PR DESCRIPTION
### Issue link:
https://github.com/epam/UUI/issues/1593 
https://github.com/epam/UUI/issues/1589

### Description:
- Removed the dropdown icon if `minCharsToSearch` props exist. 
- Removed padding 0 from text picker input.
<img width="1375" alt="Screenshot 2023-09-07 at 19 28 46" src="https://github.com/epam/UUI/assets/26334961/1ee4c8ef-a5b2-451c-b89a-4ae599d74160">
