### PR TITLE
[FiltersPanel]: Fixed focus lost on closing PickerInput body and focus lost on DataPickerBody open.

### DIFF
--- a/uui-components/src/pickers/PickerBodyBase.tsx
+++ b/uui-components/src/pickers/PickerBodyBase.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import isEqual from 'react-fast-compare';
 
 import {
-    DataSourceListProps, DataSourceState, IEditable, IHasRawProps,
+    DataSourceListProps, DataSourceState, IEditable, IHasRawProps, isMobile,
 } from '@epam/uui-core';
 
 export interface PickerBodyBaseProps extends DataSourceListProps, IEditable<DataSourceState>, IHasRawProps<React.HTMLAttributes<HTMLDivElement>> {
@@ -19,7 +19,15 @@ export interface PickerBodyBaseProps extends DataSourceListProps, IEditable<Data
 export abstract class PickerBodyBase<TProps extends PickerBodyBaseProps> extends React.Component<TProps> {
     needFocusSearch = this.showSearch();
     searchRef = React.createRef<HTMLInputElement>();
+
     componentDidUpdate(prevProps: PickerBodyBaseProps) {
+        // Focusing of searchInput is done via ref.focus(), but not via autoFocus on SearchInput,
+        // because otherwise, after body close, focus on PickerToggler is lost and on  press Tab, it is moved to document.body.
+        if (this.needFocusSearch && !isMobile()) {
+            this.searchRef.current?.focus({ preventScroll: true });
+            this.needFocusSearch = false;
+        }
+
         if (prevProps.rows.length !== this.props.rows.length || (!isEqual(prevProps.value.checked, this.props.value.checked) && !this.props.fixedBodyPosition)) {
             this.props.scheduleUpdate?.();
         }

--- a/uui/components/filters/FiltersPanel.tsx
+++ b/uui/components/filters/FiltersPanel.tsx
@@ -199,7 +199,6 @@ function FiltersToolbarImpl<TFilter extends object>(props: FiltersPanelProps<TFi
                     onValueChange={ onFiltersChange }
                     selectionMode="multi"
                     valueType="entity"
-                    // key={ newFilterId }
                     renderRow={ (props) => (
                         <DataPickerRow
                             { ...props }
@@ -207,8 +206,10 @@ function FiltersToolbarImpl<TFilter extends object>(props: FiltersPanelProps<TFi
                             key={ props.key }
                             onCheck={ (row) => {
                                 props.onCheck && props.onCheck(row);
-                                pickerInputRef.current?.closePickerBody?.();
-                                !row.isChecked && setNewFilterId(row.value.field);
+                                setNewFilterId(row.value.field);
+                                // PickerInput should be closed after filterId update and opening the filter's body.
+                                // Otherwise, the focus will be not set in the search input of the filter's body.
+                                setTimeout(() => pickerInputRef.current?.closePickerBody?.(), 0);
                             } }
                             renderItem={ (item, rowProps) => <PickerItem { ...rowProps } title={ item.title } /> }
                         />

--- a/uui/components/pickers/DataPickerBody.tsx
+++ b/uui/components/pickers/DataPickerBody.tsx
@@ -48,7 +48,6 @@ export class DataPickerBody extends PickerBodyBase<DataPickerBodyProps> {
                                 onKeyDown={ this.searchKeyDown }
                                 size={ searchSize }
                                 debounceDelay={ this.props.searchDebounceDelay }
-                                autoFocus={ this.showSearch() && !isMobile() }
                             />
                         </FlexCell>
                     </div>


### PR DESCRIPTION
### Summary

- Fixed losting focus on PickerToggler after PickerInput body close
- Fixed focusing on SearchInput on DataPickerBody opening along with PickerInput body closing.