### PR TITLE
[DataTableRow] Fix data table row `rowProps`

### DIFF
--- a/uui-components/src/table/DataTableRow.tsx
+++ b/uui-components/src/table/DataTableRow.tsx
@@ -60,6 +60,7 @@ const DataTableRowImpl = React.forwardRef(function DataTableRow<TItem, TId>(prop
                 renderCell={ renderCell }
                 onClick={ clickHandler && (() => clickHandler(props)) }
                 rawProps={ {
+                    ...props.rawProps,
                     ...params.eventHandlers,
                     role: 'row',
                     'aria-expanded': (props.isFolded === undefined || props.isFolded === null) ? undefined : !props.isFolded,


### PR DESCRIPTION
## Summary

#1628

Adds ability to add `rowProps`for `DataTableRow`.