### PR TITLE
[useTree]: Fixed rewriting checked on latency

### DIFF
--- a/app/src/sandbox/reactQueryLocationsTable/LocationsTable.tsx
+++ b/app/src/sandbox/reactQueryLocationsTable/LocationsTable.tsx
@@ -118,7 +118,6 @@ export function LocationsTable() {
     const cascadeSelectionService = useCascadeSelection({
         api,
         dataSourceState: tableState,
-        rowOptions,
         isFolded,
         cascadeSelection,
         itemsMap,

--- a/app/src/sandbox/reactQueryLocationsTable/useCascadeSelection.ts
+++ b/app/src/sandbox/reactQueryLocationsTable/useCascadeSelection.ts
@@ -1,15 +1,13 @@
-import { CascadeSelection, DataRowOptions, DataSourceState, IMap, ITree, LazyDataSourceApi, ITreeLoadResult,
+import { CascadeSelection, DataSourceState, IMap, ITree, LazyDataSourceApi, ITreeLoadResult,
     ITreeParams, useCascadeSelectionService, Tree as UUITree } from '@epam/uui-core';
 import { useQueryClient } from '@tanstack/react-query';
 import { Location } from '@epam/uui-docs';
 import { Tree } from './Tree';
 import { useCallback, useMemo } from 'react';
 
-export interface UseCascadeSelectionProps<TItem, TId> extends ITreeParams<Location, string> {
+export interface UseCascadeSelectionProps<TId> extends ITreeParams<Location, string> {
     api: LazyDataSourceApi<Location, string, unknown>,
     cascadeSelection?: CascadeSelection;
-    getRowOptions?: (item: TItem, index?: number) => DataRowOptions<TItem, TId>;
-    rowOptions?: DataRowOptions<TItem, TId>;
     dataSourceState: DataSourceState<any, string>;
     isFolded: (item: Location) => boolean;
     itemsMap?: IMap<TId, Location>;
@@ -28,12 +26,10 @@ export function useCascadeSelection({
     getParentId,
     complexIds,
     cascadeSelection = false,
-    getRowOptions,
-    rowOptions,
     dataSourceState,
     isFolded,
     itemsMap,
-}: UseCascadeSelectionProps<Location, string>) {
+}: UseCascadeSelectionProps<string>) {
     const queryClient = useQueryClient();
     const blankTree = useMemo(() => Tree.blank({ getId, getParentId, complexIds }, itemsMap), []);
 
@@ -71,9 +67,6 @@ export function useCascadeSelection({
 
     const cascadeSelectionService = useCascadeSelectionService({
         tree: blankTree,
-        cascadeSelection,
-        getRowOptions,
-        rowOptions,
         loadMissingRecordsOnCheck,
     });
 

--- a/uui-components/src/pickers/hooks/usePicker.ts
+++ b/uui-components/src/pickers/hooks/usePicker.ts
@@ -52,6 +52,9 @@ export function usePicker<TItem, TId, TProps extends PickerBaseProps<TItem, TId>
                 newDsState.focusedIndex = 0;
             }
 
+            console.log('currentState', st);
+            console.log('newState', newDsState);
+
             return newDsState;
         });
     }, [setDataSourceState]);

--- a/uui-components/src/pickers/hooks/usePicker.ts
+++ b/uui-components/src/pickers/hooks/usePicker.ts
@@ -52,9 +52,6 @@ export function usePicker<TItem, TId, TProps extends PickerBaseProps<TItem, TId>
                 newDsState.focusedIndex = 0;
             }
 
-            console.log('currentState', st);
-            console.log('newState', newDsState);
-
             return newDsState;
         });
     }, [setDataSourceState]);

--- a/uui-core/src/data/processing/ArrayDataSource.tsx
+++ b/uui-core/src/data/processing/ArrayDataSource.tsx
@@ -78,10 +78,6 @@ export class ArrayDataSource<TItem = any, TId = any, TFilter = any> extends Base
         // eslint-disable-next-line react-hooks/rules-of-hooks
         const cascadeSelectionService = useCascadeSelectionService({
             tree: selectionTree,
-            cascadeSelection: restProps.cascadeSelection,
-            getRowOptions: restProps.getRowOptions,
-            rowOptions: restProps.rowOptions,
-            getItemStatus: restProps.getItemStatus,
         });
 
         // eslint-disable-next-line react-hooks/rules-of-hooks

--- a/uui-core/src/data/processing/AsyncDataSource.tsx
+++ b/uui-core/src/data/processing/AsyncDataSource.tsx
@@ -87,10 +87,6 @@ export class AsyncDataSource<TItem = any, TId = any, TFilter = any> extends Arra
         // eslint-disable-next-line react-hooks/rules-of-hooks
         const cascadeSelectionService = useCascadeSelectionService({
             tree: selectionTree,
-            cascadeSelection: restProps.cascadeSelection,
-            getRowOptions: restProps.getRowOptions,
-            rowOptions: restProps.rowOptions,
-            getItemStatus: restProps.getItemStatus,
         });
 
         // eslint-disable-next-line react-hooks/rules-of-hooks

--- a/uui-core/src/data/processing/LazyDataSource.tsx
+++ b/uui-core/src/data/processing/LazyDataSource.tsx
@@ -95,10 +95,6 @@ export class LazyDataSource<TItem = any, TId = any, TFilter = any> extends BaseD
         // eslint-disable-next-line react-hooks/rules-of-hooks
         const cascadeSelectionService = useCascadeSelectionService({
             tree: selectionTree,
-            cascadeSelection: restProps.cascadeSelection,
-            getRowOptions: restProps.getRowOptions,
-            rowOptions: restProps.rowOptions,
-            getItemStatus: restProps.getItemStatus,
             loadMissingRecordsOnCheck,
         });
 

--- a/uui-core/src/data/processing/views/__tests__/ArrayListView.test.ts
+++ b/uui-core/src/data/processing/views/__tests__/ArrayListView.test.ts
@@ -1032,9 +1032,10 @@ describe('ArrayListView', () => {
                     checkbox: { isVisible: true },
                 }),
             };
+            currentValue = { ...initialValue, checked: [7, 8] };
             const hookResult = renderHook(
                 ({ value, onValueChange, props }) => dataSource.useView(value, onValueChange, props),
-                { initialProps: { value: { ...initialValue, checked: [7, 8] }, onValueChange: onValueChangeFn, props: currentViewProps } },
+                { initialProps: { value: currentValue, onValueChange: onValueChangeFn, props: currentViewProps } },
             );
 
             const view = hookResult.result.current;
@@ -1101,9 +1102,10 @@ describe('ArrayListView', () => {
                     }),
                 };
 
+                currentValue = { ...initialValue, checked: [7, 8] };
                 const hookResult = renderHook(
                     ({ value, onValueChange, props }) => dataSource.useView(value, onValueChange, props),
-                    { initialProps: { value: { ...initialValue, checked: [7, 8] }, onValueChange: onValueChangeFn, props: currentViewProps } },
+                    { initialProps: { value: currentValue, onValueChange: onValueChangeFn, props: currentViewProps } },
                 );
 
                 const view = hookResult.result.current;
@@ -1131,9 +1133,10 @@ describe('ArrayListView', () => {
                         checkbox: { isVisible: true },
                     }),
                 };
+                currentValue = { ...initialValue, checked: [7, 8] };
                 const hookResult = renderHook(
                     ({ value, onValueChange, props }) => dataSource.useView(value, onValueChange, props),
-                    { initialProps: { value: { ...initialValue, checked: [7, 8] }, onValueChange: onValueChangeFn, props: currentViewProps } },
+                    { initialProps: { value: currentValue, onValueChange: onValueChangeFn, props: currentViewProps } },
                 );
 
                 const view = hookResult.result.current;
@@ -1326,9 +1329,11 @@ describe('ArrayListView', () => {
                         checkbox: { isVisible: true },
                     }),
                 };
+
+                currentValue = { ...initialValue, checked: [7, 8] };
                 const hookResult = renderHook(
                     ({ value, onValueChange, props }) => dataSource.useView(value, onValueChange, props),
-                    { initialProps: { value: { ...initialValue, checked: [7, 8] }, onValueChange: onValueChangeFn, props: currentViewProps } },
+                    { initialProps: { value: currentValue, onValueChange: onValueChangeFn, props: currentViewProps } },
                 );
                 const view = hookResult.result.current;
 
@@ -1352,9 +1357,11 @@ describe('ArrayListView', () => {
                         checkbox: { isVisible: true },
                     }),
                 };
+                currentValue = { ...initialValue, checked: [7, 8] };
+
                 const hookResult = renderHook(
                     ({ value, onValueChange, props }) => dataSource.useView(value, onValueChange, props),
-                    { initialProps: { value: { ...initialValue, checked: [7, 8] }, onValueChange: onValueChangeFn, props: currentViewProps } },
+                    { initialProps: { value: currentValue, onValueChange: onValueChangeFn, props: currentViewProps } },
                 );
                 const view = hookResult.result.current;
                 await act(() => {

--- a/uui-core/src/data/processing/views/__tests__/AsyncListView.test.ts
+++ b/uui-core/src/data/processing/views/__tests__/AsyncListView.test.ts
@@ -1243,9 +1243,10 @@ describe('AsyncListView', () => {
                     checkbox: { isVisible: true },
                 }),
             };
+            currentValue = { ...initialValue, checked: [7, 8] };
             const hookResult = renderHook(
                 ({ value, onValueChange, props }) => dataSource.useView(value, onValueChange, props),
-                { initialProps: { value: { ...initialValue, checked: [7, 8] }, onValueChange: onValueChangeFn, props: currentViewProps } },
+                { initialProps: { value: currentValue, onValueChange: onValueChangeFn, props: currentViewProps } },
             );
             await waitFor(() => {
                 const view = hookResult.result.current;
@@ -1330,9 +1331,10 @@ describe('AsyncListView', () => {
                     }),
                 };
 
+                currentValue = { ...initialValue, checked: [7, 8] };
                 const hookResult = renderHook(
                     ({ value, onValueChange, props }) => dataSource.useView(value, onValueChange, props),
-                    { initialProps: { value: { ...initialValue, checked: [7, 8] }, onValueChange: onValueChangeFn, props: currentViewProps } },
+                    { initialProps: { value: currentValue, onValueChange: onValueChangeFn, props: currentViewProps } },
                 );
                 await waitFor(() => {
                     const view = hookResult.result.current;
@@ -1369,9 +1371,11 @@ describe('AsyncListView', () => {
                         checkbox: { isVisible: true },
                     }),
                 };
+
+                currentValue = { ...initialValue, checked: [7, 8] };
                 const hookResult = renderHook(
                     ({ value, onValueChange, props }) => dataSource.useView(value, onValueChange, props),
-                    { initialProps: { value: { ...initialValue, checked: [7, 8] }, onValueChange: onValueChangeFn, props: currentViewProps } },
+                    { initialProps: { value: currentValue, onValueChange: onValueChangeFn, props: currentViewProps } },
                 );
                 await waitFor(() => {
                     const view = hookResult.result.current;
@@ -1585,9 +1589,11 @@ describe('AsyncListView', () => {
                         checkbox: { isVisible: true },
                     }),
                 };
+
+                currentValue = { ...initialValue, checked: [7, 8] };
                 const hookResult = renderHook(
                     ({ value, onValueChange, props }) => dataSource.useView(value, onValueChange, props),
-                    { initialProps: { value: { ...initialValue, checked: [7, 8] }, onValueChange: onValueChangeFn, props: currentViewProps } },
+                    { initialProps: { value: currentValue, onValueChange: onValueChangeFn, props: currentViewProps } },
                 );
                 await waitFor(() => {
                     const view = hookResult.result.current;
@@ -1621,9 +1627,11 @@ describe('AsyncListView', () => {
                         checkbox: { isVisible: true },
                     }),
                 };
+
+                currentValue = { ...initialValue, checked: [7, 8] };
                 const hookResult = renderHook(
                     ({ value, onValueChange, props }) => dataSource.useView(value, onValueChange, props),
-                    { initialProps: { value: { ...initialValue, checked: [7, 8] }, onValueChange: onValueChangeFn, props: currentViewProps } },
+                    { initialProps: { value: currentValue, onValueChange: onValueChangeFn, props: currentViewProps } },
                 );
                 await waitFor(() => {
                     const view = hookResult.result.current;

--- a/uui-core/src/data/processing/views/dataRows/services/useCascadeSelectionService.ts
+++ b/uui-core/src/data/processing/views/dataRows/services/useCascadeSelectionService.ts
@@ -1,20 +1,12 @@
 import { useCallback } from 'react';
 import { ITree } from '../../tree';
-import { CommonTreeConfig, GetItemStatus, LoadMissingRecords } from '../../tree/hooks/strategies/types';
-import { FAILED_RECORD, NOT_FOUND_RECORD } from '../../tree';
-import { isInProgress } from '../../helpers';
-import { CheckingHelper } from '../../tree/treeStructure';
+import { LoadMissingRecords } from '../../tree/hooks/strategies/types';
 
 /**
  * Cascade selection service configuration.
  */
-export interface UseCascadeSelectionServiceProps<TItem, TId, TFilter = any> extends
-    Pick<
-    CommonTreeConfig<TItem, TId, TFilter>,
-    | 'rowOptions' | 'getRowOptions' | 'cascadeSelection'
-    >,
-    LoadMissingRecords<TItem, TId>,
-    GetItemStatus<TId> {
+export interface UseCascadeSelectionServiceProps<TItem, TId> extends
+    LoadMissingRecords<TItem, TId> {
     /**
      * Tree-like data, cascade selection should be performed on.
      */
@@ -24,7 +16,7 @@ export interface UseCascadeSelectionServiceProps<TItem, TId, TFilter = any> exte
 /**
  * A service which provides cascade selection functionality with loading missing records.
  */
-export interface CascadeSelectionService<TId> {
+export interface CascadeSelectionService<TItem, TId> {
     /**
      * Provides a cascade selection functionality.
      * @param isChecked - checking state of the item.
@@ -33,7 +25,7 @@ export interface CascadeSelectionService<TId> {
      * @param checked - current state of checked items.
      * @returns new checked items.
      */
-    handleCascadeSelection: (isChecked: boolean, checkedId?: TId, isRoot?: boolean, checked?: TId[]) => Promise<TId[]>;
+    getCompleteTreeForCascadeSelection: (id: TId, isChecked: boolean, isRoot: boolean) => Promise<ITree<TItem, TId>>;
 }
 
 /**
@@ -42,65 +34,11 @@ export interface CascadeSelectionService<TId> {
  */
 export function useCascadeSelectionService<TItem, TId>({
     tree,
-    cascadeSelection,
-    getRowOptions,
-    rowOptions,
-    getItemStatus,
     loadMissingRecordsOnCheck = async () => tree,
-}: UseCascadeSelectionServiceProps<TItem, TId>): CascadeSelectionService<TId> {
-    const getRowProps = useCallback((item: TItem) => {
-        const externalRowOptions = getRowOptions ? getRowOptions(item) : {};
-        return { ...rowOptions, ...externalRowOptions };
-    }, [rowOptions, getRowOptions]);
+}: UseCascadeSelectionServiceProps<TItem, TId>): CascadeSelectionService<TItem, TId> {
+    const getCompleteTreeForCascadeSelection = useCallback(async (checkedId: TId, isChecked: boolean, isRoot?: boolean) => {
+        return await loadMissingRecordsOnCheck(checkedId, isChecked, isRoot);
+    }, [tree]);
 
-    const isItemCheckable = useCallback((id: TId, item: TItem | typeof NOT_FOUND_RECORD) => {
-        if (item === NOT_FOUND_RECORD) {
-            if (!getItemStatus) {
-                return true;
-            }
-
-            const status = getItemStatus(id);
-            if (isInProgress(status)) {
-                return false;
-            }
-
-            if (status === FAILED_RECORD || status === NOT_FOUND_RECORD) {
-                return true;
-            }
-
-            return false;
-        }
-
-        const rowProps = getRowProps(item);
-        return rowProps?.checkbox?.isVisible && !rowProps?.checkbox?.isDisabled;
-    }, [getRowProps, getItemStatus]);
-
-    const isItemUnknown = useCallback((id: TId) => {
-        const item = tree.getById(id);
-        if (item !== NOT_FOUND_RECORD) {
-            return false;
-        }
-        if (!getItemStatus) {
-            return true;
-        }
-
-        const status = getItemStatus(id);
-        return status === FAILED_RECORD || status === NOT_FOUND_RECORD;
-    }, [tree, getItemStatus]);
-
-    const handleCascadeSelection = useCallback(async (isChecked: boolean, checkedId?: TId, isRoot?: boolean, checked: TId[] = []) => {
-        const completedTree = await loadMissingRecordsOnCheck(checkedId, isChecked, isRoot);
-
-        return CheckingHelper.cascadeSelection<TItem, TId>({
-            tree: completedTree,
-            currentCheckedIds: checked,
-            checkedId,
-            isChecked,
-            cascadeSelectionType: cascadeSelection,
-            isCheckable: (id: TId, item: TItem | typeof NOT_FOUND_RECORD) => isItemCheckable(id, item),
-            isUnknown: isItemUnknown,
-        });
-    }, [tree, isItemCheckable, isItemUnknown, cascadeSelection]);
-
-    return { handleCascadeSelection };
+    return { getCompleteTreeForCascadeSelection };
 }

--- a/uui-core/src/data/processing/views/dataRows/services/useCascadeSelectionService.ts
+++ b/uui-core/src/data/processing/views/dataRows/services/useCascadeSelectionService.ts
@@ -38,7 +38,7 @@ export function useCascadeSelectionService<TItem, TId>({
 }: UseCascadeSelectionServiceProps<TItem, TId>): CascadeSelectionService<TItem, TId> {
     const getCompleteTreeForCascadeSelection = useCallback(async (checkedId: TId, isChecked: boolean, isRoot?: boolean) => {
         return await loadMissingRecordsOnCheck(checkedId, isChecked, isRoot);
-    }, [tree]);
+    }, [tree, loadMissingRecordsOnCheck]);
 
     return { getCompleteTreeForCascadeSelection };
 }

--- a/uui-core/src/data/processing/views/dataRows/services/useCheckingService.ts
+++ b/uui-core/src/data/processing/views/dataRows/services/useCheckingService.ts
@@ -154,20 +154,18 @@ export function useCheckingService<TItem, TId>(
 
     const handleCheck = useCallback(async (isChecked: boolean, checkedId?: TId, isRoot?: boolean) => {
         const completeTree = await getCompleteTreeForCascadeSelection(checkedId, isChecked, isRoot);
-        setDataSourceState((dsState) => {
-            return {
-                ...dsState,
-                checked: CheckingHelper.cascadeSelection({
-                    tree: completeTree,
-                    currentCheckedIds: dsState.checked ?? [],
-                    checkedId,
-                    isChecked,
-                    isCheckable: isItemCheckable,
-                    isUnknown: isItemUnknown,
-                    cascadeSelectionType: cascadeSelection,
-                }),
-            };
-        });
+        setDataSourceState((dsState) => ({
+            ...dsState,
+            checked: CheckingHelper.cascadeSelection({
+                tree: completeTree,
+                currentCheckedIds: dsState.checked ?? [],
+                checkedId,
+                isChecked,
+                isCheckable: isItemCheckable,
+                isUnknown: isItemUnknown,
+                cascadeSelectionType: cascadeSelection,
+            }),
+        }));
     }, [getCompleteTreeForCascadeSelection, setDataSourceState, isItemCheckable, isItemUnknown, cascadeSelection]);
 
     const handleSelectAll = useCallback((isChecked: boolean) => {

--- a/uui-core/src/data/processing/views/dataRows/services/useCheckingService.ts
+++ b/uui-core/src/data/processing/views/dataRows/services/useCheckingService.ts
@@ -17,7 +17,7 @@ export interface UseCheckingServiceProps<TItem, TId, TFilter = any> extends
     'getParentId' | 'dataSourceState' | 'setDataSourceState'
     | 'rowOptions' | 'getRowOptions' | 'cascadeSelection'
     >,
-    CascadeSelectionService<TId>,
+    CascadeSelectionService<TItem, TId>,
     GetItemStatus<TId> {
     /**
      * Tree-like data, selection should be performed on.
@@ -82,7 +82,7 @@ export function useCheckingService<TItem, TId>(
         cascadeSelection,
         getRowOptions,
         rowOptions,
-        handleCascadeSelection,
+        getCompleteTreeForCascadeSelection,
         getItemStatus,
     }: UseCheckingServiceProps<TItem, TId>,
 ): CheckingService<TItem, TId> {
@@ -153,23 +153,22 @@ export function useCheckingService<TItem, TId>(
     }, [tree, getItemStatus]);
 
     const handleCheck = useCallback(async (isChecked: boolean, checkedId?: TId, isRoot?: boolean) => {
-        let updatedChecked: TId[] = [];
-        if (handleCascadeSelection) {
-            updatedChecked = await handleCascadeSelection?.(isChecked, checkedId, isRoot, checked);
-        } else {
-            updatedChecked = CheckingHelper.cascadeSelection({
-                tree,
-                currentCheckedIds: checked,
-                checkedId,
-                isChecked,
-                isCheckable: isItemCheckable,
-                isUnknown: isItemUnknown,
-                cascadeSelectionType: cascadeSelection,
-            });
-        }
-
-        setDataSourceState((dsState) => ({ ...dsState, checked: updatedChecked }));
-    }, [tree, checked, setDataSourceState, isItemCheckable, isItemUnknown, cascadeSelection]);
+        const completeTree = await getCompleteTreeForCascadeSelection(checkedId, isChecked, isRoot);
+        setDataSourceState((dsState) => {
+            return {
+                ...dsState,
+                checked: CheckingHelper.cascadeSelection({
+                    tree: completeTree,
+                    currentCheckedIds: dsState.checked ?? [],
+                    checkedId,
+                    isChecked,
+                    isCheckable: isItemCheckable,
+                    isUnknown: isItemUnknown,
+                    cascadeSelectionType: cascadeSelection,
+                }),
+            };
+        });
+    }, [getCompleteTreeForCascadeSelection, setDataSourceState, isItemCheckable, isItemUnknown, cascadeSelection]);
 
     const handleSelectAll = useCallback((isChecked: boolean) => {
         handleCheck(isChecked, undefined, true);

--- a/uui-core/src/data/processing/views/dataRows/useDataRows.ts
+++ b/uui-core/src/data/processing/views/dataRows/useDataRows.ts
@@ -19,7 +19,7 @@ import { isInProgress } from '../helpers';
 export interface UseDataRowsProps<TItem, TId, TFilter = any> extends
     CommonTreeConfig<TItem, TId, TFilter>,
     ITreeLoadingState,
-    Partial<CascadeSelectionService<TId>>,
+    Partial<CascadeSelectionService<TItem, TId>>,
     GetItemStatus<TId> {
 
     /**
@@ -50,7 +50,7 @@ export function useDataRows<TItem, TId, TFilter = any>(
         isFetching,
         setDataSourceState,
         isFoldedByDefault,
-        handleCascadeSelection,
+        getCompleteTreeForCascadeSelection = async () => tree,
     } = props;
 
     const maxVisibleRowIndex = useMemo(
@@ -115,7 +115,7 @@ export function useDataRows<TItem, TId, TFilter = any>(
         getParentId,
         rowOptions,
         getRowOptions,
-        handleCascadeSelection,
+        getCompleteTreeForCascadeSelection,
         getItemStatus,
     });
 


### PR DESCRIPTION
### Summary

During lazy cascade selection, if some latency was present, during fast checking, previously checked items were rewritten.