### PR TITLE
[PickerInput]: fixed loading of selectedId with parents.

### DIFF
--- a/app/src/docs/_examples/pickerInput/LazyTreeInput.example.tsx
+++ b/app/src/docs/_examples/pickerInput/LazyTreeInput.example.tsx
@@ -1,27 +1,18 @@
-import React, { useCallback, useMemo, useState } from 'react';
+import React, { useState } from 'react';
 import { FlexCell, PickerInput } from '@epam/uui';
-import { DataQueryFilter, UuiContexts, useLazyDataSource, useUuiContext } from '@epam/uui-core';
+import { DataQueryFilter, useLazyDataSource, useUuiContext } from '@epam/uui-core';
 import { Location } from '@epam/uui-docs';
-import { TApi } from '../../../data';
 
 export default function LazyTreePicker() {
-    const svc = useUuiContext<TApi, UuiContexts>();
-    const [selectedId, onValueChange] = useState<string>('2509031');
-
-    const itemsMap = useMemo(() => new Map(), []);
-
-    const isFoldedByDefault = useCallback((item: Location) => {
-        return !['c-AF', 'DZ'].includes(item.id);
-    }, []);
+    const svc = useUuiContext();
+    const [value, onValueChange] = useState<string[]>([]);
 
     const dataSource = useLazyDataSource<Location, string, DataQueryFilter<Location>>(
         {
-            api: async (request, ctx) => {
+            api: (request, ctx) => {
                 const { search } = request;
                 const filter = search ? {} : { parentId: ctx?.parentId };
-                const result = await svc.api.demo.locations({ ...request, search, filter });
-                result.items.forEach((item) => itemsMap.set(item.id, item));
-                return result;
+                return svc.api.demo.locations({ ...request, search, filter });
             },
             cascadeSelection: true,
             getId: (i) => i.id,
@@ -35,13 +26,12 @@ export default function LazyTreePicker() {
         <FlexCell width={ 300 }>
             <PickerInput
                 dataSource={ dataSource }
-                value={ selectedId }
+                value={ value }
                 onValueChange={ onValueChange }
                 entityName="location"
-                selectionMode="single"
+                selectionMode="multi"
                 valueType="id"
                 cascadeSelection="explicit"
-                isFoldedByDefault={ isFoldedByDefault }
             />
         </FlexCell>
     );

--- a/changelog.md
+++ b/changelog.md
@@ -23,13 +23,16 @@
 * [FlexRow]: added property `justify-content` it can be equals `'center' | 'space-between' | 'space-around' | 'space-evenly' | 'start' | 'end'`, see more in Flexbox Guide(https://css-tricks.com/snippets/css/a-guide-to-flexbox/).
 * [DropSpot]: changed type of the property `infoText` from string into ReactNode. Now you can pass your own realization of it, or pass string and use our.
 
- 
 **What's Fixed**
 * [RadiInput]: added native HTML `name` attribute for the input.
 * [RadioGroup]: added native HTML `name` attribute for each group member.
 * [Tooltip]: fixed vertical paddings according to the design.
 * [SearchInput]: fixed `onCancel` prop. Now component can use provided callback, not only default implementation
 * [useForm]: fixed `close` method to always return Promise
+* [PickerInput]: fixed loading of selectedId with parents.
+  * Fixed returning checked = [] if emptyValue is not passed to PickerInput.
+  * Fixed partially selected with predefined selected value.
+  * Fixed fetching missing parents for selected element in PickerInput.
 
 # 5.5.3 - 07.02.2024
 

--- a/uui-components/src/pickers/bindingHelpers.ts
+++ b/uui-components/src/pickers/bindingHelpers.ts
@@ -31,7 +31,7 @@ class ArrayBindingHelper<TItem, TId> implements PickerBindingHelper<TItem, TId> 
             }
             return dsState.checked;
         } else {
-            return props.emptyValue;
+            return 'emptyValue' in props ? props.emptyValue : [];
         }
     }
 
@@ -83,7 +83,7 @@ class ScalarBindingHelper<TItem, TId> implements PickerBindingHelper<TItem, TId>
         return {
             ...dsState,
             selectedId: id,
-            checked: null,
+            checked: (id === null || id === undefined) ? [] : [id],
             filter: props.filter || dsState.filter,
             sorting: props.sorting ? [props.sorting] : dsState.sorting,
         };

--- a/uui-components/src/pickers/bindingHelpers.ts
+++ b/uui-components/src/pickers/bindingHelpers.ts
@@ -83,7 +83,7 @@ class ScalarBindingHelper<TItem, TId> implements PickerBindingHelper<TItem, TId>
         return {
             ...dsState,
             selectedId: id,
-            checked: (id === null || id === undefined) ? [] : [id],
+            checked: null,
             filter: props.filter || dsState.filter,
             sorting: props.sorting ? [props.sorting] : dsState.sorting,
         };

--- a/uui-components/src/pickers/hooks/usePicker.ts
+++ b/uui-components/src/pickers/hooks/usePicker.ts
@@ -120,7 +120,7 @@ export function usePicker<TItem, TId, TProps extends PickerBaseProps<TItem, TId>
     const view = dataSource.useView(getDataSourceState(), handleDataSourceValueChange, {
         rowOptions: getRowOptions(),
         getSearchFields: getSearchFields || ((item: TItem) => [getName(item)]),
-        isFoldedByDefault,
+        ...(isFoldedByDefault ? { isFoldedByDefault } : {}),
         ...(sortBy ? { sortBy } : {}),
         ...(cascadeSelection ? { cascadeSelection } : {}),
         ...(props.getRowOptions ? { getRowOptions: props.getRowOptions } : {}),

--- a/uui-core/src/data/processing/views/ArrayListView.ts
+++ b/uui-core/src/data/processing/views/ArrayListView.ts
@@ -75,6 +75,7 @@ export class ArrayListView<TItem, TId, TFilter = any> extends BaseListView<TItem
         if (this.fullTree && (prevTree !== this.visibleTree || this.isCacheIsOutdated(value, currentValue))) {
             this.updateTree(currentValue, value);
             this.updateCheckedLookup(this.value.checked);
+            this.updateSelectedLookup(this.value.selectedId);
             this.rebuildRows();
         } else {
             if (value.focusedIndex !== currentValue.focusedIndex) {

--- a/uui-core/src/data/processing/views/BaseListView.tsx
+++ b/uui-core/src/data/processing/views/BaseListView.tsx
@@ -397,8 +397,6 @@ export abstract class BaseListView<TItem, TId, TFilter> implements IDataSourceVi
                         if (childrenIds.length > 0) {
                             // some children are loaded
                             const childStats = iterateNode(id, appendRows && !row.isFolded);
-                            // row.isChildrenChecked = row.isChildrenChecked || childStats.isSomeChecked;
-                            // row.isChildrenSelected = childStats.isSomeSelected;
                             stats = this.mergeStats(stats, childStats);
                             // while searching and no children in visible tree, no need to append placeholders.
                         } else if (!this.value.search && !row.isFolded && appendRows) {

--- a/uui-core/src/data/processing/views/BaseListView.tsx
+++ b/uui-core/src/data/processing/views/BaseListView.tsx
@@ -262,7 +262,8 @@ export abstract class BaseListView<TItem, TId, TFilter> implements IDataSourceVi
             row.isFoldable = true;
         }
 
-        const isCheckable = rowOptions && rowOptions.checkbox && rowOptions.checkbox.isVisible && !rowOptions.checkbox.isDisabled;
+        const isCheckboxEnabled = rowOptions && rowOptions.checkbox && rowOptions.checkbox.isVisible;
+        const isCheckable = isCheckboxEnabled && !rowOptions.checkbox.isDisabled;
         const isSelectable = rowOptions && rowOptions.isSelectable;
         if (rowOptions != null) {
             const rowValue = row.value;
@@ -277,6 +278,12 @@ export abstract class BaseListView<TItem, TId, TFilter> implements IDataSourceVi
         row.onSelect = rowOptions && rowOptions.isSelectable && this.handleOnSelect;
         row.onFocus = (isSelectable || isCheckable || row.isFoldable) && this.handleOnFocus;
         row.isChildrenChecked = this.someChildCheckedByKey[this.idToKey(row.id)];
+        const isSingleCheck = this.value.selectedId !== undefined 
+            && this.value.selectedId !== null
+            && this.value.checked?.length === 1
+            && !isCheckboxEnabled;
+
+        row.isChildrenSelected = isSingleCheck && this.someChildCheckedByKey[this.idToKey(row.id)];
     }
 
     private isRowChecked(row: DataRowProps<TItem, TId>) {
@@ -604,7 +611,7 @@ export abstract class BaseListView<TItem, TId, TFilter> implements IDataSourceVi
             }
         }
 
-        if (row.isSelected) {
+        if (row.isSelected || row.isChildrenSelected) {
             isSomeSelected = true;
         }
 

--- a/uui-core/src/data/processing/views/BaseListView.tsx
+++ b/uui-core/src/data/processing/views/BaseListView.tsx
@@ -397,6 +397,8 @@ export abstract class BaseListView<TItem, TId, TFilter> implements IDataSourceVi
                         if (childrenIds.length > 0) {
                             // some children are loaded
                             const childStats = iterateNode(id, appendRows && !row.isFolded);
+                            row.isChildrenChecked = row.isChildrenChecked || childStats.isSomeChecked;
+                            row.isChildrenSelected = row.isChildrenSelected || childStats.isSomeSelected;
                             stats = this.mergeStats(stats, childStats);
                             // while searching and no children in visible tree, no need to append placeholders.
                         } else if (!this.value.search && !row.isFolded && appendRows) {

--- a/uui-core/src/data/processing/views/LazyListView.ts
+++ b/uui-core/src/data/processing/views/LazyListView.ts
@@ -131,7 +131,7 @@ export class LazyListView<TItem, TId, TFilter = any> extends BaseListView<TItem,
         props: LazyListViewProps<TItem, TId, TFilter>,
     ): void {
         this.isUpdatePending = true;
-        const { checked: prevChecked } = this.value ?? {};
+        const { checked: prevChecked, selectedId: prevSelectedId } = this.value ?? {};
         // We assume value to be immutable. However, we can't guarantee this.
         // Let's shallow-copy value to survive at least simple cases when it's mutated outside
         this.value = { topIndex: 0, visibleCount: 20, ...value };
@@ -139,6 +139,9 @@ export class LazyListView<TItem, TId, TFilter = any> extends BaseListView<TItem,
 
         if (!isEqual(value?.checked, prevChecked)) {
             this.updateCheckedLookup(value.checked);
+        }
+        if (value?.selectedId !== prevSelectedId) {
+            this.updateSelectedLookup(value.selectedId);
         }
 
         this.props = {
@@ -179,6 +182,7 @@ export class LazyListView<TItem, TId, TFilter = any> extends BaseListView<TItem,
         const moreRowsNeeded = this.areMoreRowsNeeded(prevValue, this.value);
         if (completeReset || this.shouldRebuildRows(prevValue, this.value)) {
             this.updateCheckedLookup(this.value.checked);
+            this.updateSelectedLookup(this.value.selectedId);
         }
 
         const shouldShowPlacehodlers = !shouldReloadData
@@ -206,6 +210,7 @@ export class LazyListView<TItem, TId, TFilter = any> extends BaseListView<TItem,
                 .then(({ isUpdated, isOutdated }) => {
                     if (isUpdated && !isOutdated) {
                         this.updateCheckedLookup(this.value.checked);
+                        this.updateSelectedLookup(this.value.selectedId);
                         this.rebuildRows();
                     }
                 }).finally(() => {

--- a/uui-core/src/data/processing/views/tree/LoadableTree.ts
+++ b/uui-core/src/data/processing/views/tree/LoadableTree.ts
@@ -8,7 +8,9 @@ import { ITree, LoadTreeOptions, TreeNodeInfo } from './ITree';
 export abstract class LoadableTree<TItem, TId> extends EditableTree<TItem, TId> {
     public async load<TFilter>(options: LoadTreeOptions<TItem, TId, TFilter>, value: Readonly<DataSourceState>, withNestedChildren: boolean = true) {
         let tree = await this.loadMissing(options, value, withNestedChildren);
-        tree = await tree.loadMissingIdsAndParents(options, value.checked);
+        const checked = (value.checked ?? []);
+        const missing = value.selectedId === null || value.selectedId === undefined ? checked : checked.concat(value.selectedId);
+        tree = await tree.loadMissingIdsAndParents(options, missing);
         return tree;
     }
 


### PR DESCRIPTION
### Summary
- Fixed returning `checked = []` if `emptyValue` is not passed to `PickerInput`.
- Fixed partially selected with predefined selected value.
- Fixed fetching missing parents for selected element in `PickerInput`.