### PR TITLE
Fix template apps

### DIFF
--- a/templates/uui-cra-template/template.json
+++ b/templates/uui-cra-template/template.json
@@ -18,7 +18,7 @@
       "@epam/uui-test-utils": "latest",
       "@testing-library/jest-dom": "^5.16.5",
       "@types/jest": "^27.5.2",
-      "@types/react": "18.2.0",
+      "@types/react": "^18",
       "@types/react-router-dom": "^5.3.3",
       "@types/history": "4.7.11",
       "@types/node": "16.18.4"

--- a/templates/uui-cra-template/template.json
+++ b/templates/uui-cra-template/template.json
@@ -19,7 +19,6 @@
       "@testing-library/jest-dom": "^5.16.5",
       "@types/jest": "^27.5.2",
       "@types/react": "18.2.0",
-      "@types/react-dom": "18.2.0",
       "@types/react-router-dom": "^5.3.3",
       "@types/history": "4.7.11",
       "@types/node": "16.18.4"

--- a/templates/uui-cra-template/template.json
+++ b/templates/uui-cra-template/template.json
@@ -18,13 +18,16 @@
       "@epam/uui-test-utils": "latest",
       "@testing-library/jest-dom": "^5.16.5",
       "@types/jest": "^27.5.2",
-      "@types/react": "^18",
+      "@types/react": "18.2.21",
       "@types/react-router-dom": "^5.3.3",
       "@types/history": "4.7.11",
       "@types/node": "16.18.4"
     },
     "eslintConfig": {
       "extends": ["react-app", "react-app/jest"]
+    },
+    "resolutions": {
+      "@types/react": "18.2.21"
     }
   }
 }

--- a/templates/uui-vite-template/package.json
+++ b/templates/uui-vite-template/package.json
@@ -27,7 +27,7 @@
     "@epam/uui-test-utils": "latest",
     "@testing-library/jest-dom": "^5.16.5",
     "@types/jest": "^27.5.2",
-    "@types/react": "^18",
+    "@types/react": "18.2.21",
     "@types/react-router-dom": "^5.3.3",
     "@vitejs/plugin-react": "^3.1.0",
     "jest": "^27.5.1",
@@ -45,5 +45,8 @@
     "eslint-plugin-jest": "^27.2.1",
     "@typescript-eslint/parser": "^5.59.7",
     "eslint-plugin-testing-library": "^5.11.0"
+  },
+  "resolutions": {
+    "@types/react": "18.2.21"
   }
 }

--- a/templates/uui-vite-template/package.json
+++ b/templates/uui-vite-template/package.json
@@ -27,7 +27,7 @@
     "@epam/uui-test-utils": "latest",
     "@testing-library/jest-dom": "^5.16.5",
     "@types/jest": "^27.5.2",
-    "@types/react": "18.2.0",
+    "@types/react": "^18",
     "@types/react-router-dom": "^5.3.3",
     "@vitejs/plugin-react": "^3.1.0",
     "jest": "^27.5.1",

--- a/templates/uui-vite-template/package.json
+++ b/templates/uui-vite-template/package.json
@@ -28,7 +28,6 @@
     "@testing-library/jest-dom": "^5.16.5",
     "@types/jest": "^27.5.2",
     "@types/react": "18.2.0",
-    "@types/react-dom": "18.2.0",
     "@types/react-router-dom": "^5.3.3",
     "@vitejs/plugin-react": "^3.1.0",
     "jest": "^27.5.1",


### PR DESCRIPTION
The issue started to reproduce after @types/react v 18.2.22 was released. Two different versions of @types/react become added to the node_modules: latest version and the version we specified in package.json of our template. When I forced to use only latest version it still showed TS errors upon build. So I forced a previous (18.2.21) version instead.
