### PR TITLE
[Button]: Add more flexible types for rawProps and added create skin component helper #1421

### DIFF
--- a/app/src/common/MainMenuAppMultiSwitch.tsx
+++ b/app/src/common/MainMenuAppMultiSwitch.tsx
@@ -7,9 +7,9 @@ import {
 } from '@epam/promo';
 import { svc } from '../services';
 
-interface MainMenuAppMultiSwitchPropsItem<TValue> extends ButtonProps, ButtonMods {
+type MainMenuAppMultiSwitchPropsItem<TValue> = ButtonProps & ButtonMods & {
     id: TValue;
-}
+};
 
 export interface MainMenuAppMultiSwitchProps<TValue> extends IEditable<TValue>, SizeMod, IAnalyticableOnChange<TValue> {
     items: MainMenuAppMultiSwitchPropsItem<TValue>[];

--- a/app/src/common/sidebar/SidebarButton.tsx
+++ b/app/src/common/sidebar/SidebarButton.tsx
@@ -4,10 +4,10 @@ import { ReactComponent as DropdownIcon } from '@epam/assets/icons/common/naviga
 import css from './SidebarButton.module.scss';
 import { cx } from '@epam/uui-core';
 
-export interface SidebarButtonProps extends VerticalTabButtonProps {
+export type SidebarButtonProps = VerticalTabButtonProps & {
     isActive: boolean;
     indent?: number;
-}
+};
 
 export class SidebarButton extends React.Component<SidebarButtonProps, any> {
     render() {

--- a/epam-promo/components/buttons/Button.tsx
+++ b/epam-promo/components/buttons/Button.tsx
@@ -21,9 +21,6 @@ export type ButtonProps = uui.ButtonCoreProps & ButtonMods;
 
 export const Button = createSkinComponent<uui.ButtonCoreProps, ButtonProps>(
     uui.Button,
-    (props) => [
-        ['42', '48'].includes(props.size) && css.uppercase,
-    ],
     (props) => {
         if (__DEV__) {
             devLogger.warnAboutDeprecatedPropValue<ButtonProps, 'color'>({
@@ -38,4 +35,7 @@ export const Button = createSkinComponent<uui.ButtonCoreProps, ButtonProps>(
             mode: mapFillToMod[props.fill] || mapFillToMod.solid,
         };
     },
+    (props) => [
+        ['42', '48'].includes(props.size) && css.uppercase,
+    ],
 );

--- a/epam-promo/components/buttons/Button.tsx
+++ b/epam-promo/components/buttons/Button.tsx
@@ -17,9 +17,9 @@ const mapFillToMod: Record<FillStyle, uui.ButtonMode> = {
     none: 'none',
 };
 
-export type ButtonProps = uui.ButtonPropsType & ButtonMods;
+export type ButtonProps = uui.ButtonCoreProps & ButtonMods;
 
-export const Button = createSkinComponent<uui.ButtonPropsType, ButtonProps>(
+export const Button = createSkinComponent<uui.ButtonCoreProps, ButtonProps>(
     uui.Button,
     (props) => [
         ['42', '48'].includes(props.size) && css.uppercase,

--- a/epam-promo/components/buttons/Button.tsx
+++ b/epam-promo/components/buttons/Button.tsx
@@ -1,5 +1,5 @@
 import * as uui from '@epam/uui';
-import { devLogger, withMods } from '@epam/uui-core';
+import { createSkinComponent, devLogger } from '@epam/uui-core';
 import { FillStyle } from '../types';
 import css from './Button.module.scss';
 
@@ -17,9 +17,9 @@ const mapFillToMod: Record<FillStyle, uui.ButtonMode> = {
     none: 'none',
 };
 
-export type ButtonProps = Omit<uui.ButtonProps, 'color'> & ButtonMods;
+export type ButtonProps = uui.ButtonPropsType & ButtonMods;
 
-export const Button = withMods<Omit<uui.ButtonProps, 'color'>, ButtonMods>(
+export const Button = createSkinComponent<uui.ButtonPropsType, ButtonProps>(
     uui.Button,
     (props) => [
         ['42', '48'].includes(props.size) && css.uppercase,

--- a/epam-promo/components/buttons/IconButton.tsx
+++ b/epam-promo/components/buttons/IconButton.tsx
@@ -15,9 +15,9 @@ export type IconButtonProps = IconButtonCoreProps & IconButtonMods;
 
 export const IconButton = createSkinComponent<IconButtonCoreProps, IconButtonProps>(
     uuiIconButton,
-    () => [],
     (props) =>
         ({
             color: props.color ?? 'gray60',
         }),
+    () => [],
 );

--- a/epam-promo/components/buttons/IconButton.tsx
+++ b/epam-promo/components/buttons/IconButton.tsx
@@ -1,6 +1,6 @@
 import { createSkinComponent } from '@epam/uui-core';
 import { allEpamPrimaryColors, EpamPrimaryColor } from '../types';
-import { IconButtonType, IconButton as uuiIconButton } from '@epam/uui';
+import { IconButtonCoreProps, IconButton as uuiIconButton } from '@epam/uui';
 
 export type IconColor = EpamPrimaryColor | 'gray30' | 'gray50' | 'gray60';
 export const allIconColors: IconColor[] = [
@@ -11,9 +11,9 @@ export interface IconButtonMods {
     color?: IconColor;
 }
 
-export type IconButtonProps = IconButtonType & IconButtonMods;
+export type IconButtonProps = IconButtonCoreProps & IconButtonMods;
 
-export const IconButton = createSkinComponent<IconButtonType, IconButtonProps>(
+export const IconButton = createSkinComponent<IconButtonCoreProps, IconButtonProps>(
     uuiIconButton,
     () => [],
     (props) =>

--- a/epam-promo/components/buttons/IconButton.tsx
+++ b/epam-promo/components/buttons/IconButton.tsx
@@ -1,6 +1,6 @@
-import { withMods } from '@epam/uui-core';
+import { createSkinComponent } from '@epam/uui-core';
 import { allEpamPrimaryColors, EpamPrimaryColor } from '../types';
-import { IconButton as uuiIconButton, IconButtonProps as UuiIconButtonProps } from '@epam/uui';
+import { IconButtonType, IconButton as uuiIconButton } from '@epam/uui';
 
 export type IconColor = EpamPrimaryColor | 'gray30' | 'gray50' | 'gray60';
 export const allIconColors: IconColor[] = [
@@ -11,13 +11,13 @@ export interface IconButtonMods {
     color?: IconColor;
 }
 
-export type IconButtonProps = Omit<UuiIconButtonProps, 'color'> & IconButtonMods;
+export type IconButtonProps = IconButtonType & IconButtonMods;
 
-export const IconButton = withMods<Omit<UuiIconButtonProps, 'color'>, IconButtonMods>(
+export const IconButton = createSkinComponent<IconButtonType, IconButtonProps>(
     uuiIconButton,
     () => [],
     (props) =>
         ({
             color: props.color ?? 'gray60',
-        } as IconButtonProps),
+        }),
 );

--- a/epam-promo/components/buttons/LinkButton.tsx
+++ b/epam-promo/components/buttons/LinkButton.tsx
@@ -9,7 +9,6 @@ export type LinkButtonProps = uui.LinkButtonCoreProps & LinkButtonMods;
 
 export const LinkButton = createSkinComponent<uui.LinkButtonProps, LinkButtonProps>(
     uui.LinkButton,
-    () => [],
     (props) => {
         if (__DEV__) {
             devLogger.warnAboutDeprecatedPropValue<LinkButtonProps, 'color'>({
@@ -23,4 +22,5 @@ export const LinkButton = createSkinComponent<uui.LinkButtonProps, LinkButtonPro
             color: props.color ?? 'blue',
         };
     },
+    () => [],
 );

--- a/epam-promo/components/buttons/LinkButton.tsx
+++ b/epam-promo/components/buttons/LinkButton.tsx
@@ -1,13 +1,13 @@
-import { devLogger, withMods } from '@epam/uui-core';
-import { LinkButton as UuiLinkButton, LinkButtonProps as UuiLinkButtonProps } from '@epam/uui';
+import { createSkinComponent, devLogger } from '@epam/uui-core';
+import { LinkButtonPropsType, LinkButton as UuiLinkButton } from '@epam/uui';
 
 export interface LinkButtonMods {
     color?: 'blue' | 'green' | 'amber' | 'red' | 'gray60' | 'gray10';
 }
 
-export type LinkButtonProps = Omit<UuiLinkButtonProps, 'color'> & LinkButtonMods;
+export type LinkButtonProps = LinkButtonPropsType & LinkButtonMods;
 
-export const LinkButton = withMods<Omit<UuiLinkButtonProps, 'color'>, LinkButtonMods>(
+export const LinkButton = createSkinComponent<LinkButtonPropsType, LinkButtonProps>(
     UuiLinkButton,
     () => [],
     (props) => {
@@ -21,6 +21,6 @@ export const LinkButton = withMods<Omit<UuiLinkButtonProps, 'color'>, LinkButton
         }
         return {
             color: props.color ?? 'blue',
-        } as LinkButtonProps;
+        };
     },
 );

--- a/epam-promo/components/buttons/LinkButton.tsx
+++ b/epam-promo/components/buttons/LinkButton.tsx
@@ -1,14 +1,14 @@
 import { createSkinComponent, devLogger } from '@epam/uui-core';
-import { LinkButtonPropsType, LinkButton as UuiLinkButton } from '@epam/uui';
+import * as uui from '@epam/uui';
 
 export interface LinkButtonMods {
     color?: 'blue' | 'green' | 'amber' | 'red' | 'gray60' | 'gray10';
 }
 
-export type LinkButtonProps = LinkButtonPropsType & LinkButtonMods;
+export type LinkButtonProps = uui.LinkButtonCoreProps & LinkButtonMods;
 
-export const LinkButton = createSkinComponent<LinkButtonPropsType, LinkButtonProps>(
-    UuiLinkButton,
+export const LinkButton = createSkinComponent<uui.LinkButtonProps, LinkButtonProps>(
+    uui.LinkButton,
     () => [],
     (props) => {
         if (__DEV__) {

--- a/epam-promo/components/widgets/Badge.tsx
+++ b/epam-promo/components/widgets/Badge.tsx
@@ -11,9 +11,9 @@ export type BadgeProps = ButtonCoreProps & BadgeMods;
 
 export const Badge = createSkinComponent<UuiBadgeProps, BadgeProps>(
     UuiBadge,
-    () => [],
     (props) =>
         ({
             color: props.color || 'blue',
         }),
+    () => [],
 );

--- a/epam-promo/components/widgets/Badge.tsx
+++ b/epam-promo/components/widgets/Badge.tsx
@@ -1,18 +1,19 @@
-import { withMods } from '@epam/uui-core';
-import { BadgeProps as UuiBadgeProps, Badge as UuiBadge } from '@epam/uui';
+import { createSkinComponent } from '@epam/uui-core';
+import { Badge as UuiBadge, BadgeProps as UuiBadgeProps, BadgePropsType, BadgeFill } from '@epam/uui';
 import { EpamAdditionalColor } from '../types';
 
-export interface BadgeMods {
+export type BadgeMods = {
     color?: EpamAdditionalColor | 'gray30';
-}
+    fill?: BadgeFill;
+};
 
-export type BadgeProps = Omit<UuiBadgeProps, 'color'> & BadgeMods;
+export type BadgeProps = BadgePropsType & BadgeMods;
 
-export const Badge = withMods<Omit<UuiBadgeProps, 'color'>, BadgeMods>(
+export const Badge = createSkinComponent<UuiBadgeProps, BadgeProps>(
     UuiBadge,
     () => [],
     (props) =>
         ({
             color: props.color || 'blue',
-        } as BadgeProps),
+        }),
 );

--- a/epam-promo/components/widgets/Badge.tsx
+++ b/epam-promo/components/widgets/Badge.tsx
@@ -1,5 +1,5 @@
 import { createSkinComponent } from '@epam/uui-core';
-import { Badge as UuiBadge, BadgeProps as UuiBadgeProps, BadgePropsType, BadgeFill } from '@epam/uui';
+import { Badge as UuiBadge, BadgeProps as UuiBadgeProps, ButtonCoreProps, BadgeFill } from '@epam/uui';
 import { EpamAdditionalColor } from '../types';
 
 export type BadgeMods = {
@@ -7,7 +7,7 @@ export type BadgeMods = {
     fill?: BadgeFill;
 };
 
-export type BadgeProps = BadgePropsType & BadgeMods;
+export type BadgeProps = ButtonCoreProps & BadgeMods;
 
 export const Badge = createSkinComponent<UuiBadgeProps, BadgeProps>(
     UuiBadge,

--- a/loveship/components/buttons/Button.tsx
+++ b/loveship/components/buttons/Button.tsx
@@ -1,6 +1,6 @@
 import { FillStyle, ControlShape, EpamPrimaryColor } from '../types';
 import { Button as uuiButton, ButtonMode, ControlSize, ButtonCoreProps } from '@epam/uui';
-import { devLogger, withMods } from '@epam/uui-core';
+import { createSkinComponent, devLogger } from '@epam/uui-core';
 import { systemIcons } from '../icons/icons';
 import css from './Button.module.scss';
 
@@ -31,7 +31,7 @@ export function applyButtonMods(mods: ButtonProps) {
     ];
 }
 
-export const Button = withMods<ButtonCoreProps, ButtonProps>(uuiButton, applyButtonMods, (props) => {
+export const Button = createSkinComponent<ButtonCoreProps, ButtonProps>(uuiButton, (props) => {
     if (__DEV__) {
         devLogger.warnAboutDeprecatedPropValue<ButtonProps, 'color'>({
             component: 'Button',
@@ -46,4 +46,4 @@ export const Button = withMods<ButtonCoreProps, ButtonProps>(uuiButton, applyBut
         clearIcon: systemIcons[props.size || defaultSize].clear,
         mode: mapFillToMod[props.fill] || mapFillToMod.solid,
     };
-});
+}, applyButtonMods);

--- a/loveship/components/buttons/Button.tsx
+++ b/loveship/components/buttons/Button.tsx
@@ -1,5 +1,5 @@
 import { FillStyle, ControlShape, EpamPrimaryColor } from '../types';
-import { Button as uuiButton, ButtonMode, ButtonProps as UuiButtonProps, ControlSize } from '@epam/uui';
+import { Button as uuiButton, ButtonMode, ControlSize, ButtonPropsType } from '@epam/uui';
 import { devLogger, withMods } from '@epam/uui-core';
 import { systemIcons } from '../icons/icons';
 import css from './Button.module.scss';
@@ -22,7 +22,7 @@ const mapFillToMod: Record<FillStyle, ButtonMode> = {
     none: 'none',
 };
 
-export type ButtonProps = Omit<UuiButtonProps, 'color'> & ButtonMods;
+export type ButtonProps = ButtonPropsType & ButtonMods;
 
 export function applyButtonMods(mods: ButtonProps) {
     return [
@@ -31,7 +31,7 @@ export function applyButtonMods(mods: ButtonProps) {
     ];
 }
 
-export const Button = withMods<Omit<UuiButtonProps, 'color'>, ButtonMods>(uuiButton, applyButtonMods, (props) => {
+export const Button = withMods<ButtonPropsType, ButtonProps>(uuiButton, applyButtonMods, (props) => {
     if (__DEV__) {
         devLogger.warnAboutDeprecatedPropValue<ButtonProps, 'color'>({
             component: 'Button',

--- a/loveship/components/buttons/Button.tsx
+++ b/loveship/components/buttons/Button.tsx
@@ -1,5 +1,5 @@
 import { FillStyle, ControlShape, EpamPrimaryColor } from '../types';
-import { Button as uuiButton, ButtonMode, ControlSize, ButtonPropsType } from '@epam/uui';
+import { Button as uuiButton, ButtonMode, ControlSize, ButtonCoreProps } from '@epam/uui';
 import { devLogger, withMods } from '@epam/uui-core';
 import { systemIcons } from '../icons/icons';
 import css from './Button.module.scss';
@@ -22,7 +22,7 @@ const mapFillToMod: Record<FillStyle, ButtonMode> = {
     none: 'none',
 };
 
-export type ButtonProps = ButtonPropsType & ButtonMods;
+export type ButtonProps = ButtonCoreProps & ButtonMods;
 
 export function applyButtonMods(mods: ButtonProps) {
     return [
@@ -31,7 +31,7 @@ export function applyButtonMods(mods: ButtonProps) {
     ];
 }
 
-export const Button = withMods<ButtonPropsType, ButtonProps>(uuiButton, applyButtonMods, (props) => {
+export const Button = withMods<ButtonCoreProps, ButtonProps>(uuiButton, applyButtonMods, (props) => {
     if (__DEV__) {
         devLogger.warnAboutDeprecatedPropValue<ButtonProps, 'color'>({
             component: 'Button',

--- a/loveship/components/buttons/IconButton.tsx
+++ b/loveship/components/buttons/IconButton.tsx
@@ -1,4 +1,4 @@
-import { IconButtonProps as uuiIconButtonProps, IconButton as uuiIconButton, IconButtonType } from '@epam/uui';
+import { IconButtonProps as uuiIconButtonProps, IconButton as uuiIconButton, IconButtonCoreProps } from '@epam/uui';
 import { devLogger, createSkinComponent } from '@epam/uui-core';
 import { EpamAdditionalColor, EpamPrimaryColor } from '../types';
 
@@ -6,7 +6,7 @@ export interface IconButtonMods {
     color?: EpamPrimaryColor | EpamAdditionalColor | 'white' | 'night200' | 'night300' | 'night400' | 'night500' | 'night600';
 }
 
-export type IconButtonProps = IconButtonType & IconButtonMods;
+export type IconButtonProps = IconButtonCoreProps & IconButtonMods;
 
 export const IconButton = createSkinComponent<uuiIconButtonProps, IconButtonProps>(
     uuiIconButton,

--- a/loveship/components/buttons/IconButton.tsx
+++ b/loveship/components/buttons/IconButton.tsx
@@ -10,7 +10,6 @@ export type IconButtonProps = IconButtonCoreProps & IconButtonMods;
 
 export const IconButton = createSkinComponent<uuiIconButtonProps, IconButtonProps>(
     uuiIconButton,
-    () => [],
     (props) => {
         if (__DEV__) {
             devLogger.warnAboutDeprecatedPropValue<IconButtonProps, 'color'>({
@@ -24,4 +23,5 @@ export const IconButton = createSkinComponent<uuiIconButtonProps, IconButtonProp
             color: props.color ?? 'night600',
         } as IconButtonProps;
     },
+    () => [],
 );

--- a/loveship/components/buttons/IconButton.tsx
+++ b/loveship/components/buttons/IconButton.tsx
@@ -1,14 +1,14 @@
-import { IconButton as uuiIconButton, IconButtonProps as UuiIconButtonProps } from '@epam/uui';
-import { devLogger, withMods } from '@epam/uui-core';
+import { IconButtonProps as uuiIconButtonProps, IconButton as uuiIconButton, IconButtonType } from '@epam/uui';
+import { devLogger, createSkinComponent } from '@epam/uui-core';
 import { EpamAdditionalColor, EpamPrimaryColor } from '../types';
 
 export interface IconButtonMods {
     color?: EpamPrimaryColor | EpamAdditionalColor | 'white' | 'night200' | 'night300' | 'night400' | 'night500' | 'night600';
 }
 
-export type IconButtonProps = Omit<UuiIconButtonProps, 'color'> & IconButtonMods;
+export type IconButtonProps = IconButtonType & IconButtonMods;
 
-export const IconButton = withMods<Omit<UuiIconButtonProps, 'color'>, IconButtonMods>(
+export const IconButton = createSkinComponent<uuiIconButtonProps, IconButtonProps>(
     uuiIconButton,
     () => [],
     (props) => {

--- a/loveship/components/buttons/LinkButton.tsx
+++ b/loveship/components/buttons/LinkButton.tsx
@@ -1,14 +1,14 @@
 import { createSkinComponent, devLogger } from '@epam/uui-core';
-import { LinkButtonPropsType, LinkButton as UuiLinkButton } from '@epam/uui';
+import * as uui from '@epam/uui';
 
 export interface LinkButtonMods {
     color?: 'sky' | 'grass' | 'sun' | 'fire' | 'cobalt' | 'lavanda' | 'fuchsia' | 'white' | 'night50' | 'night100' | 'night200' | 'night300' | 'night400' | 'night500' | 'night600' | 'night700' | 'night800' | 'night900';
 }
 
-export type LinkButtonProps = LinkButtonPropsType & LinkButtonMods;
+export type LinkButtonProps = uui.LinkButtonCoreProps & LinkButtonMods;
 
-export const LinkButton = createSkinComponent<LinkButtonProps, LinkButtonProps>(
-    UuiLinkButton,
+export const LinkButton = createSkinComponent<uui.LinkButtonCoreProps, LinkButtonProps>(
+    uui.LinkButton,
     () => [],
     (props) => {
         if (__DEV__) {

--- a/loveship/components/buttons/LinkButton.tsx
+++ b/loveship/components/buttons/LinkButton.tsx
@@ -1,13 +1,13 @@
-import { devLogger, withMods } from '@epam/uui-core';
-import { LinkButton as UuiLinkButton, LinkButtonProps as UuiLinkButtonProps } from '@epam/uui';
+import { createSkinComponent, devLogger } from '@epam/uui-core';
+import { LinkButtonPropsType, LinkButton as UuiLinkButton } from '@epam/uui';
 
 export interface LinkButtonMods {
     color?: 'sky' | 'grass' | 'sun' | 'fire' | 'cobalt' | 'lavanda' | 'fuchsia' | 'white' | 'night50' | 'night100' | 'night200' | 'night300' | 'night400' | 'night500' | 'night600' | 'night700' | 'night800' | 'night900';
 }
 
-export type LinkButtonProps = Omit<UuiLinkButtonProps, 'color'> & LinkButtonMods;
+export type LinkButtonProps = LinkButtonPropsType & LinkButtonMods;
 
-export const LinkButton = withMods<Omit<UuiLinkButtonProps, 'color'>, LinkButtonMods>(
+export const LinkButton = createSkinComponent<LinkButtonProps, LinkButtonProps>(
     UuiLinkButton,
     () => [],
     (props) => {
@@ -16,11 +16,11 @@ export const LinkButton = withMods<Omit<UuiLinkButtonProps, 'color'>, LinkButton
                 component: 'LinkButton',
                 propName: 'color',
                 propValue: props.color,
-                condition: () => ['grass', 'sun', 'fire', 'cobalt', 'lavanda', 'fuchsia', 'white', 'night50', 'night200', 'night300', 'night400', 'night500', 'night700', 'night800', 'night900'].indexOf(props.color) !== -1,
+                condition: () => ['grass', 'sun', 'fire', 'cobalt', 'lavanda', 'fuchsia', 'white', 'night50', 'night100', 'night200', 'night300', 'night400', 'night500', 'night700', 'night800', 'night900'].indexOf(props.color) !== -1,
             });
         }
         return {
             color: props.color ?? 'sky',
-        } as LinkButtonProps;
+        };
     },
 );

--- a/loveship/components/buttons/LinkButton.tsx
+++ b/loveship/components/buttons/LinkButton.tsx
@@ -9,18 +9,18 @@ export type LinkButtonProps = uui.LinkButtonCoreProps & LinkButtonMods;
 
 export const LinkButton = createSkinComponent<uui.LinkButtonCoreProps, LinkButtonProps>(
     uui.LinkButton,
-    () => [],
     (props) => {
         if (__DEV__) {
             devLogger.warnAboutDeprecatedPropValue<LinkButtonProps, 'color'>({
                 component: 'LinkButton',
                 propName: 'color',
                 propValue: props.color,
-                condition: () => ['grass', 'sun', 'fire', 'cobalt', 'lavanda', 'fuchsia', 'white', 'night50', 'night100', 'night200', 'night300', 'night400', 'night500', 'night700', 'night800', 'night900'].indexOf(props.color) !== -1,
+                condition: () => ['grass', 'sun', 'fire', 'cobalt', 'lavanda', 'fuchsia', 'white', 'night50', 'night200', 'night300', 'night400', 'night500', 'night700', 'night800', 'night900'].indexOf(props.color) !== -1,
             });
         }
         return {
             color: props.color ?? 'sky',
         };
     },
+    () => [],
 );

--- a/loveship/components/buttons/TabButton.tsx
+++ b/loveship/components/buttons/TabButton.tsx
@@ -2,9 +2,9 @@ import css from './TabButton.module.scss';
 import { TabButton as UuiTabButton, TabButtonProps as UuiTabButtonProps } from '@epam/uui';
 import { withMods } from '@epam/uui-core';
 
-export interface TabButtonMods extends UuiTabButtonProps {
+export type TabButtonMods = UuiTabButtonProps & {
     theme?: 'light' | 'dark';
-}
+};
 
 function applyTabButtonMods(mods: TabButtonMods & UuiTabButtonProps) {
     return [mods.theme === 'dark' && css.themeDark];

--- a/loveship/components/widgets/Badge.tsx
+++ b/loveship/components/widgets/Badge.tsx
@@ -23,7 +23,6 @@ export type BadgeProps = Omit <BadgeCoreProps, 'size'> & BadgeMods;
 
 export const Badge = createSkinComponent<UuiBadgeProps, BadgeProps>(
     UuiBadge,
-    applyBadgeMods,
     (props) => {
         if (__DEV__) {
             devLogger.warnAboutDeprecatedPropValue<BadgeProps, 'color'>({
@@ -38,4 +37,5 @@ export const Badge = createSkinComponent<UuiBadgeProps, BadgeProps>(
             size: props.size || defaultSize,
         };
     },
+    applyBadgeMods,
 );

--- a/loveship/components/widgets/Badge.tsx
+++ b/loveship/components/widgets/Badge.tsx
@@ -1,6 +1,6 @@
 import { createSkinComponent, devLogger } from '@epam/uui-core';
 import * as types from '../../components/types';
-import { BadgeProps as UuiBadgeProps, Badge as UuiBadge, BadgeMods as UuiBadgeMods } from '@epam/uui';
+import { BadgeProps as UuiBadgeProps, Badge as UuiBadge, BadgeMods as UuiBadgeMods, BadgeCoreProps } from '@epam/uui';
 import { EpamAdditionalColor, EpamPrimaryColor } from '../types';
 import css from './Badge.module.scss';
 
@@ -10,7 +10,7 @@ export interface BadgeMods {
     color?: EpamPrimaryColor | EpamAdditionalColor | 'white' | 'night200' | 'night300' | 'night400' | 'night500' | 'night600';
     shape?: types.ControlShape;
     fill?: UuiBadgeMods['fill'] | 'white' | 'light' | 'none';
-    size?: UuiBadgeMods['size'] | '12';
+    size?: BadgeCoreProps['size'] | '12';
 }
 
 export function applyBadgeMods(mods: BadgeMods) {
@@ -19,7 +19,7 @@ export function applyBadgeMods(mods: BadgeMods) {
     ];
 }
 
-export type BadgeProps = UuiBadgeProps & BadgeMods;
+export type BadgeProps = Omit <BadgeCoreProps, 'size'> & BadgeMods;
 
 export const Badge = createSkinComponent<UuiBadgeProps, BadgeProps>(
     UuiBadge,

--- a/loveship/components/widgets/Badge.tsx
+++ b/loveship/components/widgets/Badge.tsx
@@ -1,6 +1,6 @@
-import { devLogger, withMods } from '@epam/uui-core';
+import { createSkinComponent, devLogger } from '@epam/uui-core';
 import * as types from '../../components/types';
-import { Badge as UuiBadge, BadgeMods as UuiBadgeMods, BadgeProps as UuiBadgeProps } from '@epam/uui';
+import { BadgeProps as UuiBadgeProps, Badge as UuiBadge, BadgeMods as UuiBadgeMods } from '@epam/uui';
 import { EpamAdditionalColor, EpamPrimaryColor } from '../types';
 import css from './Badge.module.scss';
 
@@ -19,9 +19,9 @@ export function applyBadgeMods(mods: BadgeMods) {
     ];
 }
 
-export type BadgeProps = Omit<UuiBadgeProps, 'color' | 'fill' | 'size'> & BadgeMods;
+export type BadgeProps = UuiBadgeProps & BadgeMods;
 
-export const Badge = withMods<Omit<UuiBadgeProps, 'color' | 'fill' | 'size'>, BadgeMods>(
+export const Badge = createSkinComponent<UuiBadgeProps, BadgeProps>(
     UuiBadge,
     applyBadgeMods,
     (props) => {
@@ -36,6 +36,6 @@ export const Badge = withMods<Omit<UuiBadgeProps, 'color' | 'fill' | 'size'>, Ba
         return {
             color: props.color || 'sky',
             size: props.size || defaultSize,
-        } as BadgeProps;
+        };
     },
 );

--- a/loveship/components/widgets/Tag.tsx
+++ b/loveship/components/widgets/Tag.tsx
@@ -1,18 +1,18 @@
-import { withMods } from '@epam/uui-core';
-import { Tag as UuiTag, TagProps, TagMods as UuiTagMods } from '@epam/uui';
+import { createSkinComponent } from '@epam/uui-core';
+import { TagProps, TagMods as UuiTagMods, Button } from '@epam/uui';
 import * as types from '../../components/types';
 import css from './Tag.module.scss';
 
 const defaultSize = '18';
 
-export interface TagMods extends UuiTagMods {
+export type TagMods = UuiTagMods & {
     fill?: types.FillStyle;
-}
+};
 
 export function applyTagMods(mods: TagMods) {
     return [css.root, css['fill-' + (mods.fill || 'solid')]];
 }
 
-export const Tag = withMods<Omit<TagProps, 'color'>, TagMods>(UuiTag, applyTagMods, (props) => ({
+export const Tag = createSkinComponent<TagProps, TagMods>(Button, applyTagMods, (props) => ({
     size: props.size || defaultSize,
 }));

--- a/loveship/components/widgets/Tag.tsx
+++ b/loveship/components/widgets/Tag.tsx
@@ -13,6 +13,6 @@ export function applyTagMods(mods: TagMods) {
     return [css.root, css['fill-' + (mods.fill || 'solid')]];
 }
 
-export const Tag = createSkinComponent<TagProps, TagMods>(Button, applyTagMods, (props) => ({
+export const Tag = createSkinComponent<TagProps, TagMods>(Button, (props) => ({
     size: props.size || defaultSize,
-}));
+}), applyTagMods);

--- a/uui-components/src/buttons/Button.tsx
+++ b/uui-components/src/buttons/Button.tsx
@@ -1,21 +1,15 @@
 import * as React from 'react';
 import {
-    ButtonCoreProps, Icon, uuiElement, uuiMarkers, CX, IHasRawProps, cx, IHasForwardedRef,
+    ButtonComponentProps, Icon, uuiElement, uuiMarkers, CX, cx, IHasForwardedRef,
 } from '@epam/uui-core';
 import { IconContainer } from '../layout';
 import { ButtonBase } from './ButtonBase';
 import css from './Button.module.scss';
 
-export interface ButtonProps
-    extends ButtonCoreProps,
-    IHasRawProps<React.ButtonHTMLAttributes<HTMLButtonElement>>,
-    IHasForwardedRef<HTMLButtonElement | HTMLAnchorElement> {
-    /** Icon for clear value button (usually cross) */
+export type ButtonProps = ButtonComponentProps & IHasForwardedRef<HTMLButtonElement | HTMLAnchorElement> & {
     clearIcon?: Icon;
-
-    /** CSS classes to put on the caption */
     captionCX?: CX;
-}
+};
 
 export class Button extends ButtonBase<ButtonProps> {
     constructor(props: ButtonProps) {

--- a/uui-components/src/buttons/ButtonBase.tsx
+++ b/uui-components/src/buttons/ButtonBase.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {
     cx,
-    ButtonBaseCoreProps,
+    ButtonComponentProps,
     IHasForwardedRef,
     UuiContexts,
     isEventTargetInsideClickable,
@@ -10,9 +10,10 @@ import {
     uuiMarkers,
     UuiContext,
     isAnyParentHasClass,
+    ICanRedirect,
 } from '@epam/uui-core';
 
-export interface ButtonBaseProps extends ButtonBaseCoreProps, IHasForwardedRef<HTMLButtonElement | HTMLAnchorElement> {}
+export type ButtonBaseProps = ButtonComponentProps & ICanRedirect & IHasForwardedRef<HTMLButtonElement | HTMLAnchorElement> &{};
 
 export const uuiInputElements = [
     uuiElement.checkbox, uuiElement.inputLabel, uuiElement.radioInput, uuiElement.switchBody,

--- a/uui-components/src/buttons/IconButton.tsx
+++ b/uui-components/src/buttons/IconButton.tsx
@@ -3,7 +3,7 @@ import { ButtonBaseProps, ButtonBase } from './ButtonBase';
 import { IconContainer } from '../layout';
 import css from './Button.module.scss';
 
-export interface IconButtonBaseProps extends ButtonBaseProps {}
+export type IconButtonBaseProps = ButtonBaseProps & {};
 
 export class IconButton extends ButtonBase<IconButtonBaseProps> {
     constructor(props: IconButtonBaseProps) {

--- a/uui-components/src/navigation/Anchor.tsx
+++ b/uui-components/src/navigation/Anchor.tsx
@@ -25,15 +25,6 @@ IClickable&
 IAnalyticableClick&
 IHasForwardedRef<HTMLAnchorElement | HTMLButtonElement> & {};
 
-// export interface AnchorProps
-//     extends IHasCX,
-//     ICanRedirect,
-//     IHasChildren,
-//     IDisableable,
-//     IClickable,
-//     IAnalyticableClick,
-//     IHasForwardedRef<HTMLAnchorElement | HTMLButtonElement> {}
-
 export class AnchorImpl extends ButtonBase<AnchorProps> {
     static contextType = UuiContext;
     context: UuiContexts;

--- a/uui-components/src/navigation/Anchor.tsx
+++ b/uui-components/src/navigation/Anchor.tsx
@@ -4,30 +4,35 @@ import {
     uuiMod,
     uuiElement,
     uuiMarkers,
-    IHasRawProps,
     UuiContext,
     IHasForwardedRef,
     IHasCX,
-    ICanRedirect,
     IHasChildren,
     UuiContexts,
     IDisableable,
     IClickable,
     cx,
     IAnalyticableClick,
+    ButtonComponentProps,
 } from '@epam/uui-core';
 import { ButtonBase } from '../buttons';
 import css from './Anchor.module.scss';
 
-export interface AnchorProps
-    extends IHasCX,
-    ICanRedirect,
-    IHasChildren,
-    IDisableable,
-    IClickable,
-    IAnalyticableClick,
-    IHasRawProps<React.ButtonHTMLAttributes<HTMLButtonElement>>,
-    IHasForwardedRef<HTMLAnchorElement | HTMLButtonElement> {}
+export type AnchorProps = ButtonComponentProps & IHasCX&
+IHasChildren&
+IDisableable&
+IClickable&
+IAnalyticableClick&
+IHasForwardedRef<HTMLAnchorElement | HTMLButtonElement> & {};
+
+// export interface AnchorProps
+//     extends IHasCX,
+//     ICanRedirect,
+//     IHasChildren,
+//     IDisableable,
+//     IClickable,
+//     IAnalyticableClick,
+//     IHasForwardedRef<HTMLAnchorElement | HTMLButtonElement> {}
 
 export class AnchorImpl extends ButtonBase<AnchorProps> {
     static contextType = UuiContext;

--- a/uui-core/src/helpers/createSkinComponent.ts
+++ b/uui-core/src/helpers/createSkinComponent.ts
@@ -3,8 +3,8 @@ import { CX } from '../types';
 
 export function createSkinComponent<TProps, TResult = {}>(
     Component: React.ComponentType<TProps>,
-    getCx?: (props: Readonly<TResult>) => CX,
     getProps?: (props: Readonly<TResult>) => TResult,
+    getCx?: (props: Readonly<TResult>) => CX,
 ) : (props: TResult & React.RefAttributes<TResult>) => React.ReactElement | null {
     function SkinComponent(props: TResult): React.ReactElement<any> | null {
         const allProps: any = { ...props };

--- a/uui-core/src/helpers/createSkinComponent.ts
+++ b/uui-core/src/helpers/createSkinComponent.ts
@@ -1,0 +1,53 @@
+import * as React from 'react';
+import { CX } from '../types';
+
+// export function createSkinComponent<TProps, TResult = {}>(
+//     Component: any,
+//     getCx?: (props: Readonly<TResult>) => CX,
+//     getProps?: (props: Readonly<TResult>) => TResult,
+// ) {
+//     // const wrappedComponent = (props: TResult): React.ReactElement<TResult> => {
+//     //     const allProps: any = { ...props };
+
+//     //     if (getProps) {
+//     //         Object.assign(allProps, getProps?.(props));
+//     //     }
+
+//     //     const getCxResult = getCx?.(props);
+
+//     //     if (getCxResult) {
+//     //         allProps.cx = [getCxResult, (props as any).cx];
+//     //     }
+
+//     //     return Component;
+//     // };
+
+//     // (wrappedComponent as any).displayName = `${Component?.displayName || Component?.name || 'unknown'} (createSkinComponent)`;
+
+//     return Component as React.ComponentType<TResult> | React.NamedExoticComponent<TResult>;
+// }
+
+export function createSkinComponent<TProps, TResult = {}>(
+    Component: React.ComponentType<TProps>,
+    getCx?: (props: Readonly<TResult>) => CX,
+    getProps?: (props: Readonly<TResult>) => TResult,
+) {
+    function SkinComponent(props: TResult): React.ReactElement<any> {
+        const allProps: any = { ...props };
+
+        if (getProps) {
+            Object.assign(allProps, getProps(props));
+        }
+
+        const getCxResult = getCx?.(props);
+        if (getCxResult) {
+            allProps.cx = [getCxResult, (props as any).cx];
+        }
+
+        return React.createElement(Component, allProps);
+    }
+
+    SkinComponent.displayName = `${Component.displayName || Component.name || 'unknown'} (createSkinComponent)`;
+
+    return SkinComponent;
+}

--- a/uui-core/src/helpers/createSkinComponent.ts
+++ b/uui-core/src/helpers/createSkinComponent.ts
@@ -6,7 +6,11 @@ export function createSkinComponent<TProps, TResult = {}>(
     getProps?: (props: Readonly<TResult>) => TResult,
     getCx?: (props: Readonly<TResult>) => CX,
 ) : (props: TResult & React.RefAttributes<TResult>) => React.ReactElement | null {
-    function SkinComponent(props: TResult): React.ReactElement<any> | null {
+    if (!getProps && !getCx) {
+        return Component as any;
+    }
+
+    const SkinComponent = React.forwardRef<any, any>((props: TResult, ref): React.ReactElement<any> | null => {
         const allProps: any = { ...props };
 
         if (getProps) {
@@ -18,8 +22,14 @@ export function createSkinComponent<TProps, TResult = {}>(
             allProps.cx = [getCxResult, (props as any).cx];
         }
 
+        if (Component.prototype instanceof React.Component) {
+            allProps.forwardedRef = ref;
+        } else {
+            allProps.ref = ref;
+        }
+
         return React.createElement(Component, allProps);
-    }
+    });
 
     SkinComponent.displayName = `${Component.displayName || Component.name || 'unknown'} (createSkinComponent)`;
 

--- a/uui-core/src/helpers/createSkinComponent.ts
+++ b/uui-core/src/helpers/createSkinComponent.ts
@@ -1,38 +1,12 @@
 import * as React from 'react';
 import { CX } from '../types';
 
-// export function createSkinComponent<TProps, TResult = {}>(
-//     Component: any,
-//     getCx?: (props: Readonly<TResult>) => CX,
-//     getProps?: (props: Readonly<TResult>) => TResult,
-// ) {
-//     // const wrappedComponent = (props: TResult): React.ReactElement<TResult> => {
-//     //     const allProps: any = { ...props };
-
-//     //     if (getProps) {
-//     //         Object.assign(allProps, getProps?.(props));
-//     //     }
-
-//     //     const getCxResult = getCx?.(props);
-
-//     //     if (getCxResult) {
-//     //         allProps.cx = [getCxResult, (props as any).cx];
-//     //     }
-
-//     //     return Component;
-//     // };
-
-//     // (wrappedComponent as any).displayName = `${Component?.displayName || Component?.name || 'unknown'} (createSkinComponent)`;
-
-//     return Component as React.ComponentType<TResult> | React.NamedExoticComponent<TResult>;
-// }
-
 export function createSkinComponent<TProps, TResult = {}>(
     Component: React.ComponentType<TProps>,
     getCx?: (props: Readonly<TResult>) => CX,
     getProps?: (props: Readonly<TResult>) => TResult,
-) {
-    function SkinComponent(props: TResult): React.ReactElement<any> {
+) : (props: TResult & React.RefAttributes<TResult>) => React.ReactElement | null {
+    function SkinComponent(props: TResult): React.ReactElement<any> | null {
         const allProps: any = { ...props };
 
         if (getProps) {

--- a/uui-core/src/helpers/index.ts
+++ b/uui-core/src/helpers/index.ts
@@ -25,3 +25,4 @@ export * from './queryToSearch';
 export * from './searchToQuery';
 export * from './uuiLogger';
 export * from './clearEmptyValueFromRecord';
+export * from './createSkinComponent';

--- a/uui-core/src/types/components/Button.ts
+++ b/uui-core/src/types/components/Button.ts
@@ -33,36 +33,31 @@ export interface ButtonCoreProps extends ButtonBaseCoreProps, IHasCaption, IBasi
     count?: number | null;
 }
 
-type HrefButtonProps = ButtonCoreProps & {
-    href: string | never;
+type HrefButtonRawProps = ButtonCoreProps & {
     rawProps?: React.AnchorHTMLAttributes<HTMLAnchorElement>;
+    href: string | never;
     link?: never;
 };
 
-type LinkObjectButtonProps = ButtonCoreProps & {
-    link: Link;
+type LinkButtonRawProps = ButtonCoreProps & {
     rawProps?: React.AnchorHTMLAttributes<HTMLAnchorElement>;
+    link: Link;
     href?: never;
 };
 
-type TrueButtonProps = ButtonCoreProps & {
+type ButtonRawProps = ButtonCoreProps & {
     rawProps?: React.ButtonHTMLAttributes<HTMLButtonElement>;
     href?: never;
     link?: never;
 };
 
-type TrueAnchorProps = ButtonCoreProps & {
+type AnchorRawProps = ButtonCoreProps & {
     rawProps?: React.AnchorHTMLAttributes<HTMLAnchorElement>;
-    href?: string;
-    link?: Link;
+    href: string;
+    link: Link;
 };
 
-// Discuss this
-// type Omit<T, K extends keyof any> = Pick<T, Exclude<keyof T, K>>;
-
-// export type OmitFromUnion<T, K extends string | number | symbol> = T extends {} ? Omit<T, K> : never;
-
-export type ButtonComponentProps = ICanRedirect & (HrefButtonProps | LinkObjectButtonProps | TrueButtonProps | TrueAnchorProps);
+export type ButtonComponentProps = ICanRedirect & (HrefButtonRawProps | LinkButtonRawProps | ButtonRawProps | AnchorRawProps);
 
 export interface ButtonSemanticProps {
     type?: 'success' | 'cancel' | 'action';

--- a/uui-core/src/types/components/Button.ts
+++ b/uui-core/src/types/components/Button.ts
@@ -57,6 +57,8 @@ type AnchorRawProps = ButtonCoreProps & {
     link: Link;
 };
 
+export type MergedRawProps = React.AnchorHTMLAttributes<HTMLAnchorElement> & React.ButtonHTMLAttributes<HTMLButtonElement>;
+
 export type ButtonComponentProps = ICanRedirect & (HrefButtonRawProps | LinkButtonRawProps | ButtonRawProps | AnchorRawProps);
 
 export interface ButtonSemanticProps {

--- a/uui-core/src/types/components/Button.ts
+++ b/uui-core/src/types/components/Button.ts
@@ -1,19 +1,26 @@
 import * as React from 'react';
-import { ICanRedirect, IClickable, IDisableable, IHasCaption, IHasCX, IHasIcon, IHasPlaceholder, IAnalyticableClick,
-    IHasTabIndex, IHasRawProps, IDropdownToggler,
+import {
+    ICanRedirect,
+    IClickable,
+    IDisableable,
+    IHasCaption,
+    IHasCX,
+    IHasIcon,
+    IHasPlaceholder,
+    IAnalyticableClick,
+    IHasTabIndex,
+    IDropdownToggler,
 } from '../props';
 import { IBasicPickerToggler } from '../pickers';
-import { Icon } from '../objects';
+import { Icon, Link } from '../objects';
 
 export interface ButtonBaseCoreProps
     extends IHasCX,
     IClickable,
-    ICanRedirect,
     IDisableable,
     IHasIcon,
     IAnalyticableClick,
-    IHasTabIndex,
-    IHasRawProps<React.ButtonHTMLAttributes<HTMLButtonElement>> {}
+    IHasTabIndex {}
 
 export interface ButtonCoreProps extends ButtonBaseCoreProps, IHasCaption, IBasicPickerToggler, IDropdownToggler, IHasPlaceholder {
     /** Icon for drop-down toggler */
@@ -25,6 +32,37 @@ export interface ButtonCoreProps extends ButtonBaseCoreProps, IHasCaption, IBasi
     countPosition?: 'left' | 'right';
     count?: number | null;
 }
+
+type HrefButtonProps = ButtonCoreProps & {
+    href: string | never;
+    rawProps?: React.AnchorHTMLAttributes<HTMLAnchorElement>;
+    link?: never;
+};
+
+type LinkObjectButtonProps = ButtonCoreProps & {
+    link: Link;
+    rawProps?: React.AnchorHTMLAttributes<HTMLAnchorElement>;
+    href?: never;
+};
+
+type TrueButtonProps = ButtonCoreProps & {
+    rawProps?: React.ButtonHTMLAttributes<HTMLButtonElement>;
+    href?: never;
+    link?: never;
+};
+
+type TrueAnchorProps = ButtonCoreProps & {
+    rawProps?: React.AnchorHTMLAttributes<HTMLAnchorElement>;
+    href?: string;
+    link?: Link;
+};
+
+// Discuss this
+// type Omit<T, K extends keyof any> = Pick<T, Exclude<keyof T, K>>;
+
+// export type OmitFromUnion<T, K extends string | number | symbol> = T extends {} ? Omit<T, K> : never;
+
+export type ButtonComponentProps = ICanRedirect & (HrefButtonProps | LinkObjectButtonProps | TrueButtonProps | TrueAnchorProps);
 
 export interface ButtonSemanticProps {
     type?: 'success' | 'cancel' | 'action';

--- a/uui/components/buttons/Button/Button.tsx
+++ b/uui/components/buttons/Button/Button.tsx
@@ -19,6 +19,11 @@ export interface ButtonMods {
 
 export type ButtonProps = ButtonMods & uuiComponents.ButtonProps;
 
+export type ButtonPropsType = uuiComponents.ButtonProps & {
+    size?: ControlSize | '18';
+    mode?: ButtonMode;
+};
+
 export function applyButtonMods(mods: ButtonProps) {
     return [
         `button-${mods.color || 'primary'}`,

--- a/uui/components/buttons/Button/Button.tsx
+++ b/uui/components/buttons/Button/Button.tsx
@@ -19,7 +19,7 @@ export interface ButtonMods {
 
 export type ButtonProps = ButtonMods & uuiComponents.ButtonProps;
 
-export type ButtonPropsType = uuiComponents.ButtonProps & {
+export type ButtonCoreProps = uuiComponents.ButtonProps & {
     size?: ControlSize | '18';
     mode?: ButtonMode;
 };

--- a/uui/components/buttons/IconButton.tsx
+++ b/uui/components/buttons/IconButton.tsx
@@ -13,7 +13,7 @@ export interface IconButtonMods {
 
 export type IconButtonProps = IconButtonBaseProps & IconButtonMods;
 
-export type IconButtonType= IconButtonBaseProps & {};
+export type IconButtonCoreProps= IconButtonBaseProps & {};
 
 function applyIconButtonMods(mods: IconButtonProps & IconButtonMods) {
     return [`icon-button-${mods.color || 'default'}`, css.root];

--- a/uui/components/buttons/IconButton.tsx
+++ b/uui/components/buttons/IconButton.tsx
@@ -11,7 +11,9 @@ export interface IconButtonMods {
     color?: IconColor;
 }
 
-export interface IconButtonProps extends IconButtonBaseProps, IconButtonMods {}
+export type IconButtonProps = IconButtonBaseProps & IconButtonMods;
+
+export type IconButtonType= IconButtonBaseProps & {};
 
 function applyIconButtonMods(mods: IconButtonProps & IconButtonMods) {
     return [`icon-button-${mods.color || 'default'}`, css.root];

--- a/uui/components/buttons/LinkButton.tsx
+++ b/uui/components/buttons/LinkButton.tsx
@@ -10,12 +10,13 @@ export type LinkButtonColorType = 'primary' | 'secondary' | 'contrast';
 export const allLinkButtonColors: LinkButtonColorType[] = ['primary', 'secondary', 'contrast'];
 
 export interface LinkButtonMods {
-    size?: types.ControlSize | '42';
     color?: LinkButtonColorType;
 }
 
-export type LinkButtonProps = LinkButtonMods & ButtonProps;
-export type LinkButtonPropsType = ButtonProps & LinkButtonMods;
+export type LinkButtonCoreProps = ButtonProps & {
+    size?: types.ControlSize | '42';
+};
+export type LinkButtonProps = LinkButtonCoreProps & LinkButtonMods;
 
 function applyLinkButtonMods(mods: LinkButtonProps) {
     return [
@@ -26,7 +27,7 @@ function applyLinkButtonMods(mods: LinkButtonProps) {
     ];
 }
 
-export const LinkButton = withMods<ButtonProps, LinkButtonMods>(Button, applyLinkButtonMods, (props) => ({
+export const LinkButton = withMods<LinkButtonCoreProps, LinkButtonMods>(Button, applyLinkButtonMods, (props) => ({
     dropdownIcon: systemIcons[props.size || defaultSize].foldingArrow,
     clearIcon: systemIcons[props.size || defaultSize].clear,
 }));

--- a/uui/components/buttons/LinkButton.tsx
+++ b/uui/components/buttons/LinkButton.tsx
@@ -15,6 +15,7 @@ export interface LinkButtonMods {
 }
 
 export type LinkButtonProps = LinkButtonMods & ButtonProps;
+export type LinkButtonPropsType = ButtonProps & LinkButtonMods;
 
 function applyLinkButtonMods(mods: LinkButtonProps) {
     return [

--- a/uui/components/buttons/TabButton.tsx
+++ b/uui/components/buttons/TabButton.tsx
@@ -26,5 +26,5 @@ export const TabButton = withMods<ButtonProps, TabButtonMods>(Button, applyTabBu
     clearIcon: systemIcons['36'].clear,
     countPosition: 'right',
     ...props,
-    rawProps: { role: 'tab', ...props.rawProps },
+    // rawProps: { role: 'tab', ...props.rawProps },
 }));

--- a/uui/components/buttons/TabButton.tsx
+++ b/uui/components/buttons/TabButton.tsx
@@ -1,5 +1,5 @@
 import { Button, ButtonProps } from '@epam/uui-components';
-import { withMods } from '@epam/uui-core';
+import { MergedRawProps, withMods } from '@epam/uui-core';
 import { systemIcons } from '../../icons/icons';
 import { getIconClass } from './helper';
 import css from './TabButton.module.scss';
@@ -26,5 +26,5 @@ export const TabButton = withMods<ButtonProps, TabButtonMods>(Button, applyTabBu
     clearIcon: systemIcons['36'].clear,
     countPosition: 'right',
     ...props,
-    // rawProps: { role: 'tab', ...props.rawProps },
+    rawProps: { role: 'tab', ...props.rawProps as MergedRawProps },
 }));

--- a/uui/components/inputs/MultiSwitch.tsx
+++ b/uui/components/inputs/MultiSwitch.tsx
@@ -5,9 +5,9 @@ import { ControlGroup } from '../layout/ControlGroup';
 import { Button, ButtonMods } from '../buttons';
 import { SizeMod } from '../types';
 
-interface MultiSwitchItem<TValue> extends ButtonProps, ButtonMods {
+type MultiSwitchItem<TValue> = ButtonProps & ButtonMods & {
     id: TValue;
-}
+};
 
 export type UuiMultiSwitchColor = 'primary' | 'secondary';
 

--- a/uui/components/navigation/MainMenu/MainMenuIcon.tsx
+++ b/uui/components/navigation/MainMenu/MainMenuIcon.tsx
@@ -4,9 +4,9 @@ import { ButtonProps } from '@epam/uui-components';
 import { IconButton } from '../../buttons';
 import css from './MainMenuIcon.module.scss';
 
-export interface MainMenuIconProps extends ButtonProps, IAdaptiveItem {
+export type MainMenuIconProps = ButtonProps & IAdaptiveItem & {
     icon: Icon;
-}
+};
 
 export const MainMenuIcon = React.forwardRef<HTMLButtonElement | HTMLAnchorElement, MainMenuIconProps>((props, ref) => (
     <IconButton ref={ ref } icon={ props.icon } cx={ cx(props.cx, css.container) } { ...props } />

--- a/uui/components/widgets/Badge.tsx
+++ b/uui/components/widgets/Badge.tsx
@@ -22,21 +22,21 @@ export type BadgeSize = '18' | '24' | '30' | '36' | '42' | '48';
 export interface BadgeMods {
     color?: BadgeColor;
     fill?: BadgeFill;
-    size?: BadgeSize;
 }
 
-export type BadgeProps = ButtonProps & BadgeMods;
-export type BadgePropsType = ButtonProps & {
+export type BadgeCoreProps = ButtonProps & {
     size?: BadgeSize;
 };
 
-export function applyBadgeMods(mods: BadgeMods) {
+export type BadgeProps = BadgeCoreProps & BadgeMods;
+
+export function applyBadgeMods(mods: BadgeProps) {
     return [
         css.root, buttonCss.root, css['size-' + (mods.size || defaultSize)], css['fill-' + (mods.fill || 'solid')], mods.color && `badge-${mods.color}`,
     ];
 }
 
-export const Badge = withMods<ButtonProps, BadgeMods>(Button, applyBadgeMods, (props) => ({
+export const Badge = withMods<BadgeProps, BadgeMods>(Button, applyBadgeMods, (props) => ({
     dropdownIcon: systemIcons[(props.size && mapSize[props.size]) || defaultSize].foldingArrow,
     clearIcon: systemIcons[(props.size && mapSize[props.size]) || defaultSize].clear,
     countPosition: 'left',

--- a/uui/components/widgets/Badge.tsx
+++ b/uui/components/widgets/Badge.tsx
@@ -26,6 +26,9 @@ export interface BadgeMods {
 }
 
 export type BadgeProps = ButtonProps & BadgeMods;
+export type BadgePropsType = ButtonProps & {
+    size?: BadgeSize;
+};
 
 export function applyBadgeMods(mods: BadgeMods) {
     return [


### PR DESCRIPTION
### Issue link(if exists): 
https://github.com/epam/UUI/issues/1421
+ and added `createSkinComponent`

### Description:
Points to discuss: rawProps: `rawProps: { role: 'tab', ...props.rawProps as MergedRawProps }` in the TabButtonComponent 