### PR TITLE
DropdownMenu: Cannot read properties of null error when closeOnMouseLeave=boundary #2426

### DIFF
--- a/app/src/docs/_examples/dropdownMenu/Basic.example.tsx
+++ b/app/src/docs/_examples/dropdownMenu/Basic.example.tsx
@@ -104,6 +104,7 @@ export default function BasicDropdownMenuExample() {
                         { ...props }
                     />
                 ) }
+                closeOnMouseLeave="boundary"
             />
             <ControlGroup>
                 <Button size="36" caption="Action with selected" onClick={ () => {} } />

--- a/uui-components/src/overlays/Dropdown.tsx
+++ b/uui-components/src/overlays/Dropdown.tsx
@@ -118,13 +118,19 @@ export class Dropdown extends React.Component<DropdownProps, DropdownState> {
 
     isClientInArea(e: MouseEvent) {
         const areaPadding = 30;
-        const {
-            y, x, height, width,
-        } = this.bodyNode.getBoundingClientRect();
+        const rect = this.bodyNode?.getBoundingClientRect();
 
-        if (y && x && width && height) {
-            return x - areaPadding <= e.clientX && e.clientX <= x + areaPadding + width && y - areaPadding <= e.clientY && e.clientY <= y + height + areaPadding;
+        if (rect) {
+            const {
+                y, x, height, width,
+            } = rect;
+
+            if (y && x && width && height) {
+                return x - areaPadding <= e.clientX && e.clientX <= x + areaPadding + width && y - areaPadding <= e.clientY && e.clientY <= y + height + areaPadding;
+            }
         }
+
+        return false;
     }
 
     setOpenDropdownTimer() {


### PR DESCRIPTION
<!-- **Before submitting your PR, ensure that you made the following:**

- Linked the issue(if exists)
- Lint and unit tests pass locally with my changes
- Changelog is updated or not needed
- Documentation is updated/provided or not needed
- Property explorer is updated/provided or not needed
- TSDoc comments for public interfaces is updated/provided or not needed 
 -->

#### Issue link(if exists): https://github.com/epam/UUI/issues/2426

### Description: fixed in Dropdown isClientInArea method to fix getBoundingClientRect=undefined