### PR TITLE
Bugfix/switch is readonly prop doesn't work #2010

### DIFF
--- a/uui-components/src/inputs/Switch.tsx
+++ b/uui-components/src/inputs/Switch.tsx
@@ -38,6 +38,7 @@ export class Switch extends React.Component<SwitchProps> {
                     css.container,
                     this.props.cx,
                     this.props.isDisabled && uuiMod.disabled,
+                    this.props.isReadonly && uuiMod.readonly,
                     !this.props.isReadonly && !this.props.isDisabled && uuiMarkers.clickable,
                 ) }
                 ref={ this.props.forwardedRef }

--- a/uui/components/inputs/Switch.module.scss
+++ b/uui/components/inputs/Switch.module.scss
@@ -133,11 +133,7 @@
         }
     }
 
-    &:global(.uui-disabled) {
-        :global(.uui-input-label) {
-            color: var(--uui-switch-label-disabled);
-        }
-
+    &:global(.uui-readonly), &:global(.uui-disabled) {
         &,
         :global(.uui-switch-toggler),
         :global(.uui-switch-body),
@@ -167,6 +163,12 @@
                 background-color: var(--uui-switch-toggler-bg-disabled);
                 border-color: var(--uui-switch-toggler-border-checked-disabled);
             }
+        }
+    }
+
+    &:global(.uui-disabled) {
+        :global(.uui-input-label) {
+            color: var(--uui-switch-label-disabled);
         }
     }
 }


### PR DESCRIPTION
<!-- **Before submitting your PR, ensure that you made the following:**

- Linked the issue(if exists)
- Lint and unit tests pass locally with my changes
- Changelog is updated or not needed
- Documentation is updated/provided or not needed
- Property explorer is updated/provided or not needed
- TSDoc comments for public interfaces is updated/provided or not needed 
 -->

#### Issue link(if exists): https://github.com/orgs/epam/projects/14/views/1?pane=issue&itemId=53714564

### Description: [Switch]: fixed readonly mod
