### PR TITLE
* [ModalBlocker]: added property `disableUrlChangeHandler`, it indica…

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -29,7 +29,8 @@
 * [IconButton]: fixed property `isDropdown`;
 * [Switch]: fixed property `isReadonly`;
 * [TextArea]: fixed ability to scroll when `readonly` or `disable`;
-* [ModalBlocker]: added property `disableUrlChangeHandler`, it indicates is callback `urlChangeHandler` is disabled. This callback will close all modals if the `URL` changes.
+* теперь по дефолту модальные окна закрываются по изменению роута, но вы так же можете отключить это поведение для определенной модалки через пропсу
+* [ModalBlocker]: now the Modals closed by default if the URL was changed. You can turn this off using property `disableCloseOnRouterChange`={true}.
 
 # 5.6.1 - 19.02.2024
 

--- a/changelog.md
+++ b/changelog.md
@@ -30,7 +30,6 @@
 * [IconButton]: fixed property `isDropdown`;
 * [Switch]: fixed property `isReadonly`;
 * [TextArea]: fixed ability to scroll when `readonly` or `disable`;
-* теперь по дефолту модальные окна закрываются по изменению роута, но вы так же можете отключить это поведение для определенной модалки через пропсу
 * [ModalBlocker]: now the Modals closed by default if the URL was changed. You can turn this off using property `disableCloseOnRouterChange`={true}.
 * [FlexRow]: deprecated property `spacing`, it will be removed in future release. Please use `columnGap` instead. See more: https://developer.mozilla.org/en-US/docs/Web/CSS/column-gap
 

--- a/changelog.md
+++ b/changelog.md
@@ -29,6 +29,7 @@
 * [IconButton]: fixed property `isDropdown`;
 * [Switch]: fixed property `isReadonly`;
 * [TextArea]: fixed ability to scroll when `readonly` or `disable`;
+* [ModalBlocker]: added property `disableUrlChangeHandler`, it indicates is callback `urlChangeHandler` is disabled. This callback will close all modals if the `URL` changes.
 
 # 5.6.1 - 19.02.2024
 

--- a/public/docs/docsGenOutput/docsGenOutput.json
+++ b/public/docs/docsGenOutput/docsGenOutput.json
@@ -22562,6 +22562,8 @@
       "    disableCloseByEsc?: boolean;",
       "    /** Pass true to disabled modal closing by click outside modal window */",
       "    disallowClickOutside?: boolean;",
+      "    /** Indicates is callback urlChangeHandler is disabled. This callback will close all modals if the URL changes. */",
+      "    disableUrlChangeHandler?: boolean;",
       "}"
      ]
     },
@@ -22605,6 +22607,22 @@
       "comment": {
        "raw": [
         "Pass true to disabled modal closing by click outside modal window"
+       ]
+      },
+      "typeValue": {
+       "raw": "boolean"
+      },
+      "editor": {
+       "type": "bool"
+      },
+      "required": false
+     },
+     {
+      "uid": "disableUrlChangeHandler",
+      "name": "disableUrlChangeHandler",
+      "comment": {
+       "raw": [
+        "Indicates is callback urlChangeHandler is disabled. This callback will close all modals if the URL changes."
        ]
       },
       "typeValue": {

--- a/uui-components/src/overlays/ModalBlocker.tsx
+++ b/uui-components/src/overlays/ModalBlocker.tsx
@@ -13,7 +13,7 @@ export class ModalBlocker extends React.Component<ModalBlockerProps> {
         document.body.style.overflow = 'hidden';
         !this.props.disableCloseByEsc && window.addEventListener('keydown', this.keydownHandler);
 
-        if (!this.props.disableUrlChangeHandler) {
+        if (!this.props.disableCloseOnRouterChange) {
             this.unsubscribeFromRouter = this.context.uuiRouter.listen(() => {
                 this.urlChangeHandler();
             });
@@ -33,7 +33,7 @@ export class ModalBlocker extends React.Component<ModalBlockerProps> {
     }
 
     urlChangeHandler = () => {
-        !this.props.disableUrlChangeHandler && this.context.uuiModals.closeAll();
+        !this.props.disableCloseOnRouterChange && this.context.uuiModals.closeAll();
     };
 
     keydownHandler = (e: KeyboardEvent) => {

--- a/uui-components/src/overlays/ModalBlocker.tsx
+++ b/uui-components/src/overlays/ModalBlocker.tsx
@@ -7,9 +7,17 @@ export class ModalBlocker extends React.Component<ModalBlockerProps> {
     public static contextType = UuiContext;
     public context: UuiContexts;
 
+    private unsubscribeFromRouter:() => void | null = null;
+
     componentDidMount() {
         document.body.style.overflow = 'hidden';
         !this.props.disableCloseByEsc && window.addEventListener('keydown', this.keydownHandler);
+
+        if (!this.props.disableUrlChangeHandler) {
+            this.unsubscribeFromRouter = this.context.uuiRouter.listen(() => {
+                this.urlChangeHandler();
+            });
+        }
     }
 
     componentWillUnmount() {
@@ -18,7 +26,15 @@ export class ModalBlocker extends React.Component<ModalBlockerProps> {
         if (!this.context.uuiModals.getOperations().length) {
             document.body.style.overflow = 'visible';
         }
+
+        if (this.unsubscribeFromRouter) {
+            this.unsubscribeFromRouter();
+        }
     }
+
+    urlChangeHandler = () => {
+        !this.props.disableUrlChangeHandler && this.context.uuiModals.closeAll();
+    };
 
     keydownHandler = (e: KeyboardEvent) => {
         if (e.key === 'Escape') {

--- a/uui-core/src/types/components/Modals.ts
+++ b/uui-core/src/types/components/Modals.ts
@@ -15,7 +15,7 @@ export interface ModalBlockerProps extends IModal<any>, IHasCX, IHasChildren, IH
     /** Pass true to disabled modal closing by click outside modal window */
     disallowClickOutside?: boolean;
     /** Indicates is callback urlChangeHandler is disabled. This callback will close all modals if the URL changes. */
-    disableUrlChangeHandler?: boolean;
+    disableCloseOnRouterChange?: boolean;
 }
 
 export interface ModalHeaderCoreProps extends IHasChildren, IHasCX, IHasRawProps<React.HTMLAttributes<HTMLDivElement>> {

--- a/uui-core/src/types/components/Modals.ts
+++ b/uui-core/src/types/components/Modals.ts
@@ -14,6 +14,8 @@ export interface ModalBlockerProps extends IModal<any>, IHasCX, IHasChildren, IH
     disableCloseByEsc?: boolean;
     /** Pass true to disabled modal closing by click outside modal window */
     disallowClickOutside?: boolean;
+    /** Indicates is callback urlChangeHandler is disabled. This callback will close all modals if the URL changes. */
+    disableUrlChangeHandler?: boolean;
 }
 
 export interface ModalHeaderCoreProps extends IHasChildren, IHasCX, IHasRawProps<React.HTMLAttributes<HTMLDivElement>> {

--- a/uui-core/src/types/components/Modals.ts
+++ b/uui-core/src/types/components/Modals.ts
@@ -14,7 +14,10 @@ export interface ModalBlockerProps extends IModal<any>, IHasCX, IHasChildren, IH
     disableCloseByEsc?: boolean;
     /** Pass true to disabled modal closing by click outside modal window */
     disallowClickOutside?: boolean;
-    /** Indicates is callback urlChangeHandler is disabled. This callback will close all modals if the URL changes. */
+    /**
+     * Pass true to disable modal close by router change.
+     * If omitted, modal window will be closed on any router change.
+     */
     disableCloseOnRouterChange?: boolean;
 }
 


### PR DESCRIPTION
…tes is callback `urlChangeHandler` is disabled. This callback will close all modals if the `URL` changes.

<!-- **Before submitting your PR, ensure that you made the following:**

- Linked the issue(if exists)
- Lint and unit tests pass locally with my changes
- Changelog is updated or not needed
- Documentation is updated/provided or not needed
- Property explorer is updated/provided or not needed
- TSDoc comments for public interfaces is updated/provided or not needed 
 -->

#### Issue link(if exists): https://github.com/epam/UUI/issues/1895

### Description: * [ModalBlocker]: added property `disableUrlChangeHandler`, it indicates is callback `urlChangeHandler` is disabled. This callback will close all modals if the `URL` changes.
