### PR TITLE
[DatePicker]: Fixed date picker fail on scroll out.

### DIFF
--- a/uui-components/src/overlays/Dropdown.tsx
+++ b/uui-components/src/overlays/Dropdown.tsx
@@ -49,7 +49,7 @@ export class Dropdown extends React.Component<DropdownProps, DropdownState> {
         }
 
         if (this.props.closeOnClickOutside !== false) {
-            window.addEventListener('click', this.clickOutsideHandler, true);
+            window.addEventListener('mousedown', this.clickOutsideHandler, true);
         }
     }
 
@@ -57,7 +57,7 @@ export class Dropdown extends React.Component<DropdownProps, DropdownState> {
         window.removeEventListener('dragstart', this.clickOutsideHandler);
         this.targetNode?.removeEventListener?.('mouseenter', this.handleMouseEnter);
         this.targetNode?.removeEventListener?.('mouseleave', this.handleMouseLeave);
-        window.removeEventListener('click', this.clickOutsideHandler, true);
+        window.removeEventListener('mousedown', this.clickOutsideHandler, true);
         window.removeEventListener('mousemove', this.handleMouseMove);
         this.layer && this.context.uuiLayout?.releaseLayer(this.layer);
     }

--- a/uui/components/filters/PresetPanel/__tests__/presetsPanel.test.tsx
+++ b/uui/components/filters/PresetPanel/__tests__/presetsPanel.test.tsx
@@ -19,10 +19,19 @@ async function openTabMenuAndClickOption(tab: HTMLElement, optionToClick: string
     const dialog = await screen.findByRole('dialog');
     const items = within(dialog).getAllByRole('menuitem');
     const opt = items.map((item) => within(item).queryByText(optionToClick)).find((e) => !!e);
-    fireEvent.click(opt);
+    if (opt) {
+        fireEvent.mouseDown(opt);
+        fireEvent.click(opt);
+    }
 }
 async function expectPresetTabHasOptions(tab: HTMLElement, expectedOptions: string[]) {
-    fireEvent.click(within(tab).getByRole('button'));
+    const btn = within(tab).getByRole('button');
+    /** 
+     * Dropdown is closing on mousedown event.
+     * But testing-library is not firing that event while calling `fireEvent.click(elem)`.
+     */
+    fireEvent.mouseDown(btn);
+    fireEvent.click(btn);
     const dialog = await screen.findByRole('dialog');
     const items = within(dialog).getAllByRole('menuitem');
     expect(items.length).toBe(expectedOptions.length);


### PR DESCRIPTION
### Summary

#### Problem: DatePicker body (Dropdown Body) was closed only on mouse-up event (click event). So, it was possible to scroll the dropdown target out of the screen, which led to page crush.

#### Solution: Added closing DropdownBody on mouse-down event, instead of click.
 
#### Bug reproduction

https://github.com/user-attachments/assets/7558c377-1d60-410f-8608-1e075d1949e5

#### Solution behavior:

https://github.com/user-attachments/assets/e1b40620-d435-4116-887b-8efca552d394



