### PR TITLE
[LazyDataSource]: Fixed returning `flattenSearchResults` option in `view.getConfig`.

### DIFF
--- a/uui-core/src/data/processing/views/__tests__/LazyListView.search.test.ts
+++ b/uui-core/src/data/processing/views/__tests__/LazyListView.search.test.ts
@@ -95,6 +95,20 @@ describe('LazyListView - search', () => {
             const view = hookResult.result.current;
             const rows = view.getVisibleRows();
             expect(rows).toHaveLength(1);
+
+            expect(view.getConfig()).toEqual(expect.objectContaining({
+                cascadeSelection: undefined,
+                dataSourceState: {
+                    search: 'ABC5',
+                    topIndex: 0,
+                    visibleCount: 20,
+                },
+                flattenSearchResults: true,
+                isFetching: false,
+                isLoading: false,
+                selectAll: undefined,
+                showSelectedOnly: undefined,
+            }));
         });
 
         it('should detect if found item is last child in parent', async () => {

--- a/uui-core/src/data/processing/views/tree/hooks/strategies/lazyTree/useLazyTree.ts
+++ b/uui-core/src/data/processing/views/tree/hooks/strategies/lazyTree/useLazyTree.ts
@@ -197,6 +197,7 @@ export function useLazyTree<TItem, TId, TFilter = any>(
         isFetching,
         isLoading,
         getItemStatus: itemsStatusCollector.getItemStatus(itemsMap),
+        flattenSearchResults,
         loadMissingRecordsOnCheck,
         showSelectedOnly,
         selectAll,

--- a/uui-core/src/data/processing/views/tree/hooks/strategies/types/common.ts
+++ b/uui-core/src/data/processing/views/tree/hooks/strategies/types/common.ts
@@ -1,6 +1,6 @@
 import {
     BaseDataSourceConfig,
-    DataSourceState, IMap, LazyDataSourceApi,
+    DataSourceState, FlattenSearchResultsConfig, IMap, LazyDataSourceApi,
     SetDataSourceState,
 } from '../../../../../../../types';
 import { ItemsMap } from '../../../ItemsMap';
@@ -70,7 +70,7 @@ export interface ItemsStatuses<TId> {
     itemsStatusMap?: IMap<TId, RecordStatus>;
 }
 
-export interface LazyDataSourceConfig<TItem, TId, TFilter> {
+export interface LazyDataSourceConfig<TItem, TId, TFilter> extends FlattenSearchResultsConfig {
     /**
      * A function to retrieve the data, asynchronously.
      * This function usually performs a REST API call.
@@ -117,18 +117,6 @@ export interface LazyDataSourceConfig<TItem, TId, TFilter> {
      * If reloading is started, `view.getListProps` returns `isReloading` flag, set to `true`.
      */
     backgroundReload?: boolean;
-
-    /**
-     * Falls back to plain list from tree, if there's search.
-     * Default is true.
-     *
-     * If enabled, and search is active:
-     * - API will be called with parentId and parent undefined
-     * - getChildCount is ignored, all nodes are assumed to have no children
-     *
-     * See more here: https://github.com/epam/UUI/issues/8
-     */
-    flattenSearchResults?: boolean;
 }
 
 export interface AsyncDataSourceConfig<TItem> {

--- a/uui-core/src/data/processing/views/tree/hooks/types.ts
+++ b/uui-core/src/data/processing/views/tree/hooks/types.ts
@@ -1,4 +1,5 @@
 import { ITree } from '../ITree';
+import { FlattenSearchResultsConfig } from '../../../../../types';
 import { CommonTreeConfig, GetItemStatus, LoadMissingRecords, ITreeActions, ITreeLoadingState } from './strategies/types';
 
 /**
@@ -9,7 +10,8 @@ export interface UseTreeResult<TItem, TId, TFilter = any> extends
     ITreeLoadingState,
     ITreeActions,
     LoadMissingRecords<TItem, TId>,
-    GetItemStatus<TId> {
+    GetItemStatus<TId>,
+    FlattenSearchResultsConfig {
 
     /**
      * Tree-like data, rows to be build from.

--- a/uui-core/src/types/dataSources.ts
+++ b/uui-core/src/types/dataSources.ts
@@ -159,6 +159,20 @@ export interface PatchOptions<TItem, TId> extends SortConfig<TItem> {
     fixItemBetweenSortings?: boolean;
 }
 
+export interface FlattenSearchResultsConfig {
+    /**
+     * Falls back to plain list from tree, if there's search.
+     * Default is true.
+     *
+     * If enabled, and search is active:
+     * - API will be called with parentId and parent undefined
+     * - getChildCount is ignored, all nodes are assumed to have no children
+     *
+     * See more here: https://github.com/epam/UUI/issues/8
+     */
+    flattenSearchResults?: boolean;
+}
+
 export interface BaseDataSourceConfig<TItem, TId, TFilter = any> extends PatchOptions<TItem, TId> {
     /**
      * Should return unique ID of the TItem


### PR DESCRIPTION
### Summary

Fixed `flattenSearchResults` subtitle.

<img width="951" alt="Screenshot 2024-04-08 at 14 05 10" src="https://github.com/epam/UUI/assets/22456368/267097b0-cedc-44ed-8934-da62aa518346">
