### PR TITLE
[Pickers]: fixed infinite updating if onValueChange is called in useEffect.

### DIFF
--- a/uui-components/src/pickers/hooks/usePicker.ts
+++ b/uui-components/src/pickers/hooks/usePicker.ts
@@ -64,7 +64,8 @@ export function usePicker<TItem, TId, TProps extends PickerBaseProps<TItem, TId>
         if ((!prevDataSourceState && (dataSourceState.checked?.length || dataSourceState.selectedId != null))
             || (prevDataSourceState && (
                 !isEqual(prevDataSourceState.checked, dataSourceState.checked)
-                || dataSourceState.selectedId !== prevDataSourceState.selectedId
+                || (!(dataSourceState.selectedId == null && prevDataSourceState.selectedId == null)
+                    && dataSourceState.selectedId !== prevDataSourceState.selectedId)
             ))
         ) {
             const newValue = dataSourceStateToValue(props, dataSourceState, dataSource);


### PR DESCRIPTION
### Summary

Reproduces only if rendered via react-dom render.
Fixed problem with infinite updating of Pickers if onValueChange is called in useEffect.