### PR TITLE
Bugfix/TimePicker added property to hide cross #2040

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,7 @@
     * Added the ability to pin columns to the right.
 * [RTE]: added `onFocus` prop
 * [IconButton]: added property `size`;
+* [TimePicker]: added property `hideCross` to hide inputs' cross if it needs;
 
 
 **What's Fixed**

--- a/changelog.md
+++ b/changelog.md
@@ -8,7 +8,7 @@
     * Added the ability to pin columns to the right.
 * [RTE]: added `onFocus` prop
 * [IconButton]: added property `size`;
-* [TimePicker]: added property `hideCross` to hide inputs' cross if it needs;
+* [TimePicker]: added property `disableClear` to disable inputs' clear cross, if it needs;
 
 
 **What's Fixed**

--- a/public/docs/docsGenOutput/docsGenOutput.json
+++ b/public/docs/docsGenOutput/docsGenOutput.json
@@ -83743,7 +83743,7 @@
       "    /**",
       "     * Indicates that inputs' clear cross is hidden",
       "     */",
-      "    hideCross?: boolean;",
+      "    disableClear?: boolean;",
       "}"
      ]
     },
@@ -83867,8 +83867,8 @@
       "required": false
      },
      {
-      "uid": "hideCross",
-      "name": "hideCross",
+      "uid": "disableClear",
+      "name": "disableClear",
       "comment": {
        "raw": [
         "Indicates that inputs' clear cross is hidden"

--- a/public/docs/docsGenOutput/docsGenOutput.json
+++ b/public/docs/docsGenOutput/docsGenOutput.json
@@ -83740,6 +83740,10 @@
       "    inputCx?: CX;",
       "    /** CSS class(es) to put on body-part component. See https://github.com/JedWatson/classnames#usage for details */",
       "    bodyCx?: CX;",
+      "    /**",
+      "     * Indicates that inputs' clear cross is hidden",
+      "     */",
+      "    hideCross?: boolean;",
       "}"
      ]
     },
@@ -83860,6 +83864,22 @@
        "raw": "null | string | number | boolean | ClassDictionary | ClassArray"
       },
       "typeValueRef": "@epam/uui-core:ClassValue",
+      "required": false
+     },
+     {
+      "uid": "hideCross",
+      "name": "hideCross",
+      "comment": {
+       "raw": [
+        "Indicates that inputs' clear cross is hidden"
+       ]
+      },
+      "typeValue": {
+       "raw": "boolean"
+      },
+      "editor": {
+       "type": "bool"
+      },
       "required": false
      },
      {

--- a/uui/components/inputs/__tests__/TimePicker.test.tsx
+++ b/uui/components/inputs/__tests__/TimePicker.test.tsx
@@ -37,9 +37,9 @@ describe('TimePicker', () => {
         expect(tree).toMatchSnapshot();
     });
 
-    it('should be rendered correctly with hideCross property', async () => {
+    it('should be rendered correctly with disableClear property', async () => {
         const tree = await renderSnapshotWithContextAsync(
-            <TimePicker value={ { hours: 1, minutes: 5 } } onValueChange={ jest.fn } format={ 24 } minutesStep={ 5 } size="36" hideCross={ true } />,
+            <TimePicker value={ { hours: 1, minutes: 5 } } onValueChange={ jest.fn } format={ 24 } minutesStep={ 5 } size="36" disableClear={ true } />,
         );
 
         expect(tree).toMatchSnapshot();

--- a/uui/components/inputs/__tests__/TimePicker.test.tsx
+++ b/uui/components/inputs/__tests__/TimePicker.test.tsx
@@ -37,6 +37,14 @@ describe('TimePicker', () => {
         expect(tree).toMatchSnapshot();
     });
 
+    it('should be rendered correctly with hideCross property', async () => {
+        const tree = await renderSnapshotWithContextAsync(
+            <TimePicker value={ { hours: 1, minutes: 5 } } onValueChange={ jest.fn } format={ 24 } minutesStep={ 5 } size="36" hideCross={ true } />,
+        );
+
+        expect(tree).toMatchSnapshot();
+    });
+
     it('should set a value', async () => {
         const { dom } = await setupTestComponent({ value: null });
         expect(dom.input.value).toEqual('');

--- a/uui/components/inputs/__tests__/__snapshots__/TimePicker.test.tsx.snap
+++ b/uui/components/inputs/__tests__/__snapshots__/TimePicker.test.tsx.snap
@@ -43,3 +43,24 @@ exports[`TimePicker should be rendered correctly with full props 1`] = `
   />
 </div>
 `;
+
+exports[`TimePicker should be rendered correctly with hideCross property 1`] = `
+<div
+  className="container uui-input-box -clickable root size-36 mode-form root timepickerInput"
+  onClick={null}
+  onFocus={[Function]}
+  tabIndex={-1}
+>
+  <input
+    className="uui-input"
+    onBlur={[Function]}
+    onChange={[Function]}
+    onFocus={[Function]}
+    onKeyDown={[Function]}
+    placeholder="HH:mm"
+    tabIndex={0}
+    type="text"
+    value="01:05"
+  />
+</div>
+`;

--- a/uui/components/inputs/__tests__/__snapshots__/TimePicker.test.tsx.snap
+++ b/uui/components/inputs/__tests__/__snapshots__/TimePicker.test.tsx.snap
@@ -64,24 +64,3 @@ exports[`TimePicker should be rendered correctly with full props 1`] = `
   />
 </div>
 `;
-
-exports[`TimePicker should be rendered correctly with hideCross property 1`] = `
-<div
-  className="container uui-input-box -clickable root size-36 mode-form root timepickerInput"
-  onClick={null}
-  onFocus={[Function]}
-  tabIndex={-1}
->
-  <input
-    className="uui-input"
-    onBlur={[Function]}
-    onChange={[Function]}
-    onFocus={[Function]}
-    onKeyDown={[Function]}
-    placeholder="HH:mm"
-    tabIndex={0}
-    type="text"
-    value="01:05"
-  />
-</div>
-`;

--- a/uui/components/inputs/__tests__/__snapshots__/TimePicker.test.tsx.snap
+++ b/uui/components/inputs/__tests__/__snapshots__/TimePicker.test.tsx.snap
@@ -21,6 +21,27 @@ exports[`TimePicker should be rendered correctly 1`] = `
 </div>
 `;
 
+exports[`TimePicker should be rendered correctly with disableClear property 1`] = `
+<div
+  className="container uui-input-box -clickable root size-36 mode-form root timepickerInput"
+  onClick={null}
+  onFocus={[Function]}
+  tabIndex={-1}
+>
+  <input
+    className="uui-input"
+    onBlur={[Function]}
+    onChange={[Function]}
+    onFocus={[Function]}
+    onKeyDown={[Function]}
+    placeholder="HH:mm"
+    tabIndex={0}
+    type="text"
+    value="01:05"
+  />
+</div>
+`;
+
 exports[`TimePicker should be rendered correctly with full props 1`] = `
 <div
   className="container uui-input-box uui-disabled root size-36 mode-form root timepickerInput"

--- a/uui/components/inputs/timePicker/TimePicker.tsx
+++ b/uui/components/inputs/timePicker/TimePicker.tsx
@@ -52,6 +52,10 @@ export interface TimePickerProps extends SizeMod, IHasEditMode, IEditable<TimePi
     inputCx?: CX;
     /** CSS class(es) to put on body-part component. See https://github.com/JedWatson/classnames#usage for details */
     bodyCx?: CX;
+    /**
+     * Indicates that inputs' clear cross is hidden
+     */
+    hideCross?: boolean;
 }
 
 export interface TimePickerValue {
@@ -178,7 +182,7 @@ export function TimePicker(props: TimePickerProps) {
                 cx={ [css.root, css.timepickerInput, props.inputCx] }
                 value={ state.inputValue }
                 onValueChange={ handleInputChange }
-                onCancel={ onClear }
+                onCancel={ !props.hideCross && onClear }
                 onFocus={ handleFocus }
                 onBlur={ handleBlur }
                 isDropdown={ false }

--- a/uui/components/inputs/timePicker/TimePicker.tsx
+++ b/uui/components/inputs/timePicker/TimePicker.tsx
@@ -55,7 +55,7 @@ export interface TimePickerProps extends SizeMod, IHasEditMode, IEditable<TimePi
     /**
      * Indicates that inputs' clear cross is hidden
      */
-    hideCross?: boolean;
+    disableClear?: boolean;
 }
 
 export interface TimePickerValue {
@@ -182,7 +182,7 @@ export function TimePicker(props: TimePickerProps) {
                 cx={ [css.root, css.timepickerInput, props.inputCx] }
                 value={ state.inputValue }
                 onValueChange={ handleInputChange }
-                onCancel={ !props.hideCross && onClear }
+                onCancel={ !props.disableClear && onClear }
                 onFocus={ handleFocus }
                 onBlur={ handleBlur }
                 isDropdown={ false }


### PR DESCRIPTION
<!-- **Before submitting your PR, ensure that you made the following:**

- Linked the issue(if exists)
- Lint and unit tests pass locally with my changes
- Changelog is updated or not needed
- Documentation is updated/provided or not needed
- Property explorer is updated/provided or not needed
- TSDoc comments for public interfaces is updated/provided or not needed 
 -->

#### Issue link(if exists): https://github.com/epam/UUI/issues/2040

### Description:[TimePicker]: added property hideCross to hide inputs' clear cross.