### PR TITLE
Bugfix/nullpointer when colsizes missed

### DIFF
--- a/uui-editor/src/plugins/tablePlugin/TableElement.tsx
+++ b/uui-editor/src/plugins/tablePlugin/TableElement.tsx
@@ -25,7 +25,7 @@ const TableElement = withHOC(TableProvider, withRef<typeof PlateElement>(({ clas
     const colSizeOverrides = tableStore.colSizeOverrides();
 
     const currentColSizes = useMemo(() => {
-        return element.colSizes.map((size, index) => colSizeOverrides.get(index) || size || EMPTY_COL_WIDTH);
+        return element.colSizes?.map((size, index) => colSizeOverrides.get(index) || size || EMPTY_COL_WIDTH);
     }, [colSizeOverrides, element]);
 
     const tableWidth = useMemo(() => currentColSizes.reduce((acc, cur) => acc + cur, 0), [currentColSizes]);

--- a/uui-editor/src/plugins/tablePlugin/TableElement.tsx
+++ b/uui-editor/src/plugins/tablePlugin/TableElement.tsx
@@ -25,7 +25,7 @@ const TableElement = withHOC(TableProvider, withRef<typeof PlateElement>(({ clas
     const colSizeOverrides = tableStore.colSizeOverrides();
 
     const currentColSizes = useMemo(() => {
-        return element.colSizes?.map((size, index) => colSizeOverrides.get(index) || size || EMPTY_COL_WIDTH);
+        return element.colSizes?.map((size, index) => colSizeOverrides.get(index) || size || EMPTY_COL_WIDTH) || [];
     }, [colSizeOverrides, element]);
 
     const tableWidth = useMemo(() => currentColSizes.reduce((acc, cur) => acc + cur, 0), [currentColSizes]);


### PR DESCRIPTION
It fixes the issue when colSizes is missed in the JSON. Note that colSizes is optional here:
```
// node_modules/@udecode/plate-table/dist/index.d.ts

interface TTableElement extends TElement {
    colSizes?: number[];
    marginLeft?: number;
}

```