### PR TITLE
[DataSources]: Fixed background reload in paged table and filtered table.

### DIFF
--- a/uui-core/src/data/processing/views/BaseListView.tsx
+++ b/uui-core/src/data/processing/views/BaseListView.tsx
@@ -657,7 +657,7 @@ export abstract class BaseListView<TItem, TId, TFilter> implements IDataSourceVi
 
     protected checkedWasChanged = (prevValue?: DataSourceState<TFilter, TId>, newValue?: DataSourceState<TFilter, TId>) => 
         (prevValue?.checked?.length ?? 0) !== (newValue?.checked?.length ?? 0)
-        || !isEqual(newValue?.checked, prevValue?.checked);
+        || (prevValue.checked && newValue.checked && !isEqual(newValue?.checked, prevValue?.checked));
     
     protected sortingWasChanged = (prevValue?: DataSourceState<TFilter, TId>, newValue?: DataSourceState<TFilter, TId>) => 
         !isEqual(newValue?.sorting, prevValue?.sorting);

--- a/uui-core/src/data/processing/views/LazyListView.ts
+++ b/uui-core/src/data/processing/views/LazyListView.ts
@@ -191,7 +191,6 @@ export class LazyListView<TItem, TId, TFilter = any> extends BaseListView<TItem,
             // on filters change skeleton should not appear
             (completeReset && shouldShowPlacehodlers)
             || this.shouldRebuildRows(prevValue, this.value)
-            || !isEqual(this.props.rowOptions, prevProps?.rowOptions)
             || isFoldingChanged
             || moreRowsNeeded
         ) {


### PR DESCRIPTION
### Summary

Placeholders appeared on the first page change, because at that moment there was no checked property in dataSource state.
Also, placeholders appeared on every change of rowOptions (not memorized callbacks).