### PR TITLE
Bugfix/TimePicker 24format parsing fix

### DIFF
--- a/uui/components/inputs/__tests__/TimePicker.test.tsx
+++ b/uui/components/inputs/__tests__/TimePicker.test.tsx
@@ -118,6 +118,15 @@ describe('TimePicker', () => {
         expect(dom.input.value).toEqual('05:00 PM');
     });
 
+    it('should set a right value #9', async () => {
+        const { dom } = await setupTestComponent({ value: { hours: 11, minutes: 23 }, format: 24 });
+        expect(dom.input.value).toEqual('11:23');
+        fireEvent.change(dom.input, { target: { value: '0000' } });
+        expect(dom.input.value).toEqual('0000');
+        fireEvent.blur(dom.input);
+        expect(dom.input.value).toEqual('00:00');
+    });
+
     it('should reset invalid value onBlur', async () => {
         const { dom } = await setupTestComponent({ value: { hours: 18, minutes: 23 } });
         expect(dom.input.value).toEqual('06:23 PM');

--- a/uui/components/inputs/__tests__/TimePickerParseHelper.test.tsx
+++ b/uui/components/inputs/__tests__/TimePickerParseHelper.test.tsx
@@ -52,11 +52,11 @@ describe('TimePicker, formatTime function', () => {
     it('Should return time without meridian', () => {
         expect(formatTime(12, 34, false)).toEqual('12:34');
         expect(formatTime(2, 4, false)).toEqual('02:04');
+        expect(formatTime(0, 0, false)).toEqual('00:00');
     });
 
     it('Should return empty string', () => {
         expect(formatTime(0, 0, 'AM')).toEqual('');
         expect(formatTime(0, 0, 'PM')).toEqual('');
-        expect(formatTime(0, 0, false)).toEqual('');
     });
 });

--- a/uui/components/inputs/timePicker/parseTimeHelper.ts
+++ b/uui/components/inputs/timePicker/parseTimeHelper.ts
@@ -29,7 +29,7 @@ export const formatTime = (hours: number, minutes: number, meridian: 'AM' | 'PM'
     const hoursToString = Number.isNaN(hours) ? '00' : hours.toString().padStart(2, '0');
     const minutesToString = Number.isNaN(minutes) ? '00' : minutes.toString().padStart(2, '0');
 
-    if (hoursToString === '00' && minutesToString === '00') {
+    if (meridian && hoursToString === '00' && minutesToString === '00') {
         return '';
     }
 


### PR DESCRIPTION
<!-- **Before submitting your PR, ensure that you made the following:**

- Linked the issue(if exists)
- Lint and unit tests pass locally with my changes
- Changelog is updated or not needed
- Documentation is updated/provided or not needed
- Property explorer is updated/provided or not needed
- TSDoc comments for public interfaces is updated/provided or not needed 
 -->

#### Issue link(if exists): 

### Description: fixed parsing of input '0000' in 24 time format, should return '00:00'.
