### PR TITLE
Fix Apicontext abort handling

### DIFF
--- a/uui-core/src/services/ApiContext.ts
+++ b/uui-core/src/services/ApiContext.ts
@@ -241,6 +241,11 @@ export class ApiContext extends BaseContext implements IApiContext {
                     this.resolveCall(call, result);
                 })
                 .catch((e) => {
+                    if (e?.name === 'AbortError') {
+                        this.removeFromQueue(call);
+                        return;
+                    }
+
                     /* Problem with response JSON parsing */
                     call.status = 'error';
                     this.setStatus('error');


### PR DESCRIPTION
Fixes ApiContext handling of request aborts with AbortController. Prior to this fix, aborts during reading and parsing response stalls the requests queue.