### PR TITLE
Bugfix/PickerInput focus locked #1989

### DIFF
--- a/uui-components/src/pickers/PickerToggler.tsx
+++ b/uui-components/src/pickers/PickerToggler.tsx
@@ -102,10 +102,22 @@ function PickerTogglerComponent<TItem, TId>(props: PickerTogglerProps<TItem, TId
         if (props.selectedRowsCount > maxItems) {
             return props.renderItem?.({
                 value: i18n.pickerToggler.createItemValue(props.selectedRowsCount, props.entityName || ''),
-                onCheck: () => props.onClear?.(),
+                onCheck: () => {
+                    props.onClear?.();
+                    // When we delete item it disappears from the DOM and focus is passed to the Body. So in this case we have to return focus on the toggleContainer by hand.
+                    toggleContainer.current?.focus();
+                },
             } as any);
         } else {
-            return props.selection?.map((row) => props.renderItem?.(row));
+            return props.selection?.map((row) => {
+                const newRow = { ...row,
+                    onCheck: () => {
+                        row.onCheck?.(row);
+                        // When we delete item it disappears from the DOM and focus is passed to the Body. So in this case we have to return focus on the toggleContainer by hand.
+                        toggleContainer.current?.focus();
+                    } };
+                return props.renderItem?.(newRow);
+            });
         }
     };
 

--- a/uui/components/pickers/PickerToggler.tsx
+++ b/uui/components/pickers/PickerToggler.tsx
@@ -61,9 +61,8 @@ function PickerTogglerComponent<TItem extends string, TId>(props: PickerTogglerP
             caption={ getCaption(row) }
             tabIndex={ -1 }
             size={ props.size ? getPickerTogglerButtonSize(props.size) : '30' }
-            onClear={ (e) => {
+            onClear={ () => {
                 row.onCheck?.(row);
-                e.stopPropagation();
             } }
             isDisabled={ props.isDisabled || props.isReadonly || row?.checkbox?.isDisabled }
         />


### PR DESCRIPTION
<!-- **Before submitting your PR, ensure that you made the following:**

- Linked the issue(if exists)
- Lint and unit tests pass locally with my changes
- Changelog is updated or not needed
- Documentation is updated/provided or not needed
- Property explorer is updated/provided or not needed
- TSDoc comments for public interfaces is updated/provided or not needed 
 -->

#### Issue link(if exists): https://github.com/epam/UUI/issues/1989

### Description: Component stays in focused state when clicking outside. Fixed by return focus on the PickerToggler container.
