### PR TITLE
[PickerInput]: fix paddings for multiline pickers

### DIFF
--- a/uui/components/pickers/PickerItem.module.scss
+++ b/uui/components/pickers/PickerItem.module.scss
@@ -1,26 +1,32 @@
 .root {
-    .multiline-vertical-padding-24 {
-        padding-top: 3px;
-        padding-bottom: 3px;
-    }
+    .multiline {
+        &.vertical-padding-24 {
+            padding-top: 3px;
+            padding-bottom: 3px;
+        }
 
-    .multiline-vertical-padding-30 {
-        padding-top: 6px;
-        padding-bottom: 6px;
-    }
+        &.vertical-padding-30 {
+            padding-top: 6px;
+            padding-bottom: 6px;
+        }
 
-    .multiline-vertical-padding-36 {
-        padding-top: 6px;
-        padding-bottom: 6px;
-    }
+        &.vertical-padding-36 {
+            padding-top: 6px;
+            padding-bottom: 6px;
+        }
 
-    .multiline-vertical-padding-42 {
-        padding-top: 9px;
-        padding-bottom: 9px;
-    }
+        &.vertical-padding-42 {
+            padding-top: 9px;
+            padding-bottom: 9px;
+        }
 
-    .multiline-vertical-padding-48 {
-        padding-top: 9px;
-        padding-bottom: 9px;
+        &.vertical-padding-48 {
+            padding-top: 9px;
+            padding-bottom: 9px;
+        }
+
+        .text {
+            padding: 0;
+        }
     }
 }

--- a/uui/components/pickers/PickerItem.tsx
+++ b/uui/components/pickers/PickerItem.tsx
@@ -16,15 +16,15 @@ export interface PickerItemProps<TItem, TId> extends DataRowProps<TItem, TId>, S
     title?: string;
     subtitle?: string;
     dataSourceState?: DataSourceState;
-    /** 
-     * Enables highlighting of the items' text with search-matching results. 
+    /**
+     * Enables highlighting of the items' text with search-matching results.
      * @default true
      * */
     highlightSearchMatches?: boolean;
 }
 export class PickerItem<TItem, TId> extends React.Component<PickerItemProps<TItem, TId>> {
     public static defaultProps = {
-        highlightSearchMatches: true,   
+        highlightSearchMatches: true,
     };
 
     getAvatarSize = (size: string, isMultiline: boolean): string | number => {
@@ -44,7 +44,7 @@ export class PickerItem<TItem, TId> extends React.Component<PickerItemProps<TIte
 
         return (
             <FlexCell width="auto" cx={ [css.root, cx] }>
-                <FlexRow size={ itemSize } cx={ isMultiline && css[`multiline-vertical-padding-${itemSize}`] } spacing="12">
+                <FlexRow size={ itemSize } cx={ isMultiline && [css.multiline, css[`vertical-padding-${itemSize}`]] } spacing="12">
                     {avatarUrl && <Avatar isLoading={ isLoading } img={ avatarUrl } size={ this.getAvatarSize(itemSize, isMultiline).toString() as AvatarProps['size'] } />}
                     {icon && <IconContainer icon={ icon } />}
                     <FlexCell width="auto">


### PR DESCRIPTION
### Description:
Issue with padding for `multiline` picker inputs.
<img width="553" alt="Screenshot 2023-09-13 at 18 41 17" src="https://github.com/epam/UUI/assets/26334961/980093cd-bb86-430b-bfd2-cc8e1b88dd29">
