### PR TITLE
[EditableTables]: placeholders added.

### DIFF
--- a/app/src/docs/_examples/tables/EditableTable.example.tsx
+++ b/app/src/docs/_examples/tables/EditableTable.example.tsx
@@ -226,6 +226,8 @@ export default function EditableTableExample() {
                 .key(item.id)
                 .default(item)
                 .onChange((_, current) => {
+                    // If placeholder is modified, new placeholder should be added.
+                    // For this purpose, lastId is updated. New placeholder will have id === lastId - 1.
                     lastId = Math.min(current.id, lastId);
 
                     return current;

--- a/app/src/docs/_examples/tables/EditableTable.example.tsx
+++ b/app/src/docs/_examples/tables/EditableTable.example.tsx
@@ -89,15 +89,10 @@ export default function EditableTableExample() {
 
     // Prepare callback to add a new item to the list.
     const handleNewItem = useCallback(() => {
-        const newItem = { ...blankItem, id: --lastId };
-        // We can manipulate form state directly with the setValue
-        // - pretty much like we do with the setState of React.useState.
-        setValue((current) => ({ ...current, items: current.items.set(newItem.id, newItem) }));
-
         // It is possible to focus rows programmatically via dataTableFocusManager,
         // even those, still not present on the screen.
         dataTableFocusManager?.focusRow(lastId - 1);
-    }, [setValue, dataTableFocusManager]);
+    }, [dataTableFocusManager]);
 
     const handleDeleteItem = useCallback((item: TodoTask) => {
         setValue((current) => ({ ...current, items: current.items.set(item.id, { ...item, isDeleted: true }) }));

--- a/app/src/docs/_examples/tables/EditableTable.example.tsx
+++ b/app/src/docs/_examples/tables/EditableTable.example.tsx
@@ -87,6 +87,18 @@ export default function EditableTableExample() {
     // For example, after adding a row, the first editable cell of the new row should be focused via `dataTableFocusManager`.
     const dataTableFocusManager = useDataTableFocusManager<TodoTask['id']>({}, []);
 
+    // Prepare callback to add a new item to the list.
+    const handleNewItem = useCallback(() => {
+        const newItem = { ...blankItem, id: --lastId };
+        // We can manipulate form state directly with the setValue
+        // - pretty much like we do with the setState of React.useState.
+        setValue((current) => ({ ...current, items: current.items.set(newItem.id, newItem) }));
+
+        // It is possible to focus rows programmatically via dataTableFocusManager,
+        // even those, still not present on the screen.
+        dataTableFocusManager?.focusRow(lastId - 1);
+    }, [setValue, dataTableFocusManager]);
+
     const handleDeleteItem = useCallback((item: TodoTask) => {
         setValue((current) => ({ ...current, items: current.items.set(item.id, { ...item, isDeleted: true }) }));
     }, [setValue]);
@@ -240,6 +252,9 @@ export default function EditableTableExample() {
         <Panel background="surface-main" shadow cx={ css.container }>
             {/* Render a panel with Save/Revert buttons to control the form */}
             <FlexRow columnGap="12" padding="12" vPadding="12" borderBottom>
+                <FlexCell width="auto">
+                    <Button caption="Add task" fill="outline" color="primary" onClick={ handleNewItem } />
+                </FlexCell>
                 <FlexSpacer />
                 <FlexCell width="auto">
                     <Button size="18" icon={ undoIcon } onClick={ undo } isDisabled={ !canUndo } fill="outline" />

--- a/uui-docs/src/models/index.ts
+++ b/uui-docs/src/models/index.ts
@@ -289,7 +289,6 @@ export interface TodoTask {
     dueDate?: string;
     comments?: string;
     isDeleted?: boolean;
-    isPlaceholder?: boolean;
 }
 
 export interface ProjectTask {

--- a/uui-docs/src/models/index.ts
+++ b/uui-docs/src/models/index.ts
@@ -289,6 +289,7 @@ export interface TodoTask {
     dueDate?: string;
     comments?: string;
     isDeleted?: boolean;
+    isPlaceholder?: boolean;
 }
 
 export interface ProjectTask {

--- a/uui/components/pickers/PickerInput.tsx
+++ b/uui/components/pickers/PickerInput.tsx
@@ -67,10 +67,10 @@ function PickerInputComponent<TItem, TId>({ highlightSearchMatches = true, ...pr
 
     const dropdownRef = useRef(null);
 
-    useImperativeHandle(ref, () => ({
-        ...dropdownRef.current,
-        closePickerBody,
-    }), [closePickerBody]);
+    useImperativeHandle(ref, () => {
+        dropdownRef.current.closePickerBody = closePickerBody;
+        return dropdownRef.current;
+    }, [closePickerBody]);
 
     const getTogglerMods = (): PickerTogglerMods => {
         return {

--- a/uui/components/pickers/PickerInput.tsx
+++ b/uui/components/pickers/PickerInput.tsx
@@ -68,7 +68,10 @@ function PickerInputComponent<TItem, TId>({ highlightSearchMatches = true, ...pr
     const dropdownRef = useRef(null);
 
     useImperativeHandle(ref, () => {
-        dropdownRef.current.closePickerBody = closePickerBody;
+        if (dropdownRef.current) {
+            dropdownRef.current.closePickerBody = closePickerBody;
+        }
+
         return dropdownRef.current;
     }, [closePickerBody]);
 


### PR DESCRIPTION
### Summary

- Added placeholders to EditableTable example
- Fixed editorRef.current.focus on PickerInput.