### PR TITLE
* [DataTable]: isAlwaysVisible flag now makes column locked

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -66,6 +66,9 @@
 * [PickerInput]: added property `renderTag` which can be used for rendering custom Tags in PickerInput toggler. Exposed `PickerTogglerTag` component, which is used in `PickerInput` for default for tag rendering.
 * [PickerInput]: when using `maxItems` prop, selected values are only partially collapsed. Some(equal `maxItems` value) items remain visible, and the rest are collapsed into the "+N" view. Added tooltip with list of collapsed items to the "+N" tag
 * [DataTable]: 
+  * isAlwaysVisible flag now makes column locked, which means that you can't hide, unpin or reorder this column. Usually applicable for such column without which table because useless.
+    Note, that isAlwaysVisible column should be always fixed to any side of the table, if you didn't specify `column.fix` prop for such column, 'left' value will be used by default.
+    Also, if you have a few isAlwaysVisible columns, it's necessary to place it together in the start or end(depends on `fix` prop) of columns array.
   * added property `columnsGap?: '12' | '24'`
   * added property headerSize?: '36' | '48'. In '48' size, column name can be braked in 2 lines text.
 * [uui-editor]:

--- a/uui-components/src/table/columnsConfigurationModal/columnsConfigurationUtils.ts
+++ b/uui-components/src/table/columnsConfigurationModal/columnsConfigurationUtils.ts
@@ -3,28 +3,22 @@ import { AcceptDropParams, ColumnsConfig, DataColumnProps, DropPosition, getOrde
 import { ColumnsConfigurationRowProps, DndDataType, GroupedColumnsType, GroupedDataColumnProps } from './types';
 
 export function isColumnAlwaysPinned(column: DataColumnProps) {
-    return Boolean(column.isAlwaysVisible && column.fix);
+    return Boolean(column?.isAlwaysVisible);
 }
 
-export function canAcceptDrop(props: Pick<AcceptDropParams<DndDataType, DndDataType>, 'srcData' | 'dstData'>) {
-    const { srcData, dstData } = props;
+export function canAcceptDrop(props: AcceptDropParams<DndDataType, DndDataType>, nextColumn?: DataColumnProps, prevColumn?: DataColumnProps) {
+    const { dstData } = props;
 
-    const DISALLOW = {};
+    if (isColumnAlwaysPinned(dstData.column)) {
+        if (dstData.column.fix === 'left' && !isColumnAlwaysPinned(nextColumn)) { // If user try to drop column at the last isAlwaysVisible column. Allow to drop only to the end of the fixed list.
+            return { bottom: true };
+        }
 
-    const isMovingToUnpinnedArea = !dstData.columnConfig.fix;
-    const isMovingBetweenPinnedAreas = !!srcData.columnConfig.fix && !!dstData.columnConfig.fix && srcData.columnConfig.fix !== dstData.columnConfig.fix;
-    const isMovingToHiddenArea = !dstData.columnConfig.isVisible;
+        if (dstData.column.fix === 'right' && !isColumnAlwaysPinned(prevColumn)) { // If user try to drop column at the first isAlwaysVisible. Allow to drop only to the start of the fixed list
+            return { top: true };
+        }
 
-    if (isColumnAlwaysPinned(srcData.column) && isMovingToUnpinnedArea) {
-        return DISALLOW;
-    }
-
-    if (srcData.column.isAlwaysVisible && isMovingToHiddenArea) {
-        return DISALLOW;
-    }
-
-    if (isMovingBetweenPinnedAreas) {
-        return DISALLOW;
+        return {}; // Shouldn't drop between 2 isAlwaysVisible columns
     }
 
     return { top: true, bottom: true };

--- a/uui-components/src/table/columnsConfigurationModal/hooks/useColumnsConfiguration.ts
+++ b/uui-components/src/table/columnsConfigurationModal/hooks/useColumnsConfiguration.ts
@@ -54,8 +54,10 @@ export function useColumnsConfiguration(props: UseColumnsConfigurationProps<any,
         () =>
             columnsSorted.map((column: DataColumnProps, index): ColumnsConfigurationRowProps => {
                 const columnConfig = columnsConfig[column.key];
-                const prevColumn = columnsConfig[columnsSorted[index - 1]?.key];
-                const nextColumn = columnsConfig[columnsSorted[index + 1]?.key];
+                const nextColumn = columnsSorted[index + 1];
+                const prevColumn = columnsSorted[index - 1];
+                const prevColumnConfig = columnsConfig[prevColumn?.key];
+                const nextColumnConfig = columnsConfig[nextColumn?.key];
                 const handleDrop = (params: DropParams<DndDataType, DndDataType>) => {
                     const { srcData, position } = params;
                     // NOTE: srcData - is the column which we are dropping.
@@ -63,8 +65,8 @@ export function useColumnsConfiguration(props: UseColumnsConfigurationProps<any,
                         const columnNew = moveColumnRelativeToAnotherColumn({
                             columnConfig: srcData.columnConfig,
                             targetColumn: columnConfig,
-                            targetNextColumn: nextColumn,
-                            targetPrevColumn: prevColumn,
+                            targetNextColumn: nextColumnConfig,
+                            targetPrevColumn: prevColumnConfig,
                             position,
                         });
                         return {
@@ -78,12 +80,12 @@ export function useColumnsConfiguration(props: UseColumnsConfigurationProps<any,
                 return {
                     ...column,
                     columnConfig,
-                    isDndAllowed,
+                    isDndAllowed: isDndAllowed && !isPinnedAlways,
                     isPinnedAlways,
                     fix,
                     togglePin: (_fix: TColumnPinPosition) => togglePin(column.key, _fix),
                     toggleVisibility: () => toggleVisibility(column.key),
-                    onCanAcceptDrop: canAcceptDrop,
+                    onCanAcceptDrop: (props) => canAcceptDrop(props, nextColumn, prevColumn),
                     onDrop: handleDrop,
                 };
             }),

--- a/uui-core/src/helpers/applyColumnsConfig.ts
+++ b/uui-core/src/helpers/applyColumnsConfig.ts
@@ -36,7 +36,7 @@ export const getColumnsConfig = <TItem, TId>(columns: DataColumnProps<TItem, TId
 
             resultConfig[column.key] = {
                 width: column.width,
-                fix: column.fix,
+                fix: column.fix ?? (column.isAlwaysVisible ? 'left' : undefined),
                 isVisible: !column.isHiddenByDefault,
                 order: order,
             };

--- a/uui-core/src/types/tables.ts
+++ b/uui-core/src/types/tables.ts
@@ -69,7 +69,10 @@ export interface DataColumnProps<TItem = any, TId = any, TFilter = any> extends 
      */
     isSortable?: boolean;
 
-    /** Disallows to hide column via ColumnsConfiguration */
+    /** Makes this column locked, which means that you can't hide, unpin or reorder this column. Usually applicable for such column without which table because useless.
+     * Note, that isAlwaysVisible column should be always fixed to any side of the table, if you didn't specify `column.fix` prop for such column, 'left' value will be used by default.
+     * Also, if you have a few isAlwaysVisible columns, it's necessary to place it together in the start or end(depends on `fix` prop) of columns array.
+     * */
     isAlwaysVisible?: boolean;
 
     /** Makes column hidden by default. User can turn it on later, via ColumnsConfiguration */

--- a/uui/components/tables/columnsConfigurationModal/ColumnRow.tsx
+++ b/uui/components/tables/columnsConfigurationModal/ColumnRow.tsx
@@ -25,23 +25,16 @@ export const ColumnRow = React.memo(function ColumnRow(props: ColumnRowProps<any
     const data = { column, columnConfig };
 
     const renderContent = (dndActorParams: DndActorRenderParams) => {
-        const wrapperClasses = cx(styles.rowWrapper, !isPinned && styles.notPinned, ...(isDndAllowed ? dndActorParams.classNames : []));
+        const wrapperClasses = cx(styles.rowWrapper, !isPinned && styles.notPinned);
         const { onTouchStart, onPointerDown, ...restEventHandlers } = dndActorParams.eventHandlers;
-        const wrapperAttrs = {
-            ...(isDndAllowed ? { ref: dndActorParams.ref } : {}),
-            ...(isDndAllowed ? { rawProps: { ...restEventHandlers } } : {}),
-        };
-        const dragHandleRawProps: any = {
-            ...(isDndAllowed ? { onTouchStart, onPointerDown } : {}),
-        };
 
         const { ref, ...dndActorPropsWithoutRef } = dndActorParams;
 
         return (
-            <FlexRow size="30" cx={ wrapperClasses } { ...wrapperAttrs }>
+            <FlexRow size="30" cx={ wrapperClasses } ref={ dndActorParams.ref } rawProps={ { ...restEventHandlers } }>
                 <DragHandle
                     dragHandleIcon={ DragIndicatorIcon }
-                    rawProps={ dragHandleRawProps }
+                    rawProps={ { onTouchStart, onPointerDown } }
                     isDisabled={ !isDndAllowed }
                     cx={ cx(styles.dragHandle, !isDndAllowed && styles.dndDisabled) }
                 />
@@ -64,7 +57,7 @@ export const ColumnRow = React.memo(function ColumnRow(props: ColumnRowProps<any
     return (
         <DndActor
             key={ column.key }
-            srcData={ data }
+            srcData={ isDndAllowed && data }
             dstData={ data }
             canAcceptDrop={ onCanAcceptDrop }
             onDrop={ onDrop }

--- a/uui/components/tables/columnsConfigurationModal/__tests__/__snapshots__/ColumnsConfigurationModal.test.tsx.snap
+++ b/uui/components/tables/columnsConfigurationModal/__tests__/__snapshots__/ColumnsConfigurationModal.test.tsx.snap
@@ -207,7 +207,7 @@ exports[`ColumnsConfigurationModal should be rendered correctly 1`] = `
                       width={18}
                     />
                   </div>
-                  Not pinned
+                  Pinned to the left
                 </span>
                 <div
                   className="container uui-icon uui-enabled arrow"
@@ -229,7 +229,7 @@ exports[`ColumnsConfigurationModal should be rendered correctly 1`] = `
                 }
               >
                 <div
-                  className="uui-flex-row root size-30 rowWrapper notPinned -draggable container align-items-center"
+                  className="uui-flex-row root size-30 rowWrapper container align-items-center"
                   onPointerEnter={[Function]}
                   onPointerLeave={[Function]}
                   onPointerMove={[Function]}
@@ -242,12 +242,11 @@ exports[`ColumnsConfigurationModal should be rendered correctly 1`] = `
                   }
                 >
                   <div
-                    className="dragHandle container uui-drag-handle"
-                    onPointerDown={[Function]}
+                    className="dragHandle dndDisabled container uui-drag-handle uui-disabled"
                     onTouchStart={[Function]}
                   >
                     <div
-                      className="container uui-icon uui-enabled"
+                      className="container uui-icon uui-disabled"
                       style={Object {}}
                     >
                       <svg
@@ -295,52 +294,26 @@ exports[`ColumnsConfigurationModal should be rendered correctly 1`] = `
                     }
                   >
                     <span>
-                      <span
-                        style={
-                          Object {
-                            "display": "flex",
-                            "gap": "12px",
-                          }
-                        }
+                      <button
+                        aria-disabled={true}
+                        className="uui-button-box uui-disabled container uui-icon_button uui-color-info root pinTogglerIcon"
+                        tabIndex={-1}
+                        type="button"
                       >
-                        <button
-                          aria-disabled={false}
-                          className="uui-button-box uui-enabled -clickable container uui-icon_button uui-color-neutral root pinTogglerIcon"
-                          onClick={[Function]}
-                          tabIndex={0}
-                          type="button"
+                        <div
+                          className="container uui-icon uui-enabled"
+                          style={Object {}}
                         >
-                          <div
-                            className="container uui-icon uui-enabled"
-                            style={Object {}}
-                          >
-                            <svg
-                              className=""
-                            />
-                          </div>
-                        </button>
-                        <button
-                          aria-disabled={false}
-                          className="uui-button-box uui-enabled -clickable container uui-icon_button uui-color-neutral root pinTogglerIcon"
-                          onClick={[Function]}
-                          tabIndex={0}
-                          type="button"
-                        >
-                          <div
-                            className="container uui-icon uui-enabled"
-                            style={Object {}}
-                          >
-                            <svg
-                              className=""
-                            />
-                          </div>
-                        </button>
-                      </span>
+                          <svg
+                            className=""
+                          />
+                        </div>
+                      </button>
                     </span>
                   </div>
                 </div>
                 <div
-                  className="uui-flex-row root size-30 rowWrapper notPinned -draggable container align-items-center"
+                  className="uui-flex-row root size-30 rowWrapper container align-items-center"
                   onPointerEnter={[Function]}
                   onPointerLeave={[Function]}
                   onPointerMove={[Function]}
@@ -353,12 +326,11 @@ exports[`ColumnsConfigurationModal should be rendered correctly 1`] = `
                   }
                 >
                   <div
-                    className="dragHandle container uui-drag-handle"
-                    onPointerDown={[Function]}
+                    className="dragHandle dndDisabled container uui-drag-handle uui-disabled"
                     onTouchStart={[Function]}
                   >
                     <div
-                      className="container uui-icon uui-enabled"
+                      className="container uui-icon uui-disabled"
                       style={Object {}}
                     >
                       <svg
@@ -406,47 +378,21 @@ exports[`ColumnsConfigurationModal should be rendered correctly 1`] = `
                     }
                   >
                     <span>
-                      <span
-                        style={
-                          Object {
-                            "display": "flex",
-                            "gap": "12px",
-                          }
-                        }
+                      <button
+                        aria-disabled={true}
+                        className="uui-button-box uui-disabled container uui-icon_button uui-color-info root pinTogglerIcon"
+                        tabIndex={-1}
+                        type="button"
                       >
-                        <button
-                          aria-disabled={false}
-                          className="uui-button-box uui-enabled -clickable container uui-icon_button uui-color-neutral root pinTogglerIcon"
-                          onClick={[Function]}
-                          tabIndex={0}
-                          type="button"
+                        <div
+                          className="container uui-icon uui-enabled"
+                          style={Object {}}
                         >
-                          <div
-                            className="container uui-icon uui-enabled"
-                            style={Object {}}
-                          >
-                            <svg
-                              className=""
-                            />
-                          </div>
-                        </button>
-                        <button
-                          aria-disabled={false}
-                          className="uui-button-box uui-enabled -clickable container uui-icon_button uui-color-neutral root pinTogglerIcon"
-                          onClick={[Function]}
-                          tabIndex={0}
-                          type="button"
-                        >
-                          <div
-                            className="container uui-icon uui-enabled"
-                            style={Object {}}
-                          >
-                            <svg
-                              className=""
-                            />
-                          </div>
-                        </button>
-                      </span>
+                          <svg
+                            className=""
+                          />
+                        </div>
+                      </button>
                     </span>
                   </div>
                 </div>


### PR DESCRIPTION
<!-- **Before submitting your PR, ensure that you made the following:**

- Linked the issue(if exists)
- Lint and unit tests pass locally with my changes
- Changelog is updated or not needed
- Documentation is updated/provided or not needed
- Property explorer is updated/provided or not needed
- TSDoc comments for public interfaces is updated/provided or not needed 
 -->

#### Issue link(if exists): #2258

### Description:
[DataTable]: isAlwaysVisible flag now makes column locked, which means that you can't hide, unpin or reorder this column. Usually applicable for such column without which table because useless.
 Note, that isAlwaysVisible column should be always fixed to any side of the table, if you didn't specify `column.fix` prop for such column, 'left' value will be used by default.
 Also, if you have a few isAlwaysVisible columns, it's necessary to place it together in the start or end(depends on `fix` prop) of columns array.