### PR TITLE
Fix offset in `DropdownSubMenu` for `left-start` option

### DIFF
--- a/app/src/docs/_examples/dropdownMenu/Basic.example.tsx
+++ b/app/src/docs/_examples/dropdownMenu/Basic.example.tsx
@@ -76,7 +76,7 @@ export default function BasicDropdownMenuExample() {
             <DropdownMenuBody { ...props }>
                 <DropdownMenuButton caption="Cancel Data Loads" indent={ true } onClick={ () => {} } />
                 <DropdownMenuButton caption="Deactivate" indent={ true } onClick={ () => {} } />
-                <Tooltip content="You don't have permissions to performe this action">
+                <Tooltip content="You don't have permissions to perform this action">
                     <DropdownMenuButton isDisabled={ true } caption="Delete" icon={ DeleteIcon } onClick={ () => {} } />
                 </Tooltip>
             </DropdownMenuBody>

--- a/changelog.md
+++ b/changelog.md
@@ -10,13 +10,14 @@
 * [PickerToggler]: changed padding for left icon, remove transparent for left/right icon in cell mode
 * [uui-editor]: header, notes and color plugins now available for customizations
 * [TextArea]: removed maxLength prop override in cell mode
+* [DropdownSubMenu]: fixed `offset` value for `left-start` placement option
 
 
 
 # 5.8.1 - 21.06.2024
 
 **What's Fixed**
-* [LazyDataSource]: 
+* [LazyDataSource]:
   * fixed reload data on DS deps change and fixed fetching minus count on scroll up
   * fixed updating itemsMap after setItems.
 

--- a/uui/components/overlays/DropdownMenu.tsx
+++ b/uui/components/overlays/DropdownMenu.tsx
@@ -1,7 +1,7 @@
 import React, { useRef, useContext, useState } from 'react';
 import {
     cx, withMods, uuiMod, UuiContext, IHasChildren, VPanelProps, IHasIcon, ICanRedirect, IHasCaption, IDisableable,
-    IAnalyticableClick, IHasCX, IClickable, DropdownBodyProps, IDropdownTogglerProps,
+    IAnalyticableClick, IHasCX, IClickable, DropdownBodyProps, IDropdownTogglerProps, DropdownProps,
 } from '@epam/uui-core';
 import { Text, FlexRow, Anchor, IconContainer, Dropdown, FlexSpacer, DropdownContainerProps, useDocumentDir } from '@epam/uui-components';
 import { DropdownContainer } from './DropdownContainer';
@@ -187,12 +187,15 @@ interface IDropdownSubMenu extends IHasChildren, IHasCaption, IHasIcon, IDropdow
 }
 
 export function DropdownSubMenu(props: IDropdownSubMenu) {
-    const subMenuModifiers = [
+    const subMenuModifiers: DropdownProps['modifiers'] = [
         {
             name: 'offset',
             options: {
-                offset: ({ placement }: { placement: string }) => {
-                    if (placement === 'right-start') {
+                offset: ({ placement }) => {
+                    if (
+                        placement === 'right-start'
+                        || placement === 'left-start'
+                    ) {
                         return [-6, 0];
                     } else {
                         return [6, 0];


### PR DESCRIPTION
### Main changes

* Fix `offset` for `left-start` placement option. Now it is aligned with `right-start` option

### Additional changes

* Set a correct type for `subMenuModifiers` variable and remove a custom in-place interface in `offset` function
* Fix a typo in basic dropdown menu example

### Results

Before:
![image](https://github.com/epam/UUI/assets/10310491/fc0b5c45-5003-456e-b6ff-17b513e075c1)

After:
![image](https://github.com/epam/UUI/assets/10310491/2df916d3-6835-47c5-af0a-250c27187c9d)