### PR TITLE
Fix issue when analytics not being sent when `href` prop used

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -15,6 +15,14 @@
 * [RTE]: fixed working of old iframe data structure with 'src' prop
 * [VerticalTabButton]: reverted paddings & gaps to previous values for all sizes
 * [RTE]: fixed migration of old table element data.cellSizes to the new colSizes format
+* [Anchor]: fixed `clickAnalyticsEvent` not being sent when `href` property used
+* [Badge]: fixed `clickAnalyticsEvent` not being sent when `href` property used
+* [Button]: fixed `clickAnalyticsEvent` not being sent when `href` property used
+* [LinkButton]: fixed `clickAnalyticsEvent` not being sent when `href` property used
+* [IconButton]: fixed `clickAnalyticsEvent` not being sent when `href` property used
+* [MainMenuButton]: fixed `clickAnalyticsEvent` not being sent when `href` property used
+* [TabButton]: fixed `clickAnalyticsEvent` not being sent when `href` property used
+* [Tag]: fixed `clickAnalyticsEvent` not being sent when `href` property used
 
 # 5.10.2 - 24.10.2024
 

--- a/uui-components/src/widgets/Clickable.tsx
+++ b/uui-components/src/widgets/Clickable.tsx
@@ -21,7 +21,7 @@ export const Clickable = React.forwardRef<ClickableForwardedRef, PropsWithChildr
     const context = useUuiContext();
     const isAnchor = Boolean(props.href || props.link || props.type === 'anchor');
     const isButton = Boolean(!isAnchor && (props.onClick || props.type === 'button'));
-    const hasClick = Boolean(!props.isDisabled && (props.link || props.onClick));
+    const hasClick = Boolean(!props.isDisabled && (props.link || props.onClick || props.clickAnalyticsEvent));
     const getIsLinkActive = () => {
         if (props.isLinkActive !== undefined) {
             return props.isLinkActive;

--- a/uui-components/src/widgets/__tests__/Clickable.test.tsx
+++ b/uui-components/src/widgets/__tests__/Clickable.test.tsx
@@ -134,7 +134,7 @@ describe('Clickable', () => {
         expect(mockRedirect).not.toHaveBeenCalled();
     });
 
-    it('calls sendEvent when Clickable is clicked', async () => {
+    it('calls sendEvent when Clickable with onClick is clicked', async () => {
         const mockSendEvent = jest.fn();
         jest.spyOn(React, 'useContext').mockImplementation(
             () => ({
@@ -145,6 +145,42 @@ describe('Clickable', () => {
         );
         await renderWithContextAsync(<Clickable onClick={ jest.fn } clickAnalyticsEvent={ { name: 'click' } } />);
         fireEvent.click(screen.getByRole('button'));
+        expect(mockSendEvent).toHaveBeenCalledTimes(1);
+        expect(mockSendEvent).toHaveBeenCalledWith({ name: 'click' });
+    });
+
+    it('calls sendEvent when Clickable with href is clicked', async () => {
+        const mockSendEvent = jest.fn();
+        jest.spyOn(React, 'useContext').mockImplementation(
+            () => ({
+                uuiAnalytics: {
+                    sendEvent: mockSendEvent,
+                },
+            }),
+        );
+        await renderWithContextAsync(<Clickable href="#" clickAnalyticsEvent={ { name: 'click' } } />);
+        fireEvent.click(screen.getByRole('link'));
+        expect(mockSendEvent).toHaveBeenCalledTimes(1);
+        expect(mockSendEvent).toHaveBeenCalledWith({ name: 'click' });
+    });
+
+    it('calls sendEvent when Clickable with link is clicked', async () => {
+        const pathname = '#';
+        const mockRedirect = jest.fn();
+        const mockSendEvent = jest.fn();
+        const mockCreateHref = jest.fn().mockReturnValue(pathname);
+        jest.spyOn(React, 'useContext').mockImplementation(() => ({
+            uuiRouter: {
+                redirect: mockRedirect,
+                isActive: jest.fn(),
+                createHref: mockCreateHref,
+            },
+            uuiAnalytics: {
+                sendEvent: mockSendEvent,
+            },
+        }));
+        await renderWithContextAsync(<Clickable link={ { pathname } } clickAnalyticsEvent={ { name: 'click' } } />);
+        fireEvent.click(screen.getByRole('link'));
         expect(mockSendEvent).toHaveBeenCalledTimes(1);
         expect(mockSendEvent).toHaveBeenCalledWith({ name: 'click' });
     });


### PR DESCRIPTION
### Description:

Fixed issue when `clickAnalyticsEvent` not being sent when `href` prop used at components, that uses inner Clickable component: `Tag`, `Badge`, `Anchor`, `TabButton`, `MainMenuButton`, `Button`, `LinkButton`, `IconButton`.

#### Issue link:

Closes #2611

#### QA notes:

Honestly, I don't like the idea to mock entire `React.useContext`, especially when it is required to mock more API than is actually to be tested. There's an option to mock just `jest.spyOn(AnalyticsContext.prototype, 'sendEvent')` in updated test cases instead.