### PR TITLE
[DataTableHeaderCell]: stopped other onClick events during resizing

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -34,6 +34,7 @@
 * [TextArea]: fixed ability to scroll when `readonly` or `disable`;
 * [ModalBlocker]: now the Modals closed by default if the URL was changed. You can turn this off using property `disableCloseOnRouterChange`={true}.
 * [FlexRow]: deprecated property `spacing`, it will be removed in future release. Please use `columnGap` instead. See more: https://developer.mozilla.org/en-US/docs/Web/CSS/column-gap
+* [DataTableHeaderCell]: stopped other onClick events during resizing process;
 
 # 5.6.2 - 15.03.2024
 

--- a/uui-components/src/table/DataTableHeaderCell.tsx
+++ b/uui-components/src/table/DataTableHeaderCell.tsx
@@ -8,10 +8,15 @@ interface DataTableRenderProps {
 }
 
 export interface HeaderCellContentProps extends DndActorRenderParams {
+    /** Called when resizing is started */
     onResizeStart: (e: React.MouseEvent) => void;
+    /** Called when resizing is ended */
     onResizeEnd: (e: MouseEvent) => void;
+    /** Called during the resizing process */
     onResize: (e: MouseEvent) => void;
+    /** Called when sorting */
     toggleSort: (e: React.MouseEvent) => void;
+    /** Indicates that resizing process is active */
     isResizing: boolean;
 }
 

--- a/uui-components/src/table/DataTableHeaderCell.tsx
+++ b/uui-components/src/table/DataTableHeaderCell.tsx
@@ -9,9 +9,10 @@ interface DataTableRenderProps {
 
 export interface HeaderCellContentProps extends DndActorRenderParams {
     onResizeStart: (e: React.MouseEvent) => void;
-    onResizeEnd: (e: React.MouseEvent) => void;
+    onResizeEnd: (e: MouseEvent) => void;
     onResize: (e: MouseEvent) => void;
     toggleSort: (e: React.MouseEvent) => void;
+    isResizing: boolean;
 }
 
 interface DataTableHeaderCellState {
@@ -49,17 +50,20 @@ export class DataTableHeaderCell<TItem, TId> extends React.Component<DataTableHe
         this.setState({ isResizing: true, resizeStartX: e.clientX, originalWidth: this.props.column.width });
 
         document.addEventListener('mousemove', this.onResize);
-        document.addEventListener('mouseup', this.onResizeEnd);
+        document.addEventListener('click', this.onResizeEnd);
 
         e.preventDefault();
         e.stopPropagation(); // to prevent column sorting/dnd/ect. handlers while resizing
     };
 
-    onResizeEnd = () => {
+    onResizeEnd = (e: MouseEvent) => {
         this.setState({ isResizing: false });
 
         document.removeEventListener('mousemove', this.onResize);
-        document.removeEventListener('mouseup', this.onResizeEnd);
+        document.removeEventListener('click', this.onResizeEnd);
+
+        e.preventDefault();
+        e.stopPropagation(); // to prevent column sorting/dnd/ect. handlers while resizing
     };
 
     onResize = (e: MouseEvent) => {
@@ -95,6 +99,7 @@ export class DataTableHeaderCell<TItem, TId> extends React.Component<DataTableHe
             onResizeEnd: this.onResizeEnd,
             onResizeStart: this.onResizeStart,
             toggleSort: this.toggleSort,
+            isResizing: this.state.isResizing,
             ...dndProps,
             ref: (node) => {
                 (this.cellRef.current as unknown as React.Ref<HTMLElement>) = node;

--- a/uui/components/tables/DataTableHeaderCell.tsx
+++ b/uui/components/tables/DataTableHeaderCell.tsx
@@ -124,6 +124,8 @@ export class DataTableHeaderCell<TItem, TId> extends React.Component<DataTableHe
 
     renderCellContent = (props: HeaderCellContentProps, dropdownProps?: IDropdownTogglerProps) => {
         const isResizable = this.props.column.allowResizing ?? this.props.allowColumnsResizing;
+        const onClickEvent = !props.isResizing && (!this.props.column.renderFilter ? props.toggleSort : dropdownProps?.onClick);
+
         return (
             <FlexCell
                 { ...this.props.column }
@@ -148,7 +150,7 @@ export class DataTableHeaderCell<TItem, TId> extends React.Component<DataTableHe
                     props.isDraggedOut && css.isDraggedOut,
                     props.isDndInProgress && css['dnd-marker-' + props.position],
                 ) }
-                onClick={ !this.props.column.renderFilter ? props.toggleSort : dropdownProps?.onClick }
+                onClick={ onClickEvent }
                 rawProps={ {
                     role: 'columnheader',
                     'aria-sort': this.props.sortDirection === 'asc' ? 'ascending' : this.props.sortDirection ? 'descending' : 'none',


### PR DESCRIPTION
<!-- **Before submitting your PR, ensure that you made the following:**

- Linked the issue(if exists)
- Lint and unit tests pass locally with my changes
- Changelog is updated or not needed
- Documentation is updated/provided or not needed
- Property explorer is updated/provided or not needed
- TSDoc comments for public interfaces is updated/provided or not needed 
 -->

#### Issue link(if exists): https://github.com/epam/UUI/issues/2069

### Description: [DataTableHeaderCell]: stopped other onClick events during resizing
