### PR TITLE
Fixed wrong border radius in focus state for components

### DIFF
--- a/app/src/docs/_examples/linkButton/DefaultExample.module.scss
+++ b/app/src/docs/_examples/linkButton/DefaultExample.module.scss
@@ -10,6 +10,7 @@
     align-items: flex-end;
     margin-right: 12px;
     min-width: 120px;
+    overflow: unset;
 }
 
 .descriptions {

--- a/uui/assets/styles/effects.scss
+++ b/uui/assets/styles/effects.scss
@@ -1,7 +1,6 @@
 @mixin dnd-ghost-shadow() { box-shadow: var(--uui-shadow-level-3); }
 
-@mixin focus-visible-effect($offset: var(--uui-focus-outline-offset), $radius: var(--uui-focus-radius)) {
+@mixin focus-visible-effect($offset: var(--uui-focus-outline-offset)) {
     outline: var(--uui-focus-outline-width) solid var(--uui-outline-focus);
     outline-offset: $offset;
-    border-radius: $radius;
 }

--- a/uui/assets/styles/typography.scss
+++ b/uui/assets/styles/typography.scss
@@ -85,7 +85,8 @@
         text-decoration: underline;
 
         &:focus-visible {
-            @include focus-visible-effect(2px, 2px);
+            @include focus-visible-effect(2px);
+            border-radius: var(--uui-focus-radius);
         }
 
         &:visited {

--- a/uui/components/buttons/IconButton.module.scss
+++ b/uui/components/buttons/IconButton.module.scss
@@ -5,6 +5,8 @@
     --uui-icon_btn-hover: var(--uui-color-60);
     --uui-icon_btn-active: var(--uui-color-70);
     --uui-icon_btn-disabled: var(--uui-icon-disabled); // from core or color class? Current - from core
+
+    --uui-icon_btn-focus-radius: var(--uui-focus-radius);
     //
     fill: var(--uui-icon_btn);
 
@@ -25,6 +27,7 @@
 
         &:focus-visible {
             @include focus-visible-effect();
+            border-radius: var(--uui-icon_btn-focus-radius);
         }
     }
 

--- a/uui/components/buttons/LinkButton.module.scss
+++ b/uui/components/buttons/LinkButton.module.scss
@@ -20,6 +20,7 @@
     --uui-link-button-icon-height: var(--uui-icon-size);
     --uui-link-button-line-height: var(--uui-line-height);
     --uui-link-button-font-size: var(--uui-font-size);
+    --uui-link-button-focus-radius: var(--uui-focus-radius);
     //
     min-width: var(--uui-link-button-min-width);
 
@@ -48,7 +49,8 @@
             }
 
             &:focus-visible {
-                @include focus-visible-effect(2px, 2px);
+                @include focus-visible-effect(2px);
+                border-radius: var(--uui-link-button-focus-radius);
             }
         }
 

--- a/uui/components/buttons/TabButton.module.scss
+++ b/uui/components/buttons/TabButton.module.scss
@@ -65,7 +65,7 @@
     }
 
     &:global(.-clickable):focus-visible {
-        @include focus-visible-effect(calc(0 - var(--uui-focus-outline-width)), 0);
+        @include focus-visible-effect(calc(0 - var(--uui-focus-outline-width)));
     }
 
     &:global(.uui-disabled) {

--- a/uui/components/inputs/Switch.module.scss
+++ b/uui/components/inputs/Switch.module.scss
@@ -53,7 +53,8 @@
         box-sizing: border-box;
 
         :global(input[type='checkbox']):focus-visible {
-            @include focus-visible-effect(var(--uui-focus-outline-offset), inherit);
+            @include focus-visible-effect(var(--uui-focus-outline-offset));
+            border-radius: var(--uui-switch-min-height);
             width: inherit;
             height: inherit;
             position: absolute;

--- a/uui/components/layout/Accordion.module.scss
+++ b/uui/components/layout/Accordion.module.scss
@@ -34,7 +34,7 @@
         cursor: pointer;
 
         &:focus-visible {
-            @include focus-visible-effect(-2px, 0);
+            @include focus-visible-effect(-2px);
         }
     }
 

--- a/uui/components/navigation/Anchor.module.scss
+++ b/uui/components/navigation/Anchor.module.scss
@@ -2,6 +2,7 @@
 
 .root {
     &:global(.-clickable):focus-visible {
-        @include focus-visible-effect(2px, 2px);
+        @include focus-visible-effect(2px);
+        border-radius: var(--uui-focus-radius);
     }
 }

--- a/uui/components/navigation/MainMenu/Burger/Burger.module.scss
+++ b/uui/components/navigation/MainMenu/Burger/Burger.module.scss
@@ -34,7 +34,7 @@
         }
 
         &:focus-visible {
-            @include focus-visible-effect(-2px, 0);
+            @include focus-visible-effect(-2px);
         }
 
         :global(.uui-icon) svg {

--- a/uui/components/navigation/MainMenu/Burger/BurgerButton.module.scss
+++ b/uui/components/navigation/MainMenu/Burger/BurgerButton.module.scss
@@ -29,7 +29,7 @@
             }
 
             &:focus-visible {
-                @include focus-visible-effect(-2px, null);
+                @include focus-visible-effect(-2px);
             }
         }
     }

--- a/uui/components/navigation/MainMenu/GlobalMenu.module.scss
+++ b/uui/components/navigation/MainMenu/GlobalMenu.module.scss
@@ -22,7 +22,7 @@
     }
 
     &:focus-visible {
-        @include focus-visible-effect(-2px, 0);
+        @include focus-visible-effect(-2px);
     }
 }
 

--- a/uui/components/navigation/MainMenu/MainMenu.module.scss
+++ b/uui/components/navigation/MainMenu/MainMenu.module.scss
@@ -49,6 +49,6 @@
     }
 
     :global(.-clickable):focus-visible {
-        @include focus-visible-effect(-2px, 0);
+        @include focus-visible-effect(-2px);
     }
 }

--- a/uui/components/navigation/MainMenu/MainMenuAvatar.module.scss
+++ b/uui/components/navigation/MainMenu/MainMenuAvatar.module.scss
@@ -31,7 +31,7 @@
         }
 
         &:focus-visible {
-            @include focus-visible-effect(-2px, 0);
+            @include focus-visible-effect(-2px);
         }
     }
 }

--- a/uui/components/navigation/MainMenu/MainMenuDropdown.module.scss
+++ b/uui/components/navigation/MainMenu/MainMenuDropdown.module.scss
@@ -31,7 +31,7 @@
         }
 
         &:focus-visible {
-            @include focus-visible-effect(-2px, null);
+            @include focus-visible-effect(-2px);
         }
     }
 

--- a/uui/components/overlays/DropdownMenu.module.scss
+++ b/uui/components/overlays/DropdownMenu.module.scss
@@ -137,7 +137,7 @@
         }
 
         &:focus-visible {
-            @include focus-visible-effect(-2px, null);
+            @include focus-visible-effect(-2px);
         }
     }
 

--- a/uui/components/tables/columnsConfigurationModal/ColumnsConfigurationModal.module.scss
+++ b/uui/components/tables/columnsConfigurationModal/ColumnsConfigurationModal.module.scss
@@ -86,7 +86,7 @@
 
     .subgroup-accordion {
         :global(.uui-accordion-toggler):focus-visible {
-            @include focus-visible-effect(-2px, 0);
+            @include focus-visible-effect(-2px);
         }
 
         .subgroup {

--- a/uui/components/widgets/AvatarStack.module.scss
+++ b/uui/components/widgets/AvatarStack.module.scss
@@ -14,7 +14,7 @@
 
         :global(.-clickable) {
             &:focus-visible {
-                @include focus-visible-effect(2px, 50%);
+                @include focus-visible-effect(2px);
             }
 
             &:focus-visible, &:hover {

--- a/uui/components/widgets/Badge.module.scss
+++ b/uui/components/widgets/Badge.module.scss
@@ -86,7 +86,7 @@
     }
 
     &:global(.-clickable):focus-visible {
-        @include focus-visible-effect(2px, null);  // todo
+        @include focus-visible-effect(2px);
     }
 
     &:global(.uui-fill-solid) {


### PR DESCRIPTION
<!-- **Before submitting your PR, ensure that you made the following:**

- Linked the issue(if exists)
- Lint and unit tests pass locally with my changes
- Changelog is updated or not needed
- Documentation is updated/provided or not needed
- Property explorer is updated/provided or not needed
- TSDoc comments for public interfaces is updated/provided or not needed 
 -->

### Description:
Removed border radius from mixin 'focus-visible-effect', moved to components where it is needed.
Fixed focus cutting off in LinkButton example

#### QA notes: 
see comments in MR #2533 