### PR TITLE
[LazyDataSource]: fix clearing of explicitly checked children after clear search and check parent in implicit mode.

### DIFF
--- a/app/src/docs/_examples/pickerInput/LazyTreeInput.example.tsx
+++ b/app/src/docs/_examples/pickerInput/LazyTreeInput.example.tsx
@@ -14,7 +14,6 @@ export default function LazyTreePicker() {
                 const filter = search ? {} : { parentId: ctx?.parentId };
                 return svc.api.demo.locations({ ...request, search, filter });
             },
-            cascadeSelection: true,
             getId: (i) => i.id,
             getParentId: (i) => i.parentId,
             getChildCount: (l) => l.childCount,

--- a/uui-core/src/data/processing/views/tree/treeStructure/helpers/CheckingHelper.ts
+++ b/uui-core/src/data/processing/views/tree/treeStructure/helpers/CheckingHelper.ts
@@ -185,15 +185,7 @@ export class CheckingHelper {
             if (checkedId != ROOT_ID) {
                 checkedIdsMap.set(checkedId, true);
             }
-            // for implicit mode, it is required to remove explicit check from children,
-            // if parent is checked
-            Tree.forEachChildren<TItem, TId>(
-                tree,
-                (id) => checkedIdsMap.delete(id),
-                isCheckable,
-                checkedId,
-                false,
-            );
+
             // In implicit mode, no children are loaded into the parent.
             // When some child is checked and the search is cleared, while checking the top parent no children will be loaded,
             // so there will be no children in the list of checked parent's children. Because of such behavior, explicitly checked

--- a/uui-core/src/data/processing/views/tree/treeStructure/helpers/CheckingHelper.ts
+++ b/uui-core/src/data/processing/views/tree/treeStructure/helpers/CheckingHelper.ts
@@ -1,3 +1,4 @@
+import isEqual from 'lodash.isequal';
 import { CascadeSelectionTypes } from '../../../../../../types';
 import { Tree } from '../../Tree';
 import { NOT_FOUND_RECORD, ROOT_ID } from '../../constants';
@@ -193,6 +194,22 @@ export class CheckingHelper {
                 checkedId,
                 false,
             );
+            // In implicit mode, no children are loaded into the parent.
+            // When some child is checked and the search is cleared, while checking the top parent no children will be loaded,
+            // so there will be no children in the list of checked parent's children. Because of such behavior, explicitly checked
+            // children will not be removed from the list.
+            // To remove them, it is required to pass through all the checked items and check, if their parents don't contain the checked item.
+            if (checkedIdsMap.size) {
+                for (const [id] of checkedIdsMap) {
+                    if (isEqual(id, checkedId)) {
+                        continue;
+                    }
+                    const path = Tree.getPathById(id, tree);
+                    if (path.some((item) => isEqual(item.id, checkedId))) {
+                        checkedIdsMap.delete(id);
+                    }
+                }
+            }
 
             if (checkedId === ROOT_ID) {
                 const { ids: childrenIds } = tree.getItems(checkedId);


### PR DESCRIPTION
### Summary

Fixed clearing explicitly checked children after search clear and checking parent in implicit mode.

### Testing notes (how to reproduce in develop)

https://github.com/epam/UUI/assets/22456368/8a03c81c-2369-4b99-8a81-1269695494ac

