### PR TITLE
[PickerInput]: fixed removing tags on pressing backspace.

### DIFF
--- a/uui-components/src/pickers/KeyboardUtils.tsx
+++ b/uui-components/src/pickers/KeyboardUtils.tsx
@@ -6,11 +6,12 @@ export interface DataSourceKeyboardParams extends IEditable<DataSourceState> {
     listView: IDataSourceView<any, any, any>;
     rows: DataRowProps<any, any>[];
     editMode?: 'dropdown' | 'modal';
+    searchPosition?: 'input' | 'body' | 'none';
 }
 
 export const handleDataSourceKeyboard = (params: DataSourceKeyboardParams, e: React.KeyboardEvent<HTMLElement>) => {
     const value = params.value;
-    let search = value.search;
+    const search = value.search;
 
     let focusedIndex = value.focusedIndex || 0;
     const maxVisibleIndex = value.topIndex + params.rows.length - 1;
@@ -18,8 +19,11 @@ export const handleDataSourceKeyboard = (params: DataSourceKeyboardParams, e: Re
     switch (e.key) {
         case 'Backspace': {
             const selectedRowsCount = params.listView.getSelectedRowsCount();
-            const selectedRows = params.listView.getSelectedRows({ topIndex: selectedRowsCount - 2, visibleCount: 1 });
-            if (params.editMode !== 'modal' && !value.search && value.checked && selectedRows.length > 0) {
+            const selectedRows = params.listView.getSelectedRows({ topIndex: selectedRowsCount - 1, visibleCount: 1 });
+            if (
+                params.editMode !== 'modal' && params.searchPosition === 'input'
+                && !value.search && value.checked && selectedRows.length > 0
+            ) {
                 const lastSelection = selectedRows[selectedRows.length - 1];
                 lastSelection.onCheck(lastSelection);
             }

--- a/uui-components/src/pickers/hooks/usePickerInput.ts
+++ b/uui-components/src/pickers/hooks/usePickerInput.ts
@@ -158,6 +158,7 @@ export function usePickerInput<TItem, TId, TProps>(props: UsePickerInputProps<TI
                 onValueChange: handleDataSourceValueChange,
                 listView: view,
                 editMode: props.editMode,
+                searchPosition: props.searchPosition,
                 rows,
             },
             e,

--- a/uui-components/src/pickers/hooks/usePickerInput.ts
+++ b/uui-components/src/pickers/hooks/usePickerInput.ts
@@ -140,7 +140,11 @@ export function usePickerInput<TItem, TId, TProps>(props: UsePickerInputProps<TI
 
     const shouldShowBody = () => (props.shouldShowBody ?? defaultShouldShowBody)();
 
-    const handlePickerInputKeyboard = (rows: DataSourceKeyboardParams['rows'], e: React.KeyboardEvent<HTMLElement>) => {
+    const handlePickerInputKeyboard = (
+        rows: DataSourceKeyboardParams['rows'],
+        e: React.KeyboardEvent<HTMLElement>,
+        actualSearch?: string,
+    ) => {
         if (props.isDisabled || props.isReadonly) return;
 
         if (e.key === 'Enter' && !opened) {
@@ -152,9 +156,10 @@ export function usePickerInput<TItem, TId, TProps>(props: UsePickerInputProps<TI
             toggleDropdownOpening(false);
         }
 
+        const value = getDataSourceState();
         handleDataSourceKeyboard(
             {
-                value: getDataSourceState(),
+                value: actualSearch !== undefined ? { ...value, search: actualSearch } : value,
                 onValueChange: handleDataSourceValueChange,
                 listView: view,
                 editMode: props.editMode,
@@ -262,7 +267,7 @@ export function usePickerInput<TItem, TId, TProps>(props: UsePickerInputProps<TI
         return dataSourceState.search;
     };
 
-    const getTogglerProps = (rows: DataRowProps<TItem, TId>[]): PickerTogglerProps<TItem, TId> => {
+    const getTogglerProps = (): PickerTogglerProps<TItem, TId> => {
         const selectedRowsCount = view.getSelectedRowsCount();
         const allowedMaxItems = getMaxItems(props.maxItems);
         const itemsToTake = selectedRowsCount > allowedMaxItems ? allowedMaxItems : selectedRowsCount;
@@ -314,7 +319,6 @@ export function usePickerInput<TItem, TId, TProps>(props: UsePickerInputProps<TI
             entityName: getEntityName(selectedRowsCount),
             pickerMode: isSingleSelect() ? 'single' : 'multi',
             searchPosition,
-            onKeyDown: (e) => handlePickerInputKeyboard(rows, e),
             disableSearch: searchPosition !== 'input',
             disableClear: disableClear,
             toggleDropdownOpening,
@@ -343,5 +347,6 @@ export function usePickerInput<TItem, TId, TProps>(props: UsePickerInputProps<TI
         handleDataSourceValueChange,
         handleSelectionValueChange,
         getSearchPosition,
+        handlePickerInputKeyboard,
     };
 }

--- a/uui/components/pickers/PickerInput.tsx
+++ b/uui/components/pickers/PickerInput.tsx
@@ -57,6 +57,7 @@ export function PickerInput<TItem, TId>({ highlightSearchMatches = true, ...prop
         getListProps,
         shouldShowBody,
         getSearchPosition,
+        handlePickerInputKeyboard,
     } = usePickerInput<TItem, TId, CompletePickerInputProps<TItem, TId>>({ ...props, toggleModalOpening });
 
     const getTogglerMods = (): PickerTogglerMods => {
@@ -77,6 +78,7 @@ export function PickerInput<TItem, TId>({ highlightSearchMatches = true, ...prop
                     ...getTogglerMods(),
                     ...targetProps,
                     ...editableProps,
+                    onKeyDown: (e) => handlePickerInputKeyboard(rows, e, editableProps.value),
                 }) }
             />
         );
@@ -164,7 +166,7 @@ export function PickerInput<TItem, TId>({ highlightSearchMatches = true, ...prop
     return (
         <Dropdown
             renderTarget={ (dropdownProps) => {
-                const targetProps = getTogglerProps(rows);
+                const targetProps = getTogglerProps();
                 return renderTarget({ ...dropdownProps, ...targetProps });
             } }
             renderBody={ (bodyProps) => renderBody({ ...bodyProps, ...getPickerBodyProps(rows), ...getListProps() }, rows) }


### PR DESCRIPTION
### Summary

Enabled removing tags on backspace only if searchPosition = 'input' and editMode != 'modal'.