### PR TITLE
Bugfix/PickerInput focus locked #1989

### DIFF
--- a/app/src/common/AppHeader.module.scss
+++ b/app/src/common/AppHeader.module.scss
@@ -30,7 +30,9 @@
     }
 
     .theme-caption {
-        font-size: 14px;
+        :global(.uui-caption) {
+            font-size: 14px;
+        }
     }
 }
 

--- a/app/src/common/AppHeader.tsx
+++ b/app/src/common/AppHeader.tsx
@@ -93,7 +93,7 @@ export function AppHeader() {
                 priority: 100499,
                 render: () => (
                     <MainMenuCustomElement key="logo">
-                        <Anchor link={ { pathname: '/' } } href={ GIT_LINK } onClick={ () => sendEvent('Welcome') } key="logo">
+                        <Anchor link={ { pathname: '/' } } href={ GIT_LINK } onClick={ () => sendEvent('Welcome') }>
                             <IconContainer icon={ LogoIcon } cx={ css.logoIcon } />
                         </Anchor>
                     </MainMenuCustomElement>
@@ -172,7 +172,7 @@ export function AppHeader() {
                 priority: 2,
                 render: () => (
                     <MainMenuButton
-                        captionCX={ css.themeCaption }
+                        cx={ css.themeCaption }
                         caption="Theme"
                         showInBurgerMenu
                         key="themeCaption"
@@ -196,6 +196,7 @@ export function AppHeader() {
                 priority: 0,
                 render: () => (
                     <Anchor
+                        key="survey"
                         rawProps={ { style: { height: '60px' } } }
                         target="_blank"
                         href="https://forms.office.com/e/9iEvJUKdeM"

--- a/app/src/docs/_examples/adaptivePanel/Basic.example.tsx
+++ b/app/src/docs/_examples/adaptivePanel/Basic.example.tsx
@@ -9,7 +9,7 @@ export default function BasicAdaptivePanelExample() {
     const renderItem = (item: AdaptiveItemProps<{ data?: { caption: string } }>) => {
         return (
             <div>
-                <Button cx={ css.itemWithMargins } caption={ item.data.caption } onClick={ () => {} } />
+                <Button key={ item.id } cx={ css.itemWithMargins } caption={ item.data.caption } onClick={ () => {} } />
             </div>
         );
     };

--- a/app/src/sandbox/adaptivePanel/AdaptivePanelDemo.tsx
+++ b/app/src/sandbox/adaptivePanel/AdaptivePanelDemo.tsx
@@ -10,7 +10,7 @@ const items: AdaptiveItemProps<{ data?: { name: string } }>[] = [
     //         renderBody={ () => <DropdownContainer><Text>{ hiddenItems.map(i => i.render()) }</Text></DropdownContainer> }
     //     />,
     //     collapsedContainer: true, priority: 99 },
-    { id: '2', render: () => <Button caption="Administrators-4" />, priority: 4 }, { id: '3', render: () => <Button caption="Only age more thanfgdgdfgdg 40-1" />, priority: 1 }, { id: '4', render: () => <Button caption="Managers-2" />, priority: 2 }, { id: '6', render: () => <Button caption="Senior Admins-11" />, priority: 11 }, { id: '7', render: () => <Button caption="Senior Admins-12" />, priority: 12 }, { id: '8', render: () => <Button caption="Senior Admins-13" />, priority: 13 }, {
+    { id: '2', render: () => <Button key="Administrators-4" caption="Administrators-4" />, priority: 4 }, { id: '3', render: () => <Button key="Only age more thanfgdgdfgdg 40-1" caption="Only age more thanfgdgdfgdg 40-1" />, priority: 1 }, { id: '4', render: () => <Button key="Managers-2" caption="Managers-2" />, priority: 2 }, { id: '6', render: () => <Button key="Senior Admins-11" caption="Senior Admins-11" />, priority: 11 }, { id: '7', render: () => <Button key="Senior Admins-12" caption="Senior Admins-12" />, priority: 12 }, { id: '8', render: () => <Button key="Senior Admins-13" caption="Senior Admins-13" />, priority: 13 }, {
         id: '5',
         render: (item, hiddenItems) => (
             <Dropdown

--- a/changelog.md
+++ b/changelog.md
@@ -11,6 +11,7 @@
     * Fixed returning checked = [] if emptyValue is not passed to PickerInput.
     * Fixed partially selected with predefined selected value.
     * Fixed fetching missing parents for selected element in PickerInput.
+    * Fixed focus reset after clicking outside.
 * [DropdownContainer]: fixed warning about incorrect ref in React strict mode
 * [Avatar]: change type of 'img' prop to also accept null value
 * [RTE]: fixed tabled border rendering issues in Firefox

--- a/uui-components/src/navigation/MainMenu/MainMenu.tsx
+++ b/uui-components/src/navigation/MainMenu/MainMenu.tsx
@@ -166,6 +166,7 @@ export class MainMenu extends React.Component<MainMenuProps, MainMenuState> {
                 priority: 100499,
                 render: () => (
                     <MainMenuLogo
+                        key="customerLogo"
                         logoUrl={ this.props.customerLogoUrl }
                         logoBgColor={ this.props.customerLogoBgColor }
                         link={ this.props.customerLogoLink || this.props.logoLink }

--- a/uui-components/src/pickers/PickerToggler.tsx
+++ b/uui-components/src/pickers/PickerToggler.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { IPickerToggler, IHasIcon, IHasCX, ICanBeReadonly, Icon, uuiMod, uuiElement, uuiMarkers, DataRowProps, cx, IHasRawProps, ICanFocus } from '@epam/uui-core';
+import { IPickerToggler, IHasIcon, IHasCX, ICanBeReadonly, Icon, uuiMod, uuiElement, uuiMarkers, DataRowProps, cx, IHasRawProps, ICanFocus, isEventTargetInsideClickable } from '@epam/uui-core';
 import { IconContainer } from '../layout';
 import css from './PickerToggler.module.scss';
 import { i18n } from '../i18n';
@@ -88,13 +88,13 @@ function PickerTogglerComponent<TItem, TId>(props: PickerTogglerProps<TItem, TId
         }
     };
 
-    const handleCrossIconClick = (e: React.SyntheticEvent<HTMLElement>) => {
+    const handleCrossIconClick = () => {
         if (props.onClear) {
             props.onClear();
             props.onValueChange('');
         }
+        // When we click on the cross it disappears from the DOM and focus is passed to the Body. So in this case we have to return focus on the toggleContainer by hand.
         toggleContainer.current?.focus();
-        e.stopPropagation();
     };
 
     const renderItems = () => {
@@ -151,23 +151,13 @@ function PickerTogglerComponent<TItem, TId>(props: PickerTogglerProps<TItem, TId
     };
 
     const togglerPickerOpened = (e: React.MouseEvent<HTMLDivElement>) => {
-        if (props.isDisabled || props.isReadonly) return;
+        if (props.isDisabled || props.isReadonly || isEventTargetInsideClickable(e)) return;
         e.preventDefault();
         if (inFocus && props.value && props.minCharsToSearch) return;
 
         toggleContainer.current.focus();
         props.onClick?.();
     };
-
-    const closeOpenedPickerBody = useCallback(
-        (e: React.MouseEvent<HTMLDivElement>) => {
-            if (props.isOpen) {
-                props.closePickerBody();
-                e.stopPropagation();
-            }
-        },
-        [props.isOpen, props.closePickerBody],
-    );
 
     const icon = props.icon && (
         <IconContainer
@@ -214,7 +204,7 @@ function PickerTogglerComponent<TItem, TId>(props: PickerTogglerProps<TItem, TId
                             rawProps={ { role: 'button', 'aria-label': 'Clear' } }
                         />
                     )}
-                    {props.isDropdown && !props?.minCharsToSearch && <IconContainer icon={ props.dropdownIcon } flipY={ props.isOpen } cx="uui-icon-dropdown" onClick={ closeOpenedPickerBody } />}
+                    {props.isDropdown && !props?.minCharsToSearch && <IconContainer icon={ props.dropdownIcon } flipY={ props.isOpen } cx="uui-icon-dropdown" />}
                 </div>
             )}
         </div>

--- a/uui-components/src/pickers/PickerToggler.tsx
+++ b/uui-components/src/pickers/PickerToggler.tsx
@@ -93,6 +93,7 @@ function PickerTogglerComponent<TItem, TId>(props: PickerTogglerProps<TItem, TId
             props.onClear();
             props.onValueChange('');
         }
+        toggleContainer.current?.focus();
         e.stopPropagation();
     };
 

--- a/uui/components/pickers/__tests__/__snapshots__/PickerInput.test.tsx.snap
+++ b/uui/components/pickers/__tests__/__snapshots__/PickerInput.test.tsx.snap
@@ -24,7 +24,7 @@ exports[`PickerInput should open body 1`] = `
         class="actions"
       >
         <div
-          class="container uui-icon uui-enabled -clickable uui-icon-dropdown"
+          class="container uui-icon uui-enabled uui-icon-dropdown"
         >
           <svg
             class="flipY"
@@ -242,8 +242,7 @@ exports[`PickerInput should render icon at specific position 1`] = `
     className="actions"
   >
     <div
-      className="container uui-icon uui-enabled -clickable uui-icon-dropdown"
-      onClick={[Function]}
+      className="container uui-icon uui-enabled uui-icon-dropdown"
       style={Object {}}
     >
       <svg
@@ -290,8 +289,7 @@ exports[`PickerInput should render icon at specific position 2`] = `
     className="actions"
   >
     <div
-      className="container uui-icon uui-enabled -clickable uui-icon-dropdown"
-      onClick={[Function]}
+      className="container uui-icon uui-enabled uui-icon-dropdown"
       style={Object {}}
     >
       <svg
@@ -338,8 +336,7 @@ exports[`PickerInput should render icon at specific position 3`] = `
     className="actions"
   >
     <div
-      className="container uui-icon uui-enabled -clickable uui-icon-dropdown"
-      onClick={[Function]}
+      className="container uui-icon uui-enabled uui-icon-dropdown"
       style={Object {}}
     >
       <svg
@@ -378,8 +375,7 @@ exports[`PickerInput should render input as invalid 1`] = `
     className="actions"
   >
     <div
-      className="container uui-icon uui-enabled -clickable uui-icon-dropdown"
-      onClick={[Function]}
+      className="container uui-icon uui-enabled uui-icon-dropdown"
       style={Object {}}
     >
       <svg
@@ -488,8 +484,7 @@ exports[`PickerInput should render with minimum props 1`] = `
     className="actions"
   >
     <div
-      className="container uui-icon uui-enabled -clickable uui-icon-dropdown"
-      onClick={[Function]}
+      className="container uui-icon uui-enabled uui-icon-dropdown"
       style={Object {}}
     >
       <svg
@@ -528,8 +523,7 @@ exports[`PickerInput should render with mode = cell 1`] = `
     className="actions"
   >
     <div
-      className="container uui-icon uui-enabled -clickable uui-icon-dropdown"
-      onClick={[Function]}
+      className="container uui-icon uui-enabled uui-icon-dropdown"
       style={Object {}}
     >
       <svg
@@ -568,8 +562,7 @@ exports[`PickerInput should render with mode = form 1`] = `
     className="actions"
   >
     <div
-      className="container uui-icon uui-enabled -clickable uui-icon-dropdown"
-      onClick={[Function]}
+      className="container uui-icon uui-enabled uui-icon-dropdown"
       style={Object {}}
     >
       <svg
@@ -608,8 +601,7 @@ exports[`PickerInput should render with mode = inline 1`] = `
     className="actions"
   >
     <div
-      className="container uui-icon uui-enabled -clickable uui-icon-dropdown"
-      onClick={[Function]}
+      className="container uui-icon uui-enabled uui-icon-dropdown"
       style={Object {}}
     >
       <svg
@@ -648,8 +640,7 @@ exports[`PickerInput should render with mode = undefined 1`] = `
     className="actions"
   >
     <div
-      className="container uui-icon uui-enabled -clickable uui-icon-dropdown"
-      onClick={[Function]}
+      className="container uui-icon uui-enabled uui-icon-dropdown"
       style={Object {}}
     >
       <svg
@@ -688,8 +679,7 @@ exports[`PickerInput should support single line 1`] = `
     className="actions"
   >
     <div
-      className="container uui-icon uui-enabled -clickable uui-icon-dropdown"
-      onClick={[Function]}
+      className="container uui-icon uui-enabled uui-icon-dropdown"
       style={Object {}}
     >
       <svg


### PR DESCRIPTION
<!-- **Before submitting your PR, ensure that you made the following:**

- Linked the issue(if exists)
- Lint and unit tests pass locally with my changes
- Changelog is updated or not needed
- Documentation is updated/provided or not needed
- Property explorer is updated/provided or not needed
- TSDoc comments for public interfaces is updated/provided or not needed 
 -->

#### Issue link(if exists): https://github.com/epam/UUI/issues/1989

### Description: [PickerToggler]: returned focus on the togglerContainer after crossIcon clicked
