### PR TITLE
[Dropdown]: rework isInteractedOutsideDropdown helper to work with e.composedPath()

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -8,11 +8,13 @@
 * [DataTable]: Focus manager.
     * Added ability to change focus on different cells using a keyboard in editable tables.
     * See the example [here](https://uui.epam.com/demo?id=editableTable).
+* [Dropdown]: improve close on click outside dropdown logic
 
 **What's Fixed**
 * [LazyDataSource]: fixed cascade selection with not flatten search.
 * [NotificationCard]: color `gray60` in promo, and `night600` in loveship are deprecated and will be removed in future release.
 * [VirtualList]: fixed `onScroll` prop typing
+* [PickerInput]: fixed closing picker body by checking some item in 'Show only selected' mode
 
 # 5.4.3 - 19.12.2023
 

--- a/uui-components/src/overlays/DropdownHelpers.ts
+++ b/uui-components/src/overlays/DropdownHelpers.ts
@@ -3,7 +3,7 @@ import { closestTargetParentByCondition } from '@epam/uui-core';
 export const isInteractedOutsideDropdown = (e: Event, stopNodes: HTMLElement[]) => {
     const [bodyNode] = stopNodes;
 
-    if (stopNodes.some((node) => node && closestTargetParentByCondition(e, node))) {
+    if (stopNodes.some((node) => e.composedPath().includes(node))) {
         // Interacted inside any of the stop nodes
         return false;
     }

--- a/uui/components/inputs/TextInput.tsx
+++ b/uui/components/inputs/TextInput.tsx
@@ -47,13 +47,7 @@ export const SearchInput = React.forwardRef<HTMLInputElement, SearchInputProps>(
             render={ (iEditable) => (
                 <TextInput
                     icon={ systemIcons[props.size || DEFAULT_SIZE].search }
-                    onCancel={ !!props.value
-                        // In a lot of places, it is required to check if a clicked element is a part of some other element.
-                        // Usually, those are global click event handlers. To allow that logic to work correctly, it is necessary
-                        // to execute the `disappearing` of the cross (setState execution) after the event will pass through all the handlers.
-                        // Related issue: https://github.com/epam/UUI/issues/1045.
-                        ? (() => setTimeout(() => iEditable.onValueChange(''), 0))
-                        : undefined }
+                    onCancel={ !!props.value && (() => iEditable.onValueChange('')) }
                     type="search"
                     inputMode="search"
                     ref={ ref }


### PR DESCRIPTION
…composedPath(), rather than go through dom tree to detect if click was triggered on node inside parent stop nodes. It was an issues, that dom was updated earlier than event bubble to the parent node.

<!-- **Before submitting your PR, ensure that you made the following:**

- Linked the issue(if exists)
- Lint and unit tests pass locally with my changes
- Changelog is updated or not needed
- Documentation is updated/provided or not needed
- Property explorer is updated/provided or not needed
- TSDoc comments for public interfaces is updated/provided or not needed 
 -->

#### Issue link(if exists): #1789, #1385

**Testing notes:**
Need to retest:
- dropdown close on click outside logic
- Dropdown shouldn't close by clicks inside its body
- retest #1045 issue, since prior fix was reverted in flavor of this more versatile fix
