### PR TITLE
Bugfix/1663 dropdown menu button icon bug

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,7 @@
+# 5.1.4 - 14.10.2023
+**What's Fixed**
+* [DropdownMenuButton]: Fix issue in `DropdownMenuButton` where `isDisabled` prop was not being applied to it's child `IconButton`.
+
 # 5.1.3 - 31.08.2023
 
 **What's New**
@@ -80,8 +84,8 @@
 
 **Rich Text Editor component update and improvements**
 
-UUI `SlateEditor` was reworked and updated to the actual version of Slate.js framework. 
-During the update the previous code based of RTE almost completely rewritten due to a lot of breaking changes from Slate.js side. However, we put significant efforts to minimize breaking changes for our users. Therefore, update to the new version of `uui-editor` package should be seamless and easy. 
+UUI `SlateEditor` was reworked and updated to the actual version of Slate.js framework.
+During the update the previous code based of RTE almost completely rewritten due to a lot of breaking changes from Slate.js side. However, we put significant efforts to minimize breaking changes for our users. Therefore, update to the new version of `uui-editor` package should be seamless and easy.
 
 List of changes:
 * [Breaking change]: Changed RTE value format, now it's works with array instead of immutable.js object. Also, there are some additional changes inside slate value structure.

--- a/uui/components/overlays/DropdownMenu.tsx
+++ b/uui/components/overlays/DropdownMenu.tsx
@@ -107,6 +107,7 @@ export const DropdownMenuButton = React.forwardRef<any, IDropdownMenuItemProps>(
                 icon={ icon }
                 color={ isActive ? 'info' : 'default' }
                 onClick={ onIconClick }
+                isDisabled = { isDisabled }
                 cx={ cx(css.icon, iconPosition === 'right' ? css.iconAfter : css.iconBefore) }
             />
         );


### PR DESCRIPTION
<!-- **Before submitting your PR, ensure that you made the following:**

- Linked the issue(if exists)
- Lint and unit tests pass locally with my changes
- Changelog is updated or not needed
- Documentation is updated/provided or not needed
- Property explorer is updated/provided or not needed
- TSDoc comments for public interfaces is updated/provided or not needed 
 -->

#### Issue link: #1663  

### Description:
Upon investigation, it was found that isDisabled prop was not being passed to DropdownMenuButton's child IconButton. As a result, even if DropddownMenuButton was disabled, the icon would still look like enabled.