### PR TITLE
[PickerToggler]: Fixed PickerToggler focus/blur while using searchPosition="none"

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -18,6 +18,7 @@
     * Fixed fetching missing parents for selected element in PickerInput.
 * [PickerInput]: fixed 'unknown records' removing
 * [PickerInput]: Fixed focus reset after clicking outside
+* [PickerInput]: fixed toggler focus blur in case searchPosition = 'none'
 * [PickerList]: aligned caption by the left side in the footer.
 * [DropdownContainer]: disable scroll to the focused element after dropdown close
 * [DropdownContainer]: fixed warning about incorrect ref in React strict mode

--- a/uui-components/src/pickers/PickerToggler.tsx
+++ b/uui-components/src/pickers/PickerToggler.tsx
@@ -47,14 +47,17 @@ function PickerTogglerComponent<TItem, TId>(props: PickerTogglerProps<TItem, TId
     );
 
     React.useEffect(() => {
+        // We need to subscribe on any document clicks, when body is open to be able to make blur on toggler in case of click outside the body.
         props.isOpen && window.document.addEventListener('click', handleClick);
 
         if (props.autoFocus && !props.disableSearch) {
             inputContainer.current?.focus();
         }
-
-        return () => window.document.removeEventListener('click', handleClick);
-    }, [props.isOpen, handleClick]);
+        // We remove listener only when toggler became not inFocus, because in case of click outside it's not enough to do it only when isOpen changed.
+        // Because change of isOpen state is happening earlier than the click event handled by lister, and we have a situation that we remove listener before we could handle click the event.
+        // It causes issue that input stays in focus, even after click outside the body.
+        return () => !inFocus && window.document.removeEventListener('click', handleClick);
+    }, [props.isOpen, inFocus, handleClick]);
 
     const isActivePlaceholder = (): Boolean => {
         if (props.isReadonly) return false;
@@ -84,9 +87,9 @@ function PickerTogglerComponent<TItem, TId>(props: PickerTogglerProps<TItem, TId
             if (props.searchPosition === 'input') {
                 inputContainer.current?.focus();
             }
-            if (props.searchPosition === 'none') {
-                blur(e);
-            }
+            // if (props.searchPosition === 'none') {
+            //     blur(e);
+            // }
         } else {
             // If picker closed, we perform blur event as usual.
             blur(e);

--- a/uui-components/src/pickers/PickerToggler.tsx
+++ b/uui-components/src/pickers/PickerToggler.tsx
@@ -81,7 +81,12 @@ function PickerTogglerComponent<TItem, TId>(props: PickerTogglerProps<TItem, TId
         if (props.isOpen) {
             // If picker opened and search inside input, we lock focus on toggler.
             // In case, when search inside body, we need to highlight toggler like in focus state, even when focus was moved to the body. So we do nothing in this case.
-            return props.searchPosition === 'input' && inputContainer.current?.focus();
+            if (props.searchPosition === 'input') {
+                inputContainer.current?.focus();
+            }
+            if (props.searchPosition === 'none') {
+                blur(e);
+            }
         } else {
             // If picker closed, we perform blur event as usual.
             blur(e);

--- a/uui-components/src/pickers/PickerToggler.tsx
+++ b/uui-components/src/pickers/PickerToggler.tsx
@@ -87,9 +87,6 @@ function PickerTogglerComponent<TItem, TId>(props: PickerTogglerProps<TItem, TId
             if (props.searchPosition === 'input') {
                 inputContainer.current?.focus();
             }
-            // if (props.searchPosition === 'none') {
-            //     blur(e);
-            // }
         } else {
             // If picker closed, we perform blur event as usual.
             blur(e);


### PR DESCRIPTION
## Summary

Fixed focus/blur of PickerToggler with searchPosition="none" in editable tables.