### PR TITLE
[Tooltip][Dropdown]: fixed recalculation of boundary area

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -102,7 +102,8 @@
   * `data.align` removed from image element as it has duplicate: `el.align`
 
 **What's Fixed**
-[PickerInput]: fixed setting emptyValue in case of unselecting all picker items
+* [PickerInput]: fixed setting emptyValue in case of unselecting all picker items
+* [Tooltip][Dropdown]: fixed recalculation of boundary area(when we shouldn't close body) after target position was changed in closeOnMouseLeave="boundary" mode
 
 # 5.7.2 - 12.04.2024
 

--- a/uui-components/src/overlays/Dropdown.tsx
+++ b/uui-components/src/overlays/Dropdown.tsx
@@ -117,7 +117,7 @@ export class Dropdown extends React.Component<DropdownProps, DropdownState> {
         const areaPadding = 30;
         const {
             y, x, height, width,
-        } = this.state.bodyBoundingRect;
+        } = this.bodyNode.getBoundingClientRect();
 
         if (y && x && width && height) {
             return x - areaPadding <= e.clientX && e.clientX <= x + areaPadding + width && y - areaPadding <= e.clientY && e.clientY <= y + height + areaPadding;
@@ -241,18 +241,6 @@ export class Dropdown extends React.Component<DropdownProps, DropdownState> {
         const setRef = (node: HTMLElement) => {
             (ref as React.RefCallback<HTMLElement>)(node);
             this.bodyNode = node;
-            if (this.bodyNode && this.props.closeOnMouseLeave === 'boundary') {
-                const {
-                    x, y, height, width,
-                } = this.bodyNode.getBoundingClientRect();
-                if (x && y && !this.state.bodyBoundingRect.y && !this.state.bodyBoundingRect.x) {
-                    this.setState({
-                        bodyBoundingRect: {
-                            y, height, width, x,
-                        },
-                    });
-                }
-            }
         };
 
         if (isReferenceHidden && this.props.closeBodyOnTogglerHidden !== false && this.isOpened()) {


### PR DESCRIPTION
<!-- **Before submitting your PR, ensure that you made the following:**

- Linked the issue(if exists)
- Lint and unit tests pass locally with my changes
- Changelog is updated or not needed
- Documentation is updated/provided or not needed
- Property explorer is updated/provided or not needed
- TSDoc comments for public interfaces is updated/provided or not needed 
 -->

#### Issue link(if exists): #2271

### Description:
[Tooltip][Dropdown]: fixed recalculation of boundary area(when we shouldn't close body) after target position was changed in `closeOnMouseLeave="boundary"` mode