### PR TITLE
[Pickers]: synchronization of value with internal dataSourceState after value change reject.

### DIFF
--- a/uui-components/src/pickers/hooks/usePicker.ts
+++ b/uui-components/src/pickers/hooks/usePicker.ts
@@ -61,6 +61,7 @@ export function usePicker<TItem, TId, TProps extends PickerBaseProps<TItem, TId>
             setShowSelected(false);
         }
 
+        const newValue = dataSourceStateToValue(props, dataSourceState, dataSource);
         if ((!prevDataSourceState && (dataSourceState.checked?.length || dataSourceState.selectedId != null))
             || (prevDataSourceState && (
                 !isEqual(prevDataSourceState.checked, dataSourceState.checked)
@@ -68,12 +69,28 @@ export function usePicker<TItem, TId, TProps extends PickerBaseProps<TItem, TId>
                     && dataSourceState.selectedId !== prevDataSourceState.selectedId)
             ))
         ) {
-            const newValue = dataSourceStateToValue(props, dataSourceState, dataSource);
             if (!isEqual(value, newValue)) {
                 handleSelectionValueChange(newValue);
             }
+        } else {
+            const { checked, selectedId } = getDataSourceState();
+
+            if (prevDataSourceState && (isEqual(prevDataSourceState.checked, dataSourceState.checked)
+                || dataSourceState.selectedId === prevDataSourceState.selectedId)
+                && (props.selectionMode === 'multi'
+                    ? ((checked?.length || dataSourceState.checked?.length) && !isEqual(dataSourceState.checked, checked))
+                    : (!isEqual(dataSourceState.selectedId, selectedId))
+                )
+            ) {
+                handleDataSourceValueChange((dsState) => ({
+                    ...dsState,
+                    ...(props.selectionMode === 'multi'
+                        ? { checked }
+                        : { selectedId }),
+                }));
+            }
         }
-    }, [dataSourceState]);
+    }, [dataSourceState, value]);
 
     const getName = (i: (TItem & { name?: string }) | void) => {
         const unknownStr = 'Unknown';

--- a/uui-components/src/pickers/hooks/usePicker.ts
+++ b/uui-components/src/pickers/hooks/usePicker.ts
@@ -72,23 +72,23 @@ export function usePicker<TItem, TId, TProps extends PickerBaseProps<TItem, TId>
             if (!isEqual(value, newValue)) {
                 handleSelectionValueChange(newValue);
             }
-        } else {
-            const { checked, selectedId } = getDataSourceState();
+        }
 
-            if (prevDataSourceState && (isEqual(prevDataSourceState.checked, dataSourceState.checked)
-                || dataSourceState.selectedId === prevDataSourceState.selectedId)
-                && (props.selectionMode === 'multi'
-                    ? ((checked?.length || dataSourceState.checked?.length) && !isEqual(dataSourceState.checked, checked))
-                    : (!isEqual(dataSourceState.selectedId, selectedId))
-                )
-            ) {
-                handleDataSourceValueChange((dsState) => ({
-                    ...dsState,
-                    ...(props.selectionMode === 'multi'
-                        ? { checked }
-                        : { selectedId }),
-                }));
-            }
+        const { checked, selectedId } = getDataSourceState();
+
+        if (prevDataSourceState && (
+            props.selectionMode === 'multi'
+                ? (isEqual(prevDataSourceState.checked, dataSourceState.checked)
+                        && (checked?.length || dataSourceState.checked?.length) && !isEqual(dataSourceState.checked, checked))
+                : ((dataSourceState.selectedId === prevDataSourceState.selectedId)
+                        && (!isEqual(dataSourceState.selectedId, selectedId)))
+        )) {
+            handleDataSourceValueChange((dsState) => ({
+                ...dsState,
+                ...(props.selectionMode === 'multi'
+                    ? { checked }
+                    : { selectedId }),
+            }));
         }
     }, [dataSourceState, value]);
 


### PR DESCRIPTION
### Summary

Fixes problem of value synchonization with dataSourceState after change rejection.

Sandbox with reproducible problem: https://codesandbox.io/p/sandbox/uui-forked-ylxhdj