### PR TITLE
[DropdownMenu]: hover effect is active on the disabled element #2448

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,12 @@
-# 5.8.5 - xx.xx.2024
+# 5.x.x - xx.xx.2024
+
+**What's New**
+
+**What's Fixed**
+* [DropdownMenu]: fixed disabled status of subMenu. If subMenu disabled it's won't open subMenuItems.
+
+
+# 5.8.5 - 09.08.2024
 
 **What's New**
 * [Breaking change]: Typography in Electric theme h1 weight changed to 600, h2 weight changed to 400

--- a/uui/components/overlays/DropdownMenu.module.scss
+++ b/uui/components/overlays/DropdownMenu.module.scss
@@ -137,6 +137,7 @@
 
     &:global(.uui-disabled) {
         @include fillColor(var(--uui-text-disabled)); // TODO: need possibility to override - in dark theme neutral 40
+        pointer-events: none;
 
         &:hover,
         &:focus {

--- a/uui/components/overlays/DropdownMenu.tsx
+++ b/uui/components/overlays/DropdownMenu.tsx
@@ -215,7 +215,7 @@ export function DropdownSubMenu(props: IDropdownSubMenu) {
             closeDelay={ 400 }
             placement={ dir === 'rtl' ? 'left-start' : 'right-start' }
             modifiers={ subMenuModifiers }
-            renderBody={ (dropdownProps) => <DropdownMenuBody closeOnKey={ IDropdownControlKeys.LEFT_ARROW } { ...props } { ...dropdownProps } /> }
+            renderBody={ (dropdownProps) => !props.isDisabled && (<DropdownMenuBody closeOnKey={ IDropdownControlKeys.LEFT_ARROW } { ...props } { ...dropdownProps } />) }
             renderTarget={ ({ toggleDropdownOpening, ...targetProps }) => (
                 <DropdownMenuButton
                     cx={ cx(css.submenuRootItem) }


### PR DESCRIPTION
<!-- **Before submitting your PR, ensure that you made the following:**

- Linked the issue(if exists)
- Lint and unit tests pass locally with my changes
- Changelog is updated or not needed
- Documentation is updated/provided or not needed
- Property explorer is updated/provided or not needed
- TSDoc comments for public interfaces is updated/provided or not needed 
 -->

#### Issue link(if exists): https://github.com/epam/UUI/issues/2448

### Description: [DropdownMenu]: fixed disabled status of subMenu
