### PR TITLE
Bugfix/1663 dropdown menu button icon bug

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,7 @@
 * [DataTable]: added pinned rows functionality.
 
 **What's Fixed**
+* [DropdownMenuButton]: Fix bug in `DropdownMenuButton` where `isDisabled` prop was not being passed to it's child `IconButton`.
 * [PickerItem]: fixed 'cx' prop
 * [Contexts]: fixed context initialization for react 18 with strict mode
 * [ModalWindow]: changed role attribute value from 'modal' to 'dialog'

--- a/uui/components/overlays/DropdownMenu.tsx
+++ b/uui/components/overlays/DropdownMenu.tsx
@@ -108,6 +108,7 @@ export const DropdownMenuButton = React.forwardRef<any, IDropdownMenuItemProps>(
                 icon={ icon }
                 color={ isActive ? 'info' : 'default' }
                 onClick={ onIconClick }
+                isDisabled={ isDisabled }
                 cx={ cx(css.icon, iconPosition === 'right' ? css.iconAfter : css.iconBefore) }
             />
         );


### PR DESCRIPTION
<!-- **Before submitting your PR, ensure that you made the following:**

- Linked the issue(if exists)
- Lint and unit tests pass locally with my changes
- Changelog is updated or not needed
- Documentation is updated/provided or not needed
- Property explorer is updated/provided or not needed
- TSDoc comments for public interfaces is updated/provided or not needed 
 -->

#### Issue link(if exists): #1663 

### Description:
Upon investigation, it was found that isDisabled prop was not being passed to DropdownMenuButton's child IconButton. As a result, even if DropddownMenuButton was disabled, the icon would still look like enabled.

