### PR TITLE
refactored PE examples and TextArea min-height

### DIFF
--- a/app/src/docs/Alert.doc.tsx
+++ b/app/src/docs/Alert.doc.tsx
@@ -6,6 +6,7 @@ import * as promo from '@epam/promo';
 import { DocBuilder, DocPreviewBuilder, TDocConfig, TDocContext, TSkin } from '@epam/uui-docs';
 import { BaseDocsBlock, DocExample, EditableDocContent } from '../common';
 import { TAlertPreview } from './_types/previewIds';
+import { ReactComponent as ActionIcon } from '@epam/assets/icons/action-account-fill.svg';
 
 export class AlertDoc extends BaseDocsBlock {
     title = 'Alert';
@@ -29,10 +30,12 @@ export class AlertDoc extends BaseDocsBlock {
             });
             doc.merge('actions', {
                 examples: [
-                    { name: '1 action', value: [{ name: 'ACTION 1', action: () => {} }] },
-                    { name: '2 actions', value: [{ name: 'ACTION 1', action: () => {} }, { name: 'ACTION 2', action: () => {} }] },
+                    { name: '1 action', value: [{ name: 'ACTION 1', action: () => alert('Action 1') }] },
+                    { name: '2 actions', value: [{ name: 'ACTION 1', action: () => alert('Action 1') }, { name: 'ACTION 2', action: () => alert('Action 2') }], isDefault: true },
                 ],
             });
+            doc.setDefaultPropExample('onClose', () => true);
+            doc.setDefaultPropExample('icon', ({ value }) => value === ActionIcon);
         },
         preview: (docPreview: DocPreviewBuilder<uui.AlertProps | loveship.AlertProps | promo.AlertProps>) => {
             const TEST_DATA = {

--- a/app/src/docs/Badge.doc.tsx
+++ b/app/src/docs/Badge.doc.tsx
@@ -15,6 +15,7 @@ import {
 import { BaseDocsBlock, DocExample, EditableDocContent } from '../common';
 import { getCurrentTheme } from '../helpers';
 import { TBadgePreview } from './_types/previewIds';
+import { ReactComponent as ActionIcon } from '@epam/assets/icons/action-account-fill.svg';
 
 export class BadgeDoc extends BaseDocsBlock {
     title = 'Badge';
@@ -41,6 +42,13 @@ export class BadgeDoc extends BaseDocsBlock {
                     neutral: `var(--uui-${getCurrentTheme() === 'loveship_dark' ? 'neutral-40' : 'neutral-30'})`,
                 }),
             });
+            doc.merge('count', { examples: [
+                { value: '', name: 'empty value' },
+                { value: '9' },
+                { value: '99', isDefault: true },
+                { value: '99+' },
+            ] });
+            doc.setDefaultPropExample('icon', ({ value }) => value === ActionIcon);
         },
         preview: (docPreview: DocPreviewBuilder<uui.BadgeProps | promo.BadgeProps | loveship.BadgeProps | electric.BadgeProps>) => {
             const TEST_DATA = {

--- a/app/src/docs/IconButton.doc.tsx
+++ b/app/src/docs/IconButton.doc.tsx
@@ -15,6 +15,7 @@ import {
 import { BaseDocsBlock, DocExample, EditableDocContent } from '../common';
 import { getCurrentTheme } from '../helpers';
 import { TIconButtonPreview } from './_types/previewIds';
+import { ReactComponent as ActionIcon } from '@epam/assets/icons/action-account-fill.svg';
 
 export class IconButtonDoc extends BaseDocsBlock {
     title = 'Icon Button';
@@ -35,6 +36,8 @@ export class IconButtonDoc extends BaseDocsBlock {
                     neutral: `var(--uui-${getCurrentTheme() === 'loveship_dark' ? 'neutral-10' : 'neutral-60'})`,
                 }),
             });
+            doc.setDefaultPropExample('onClick', () => true);
+            doc.setDefaultPropExample('icon', ({ value }) => value === ActionIcon);
         },
         preview: (docPreview: DocPreviewBuilder<promo.IconButtonProps | loveship.IconButtonProps| uui.IconButtonProps>) => {
             const TEST_DATA = {

--- a/app/src/docs/IconContainer.doc.tsx
+++ b/app/src/docs/IconContainer.doc.tsx
@@ -3,8 +3,9 @@ import * as uui from '@epam/uui';
 import * as loveship from '@epam/loveship';
 import * as promo from '@epam/promo';
 import * as electric from '@epam/electric';
-import { TDocConfig, TDocContext, TSkin } from '@epam/uui-docs';
+import { DocBuilder, TDocConfig, TDocContext, TSkin } from '@epam/uui-docs';
 import { EditableDocContent, DocExample, BaseDocsBlock } from '../common';
+import { ReactComponent as ActionIcon } from '@epam/assets/icons/action-account-fill.svg';
 
 export class IconContainerDoc extends BaseDocsBlock {
     title = 'Icon Container';
@@ -17,6 +18,14 @@ export class IconContainerDoc extends BaseDocsBlock {
             [TSkin.Electric]: { type: '@epam/uui-components:ControlIconProps', component: electric.IconContainer },
             [TSkin.Loveship]: { type: '@epam/uui-components:ControlIconProps', component: loveship.IconContainer },
             [TSkin.Promo]: { type: '@epam/uui-components:ControlIconProps', component: promo.IconContainer },
+        },
+        doc: (doc: DocBuilder<uui.IconContainerProps>) => {
+            doc.merge('style', { examples: [
+                { value: { fill: 'tomato' }, name: '{ fill: \'tomato\' }' },
+                { value: { fill: 'green' }, name: '{ fill: \'green\' }' },
+            ] });
+            doc.setDefaultPropExample('icon', ({ value }) => value === ActionIcon);
+            doc.setDefaultPropExample('onClick', () => true);
         },
     };
 

--- a/app/src/docs/NotificationCard.doc.tsx
+++ b/app/src/docs/NotificationCard.doc.tsx
@@ -6,6 +6,7 @@ import * as electric from '@epam/electric';
 import { DocBuilder, DocPreviewBuilder, TDocConfig, TPreviewCellSize, TSkin } from '@epam/uui-docs';
 import { EditableDocContent, DocExample, BaseDocsBlock } from '../common';
 import { TNotificationCardPreview } from './_types/previewIds';
+import { ReactComponent as ActionIcon } from '@epam/assets/icons/action-account-fill.svg';
 
 export class NotificationCardDoc extends BaseDocsBlock {
     title = 'Notification Card';
@@ -36,6 +37,14 @@ export class NotificationCardDoc extends BaseDocsBlock {
                 ],
             });
             doc.setDefaultPropExample('color', ({ value }) => value === 'info');
+            doc.setDefaultPropExample('icon', ({ value }) => value === ActionIcon);
+            doc.merge('actions', {
+                examples: [
+                    { name: '1 action', value: [{ name: 'ACTION 1', action: () => alert('Action 1') }] },
+                    { name: '2 actions', value: [{ name: 'ACTION 1', action: () => alert('Action 1') }, { name: 'ACTION 2', action: () => alert('Action 2') }], isDefault: true },
+                ],
+            });
+            doc.setDefaultPropExample('onClose', () => true);
         },
 
         preview: (docPreview: DocPreviewBuilder<uui.NotificationCardProps | loveship.NotificationCardProps| promo.NotificationCardProps>) => {

--- a/app/src/docs/TabButton.doc.tsx
+++ b/app/src/docs/TabButton.doc.tsx
@@ -13,6 +13,7 @@ import {
 } from '@epam/uui-docs';
 import { BaseDocsBlock, DocExample, EditableDocContent } from '../common';
 import { TTabButtonPreview } from './_types/previewIds';
+import { ReactComponent as ActionIcon } from '@epam/assets/icons/action-account-fill.svg';
 
 export class TabButtonDoc extends BaseDocsBlock {
     title = 'Tab Button';
@@ -28,6 +29,15 @@ export class TabButtonDoc extends BaseDocsBlock {
         },
         doc: (doc: DocBuilder<uui.TabButtonProps>) => {
             doc.merge('iconPosition', { defaultValue: 'left' });
+            doc.setDefaultPropExample('isLinkActive', ({ value }) => value === true);
+            doc.setDefaultPropExample('withNotify', ({ value }) => value === true);
+            doc.merge('count', { examples: [
+                { value: '', name: 'empty value' },
+                { value: '9' },
+                { value: '99', isDefault: true },
+                { value: '99+' },
+            ] });
+            doc.setDefaultPropExample('icon', ({ value }) => value === ActionIcon);
         },
         preview: (docPreview: DocPreviewBuilder<uui.TabButtonProps>) => {
             const TEST_DATA = {

--- a/app/src/docs/Tag.doc.tsx
+++ b/app/src/docs/Tag.doc.tsx
@@ -15,6 +15,7 @@ import {
 import { EditableDocContent, DocExample, BaseDocsBlock } from '../common';
 import { getCurrentTheme } from '../helpers';
 import { TTagPreview } from './_types/previewIds';
+import { ReactComponent as ActionIcon } from '@epam/assets/icons/action-account-fill.svg';
 
 export class TagDoc extends BaseDocsBlock {
     title = 'Tag';
@@ -37,7 +38,8 @@ export class TagDoc extends BaseDocsBlock {
                 }),
             });
             doc.setDefaultPropExample('onClick', () => true);
-            doc.merge('count', { examples: [{ value: '9' }, { value: '+99' }, { value: '+999' }] });
+            doc.merge('count', { examples: [{ value: '9' }, { value: '+99', isDefault: true }, { value: '+999' }] });
+            doc.setDefaultPropExample('icon', ({ value }) => value === ActionIcon);
         },
 
         preview: (docPreview: DocPreviewBuilder<loveship.TagProps | uui.TagProps | promo.TagProps | electric.TagProps>) => {

--- a/app/src/docs/Tooltip.doc.tsx
+++ b/app/src/docs/Tooltip.doc.tsx
@@ -53,6 +53,7 @@ export class TooltipDoc extends BaseDocsBlock {
                     inverted: `var(--uui-${getCurrentTheme() === 'loveship_dark' ? 'neutral-10' : 'neutral-80'})`,
                 }),
             });
+            doc.setDefaultPropExample('value', () => true);
         },
         preview: (docPreview: DocPreviewBuilder<uui.TooltipProps | loveship.TooltipProps | promo.TooltipProps>) => {
             const TEST_DATA = {

--- a/uui-components/src/layout/IconContainer.tsx
+++ b/uui-components/src/layout/IconContainer.tsx
@@ -20,6 +20,9 @@ export interface ControlIconProps extends IHasCX, IDisableable, IHasRawProps<Rea
     size?: number;
 }
 
+/** Represents the properties of a IconContainer component. */
+export type IconContainerProps = ControlIconProps & {};
+
 export const IconContainer = React.forwardRef<HTMLDivElement, ControlIconProps>((props, ref) => {
     const isClickable = !props.isDisabled && props.onClick;
 

--- a/uui/components/inputs/TextArea.module.scss
+++ b/uui/components/inputs/TextArea.module.scss
@@ -167,6 +167,7 @@
 
         :global(.uui-input) {
             @include text-size(24px, 1px);
+            min-height: 24px;
         }
     }
 
@@ -176,6 +177,7 @@
 
         :global(.uui-input) {
             @include text-size(30px, 1px);
+            min-height: 30px;
         }
     }
 
@@ -185,6 +187,7 @@
 
         :global(.uui-input) {
             @include text-size(36px, 1px);
+            min-height: 36px;
         }
     }
 
@@ -194,6 +197,7 @@
 
         :global(.uui-input) {
             @include text-size(42px, 1px);
+            min-height: 42px;
         }
     }
 
@@ -204,6 +208,7 @@
 
         :global(.uui-input) {
             @include text-size(48px, 1px);
+            min-height: 48px;
         }
     }
 }

--- a/uui/components/layout/index.ts
+++ b/uui/components/layout/index.ts
@@ -2,6 +2,7 @@ export * from './Accordion';
 export * from './ControlGroup';
 export * from './FlexItems';
 export { IconContainer } from '@epam/uui-components';
+export type { IconContainerProps } from '@epam/uui-components';
 export * from './LabeledInput';
 export * from './RadioGroup';
 export * from './ScrollBars';


### PR DESCRIPTION
<!-- **Before submitting your PR, ensure that you made the following:**

- Linked the issue(if exists)
- Lint and unit tests pass locally with my changes
- Changelog is updated or not needed
- Documentation is updated/provided or not needed
- Property explorer is updated/provided or not needed
- TSDoc comments for public interfaces is updated/provided or not needed 
 -->

#### Issue link(if exists): https://github.com/epam/UUI/issues/2296

### Description: [PE]: improved examples by set many props by default, [TextArea]: set correct min-height
