### PR TITLE
[PickerInput]: fixed unnecessary api calls on body open with `minCharsToSearch` prop and search in body

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,10 @@
+# 5.xx.xx - xx.xx.2024
+
+**What's New**
+
+**What's Fixed**
+* [PickerInput]: fixed unnecessary api calls on body open with `minCharsToSearch` prop and search in body.
+
 # 5.11.0 - 15.11.2024
 
 **What's New**

--- a/uui-components/src/pickers/hooks/usePickerInput.ts
+++ b/uui-components/src/pickers/hooks/usePickerInput.ts
@@ -52,7 +52,9 @@ export function usePickerInput<TItem, TId, TProps>(props: UsePickerInputProps<TI
 
     const shouldShowBody = () => (props.shouldShowBody ?? defaultShouldShowBody)();
 
-    const showSelectedOnly = !shouldShowBody() || pickerInputState.showSelected;
+    const shouldLoadList = () => isSearchLongEnough() && shouldShowBody();
+
+    const showSelectedOnly = !shouldLoadList() || pickerInputState.showSelected;
 
     const picker = usePicker<TItem, TId, UsePickerInputProps<TItem, TId, TProps>>({ ...props, showSelectedOnly }, pickerInputState);
     const {


### PR DESCRIPTION

<!-- **Before submitting your PR, ensure that you made the following:**

- Linked the issue(if exists)
- Lint and unit tests pass locally with my changes
- Changelog is updated or not needed
- Documentation is updated/provided or not needed
- Property explorer is updated/provided or not needed
- TSDoc comments for public interfaces is updated/provided or not needed 
 -->

### Description:


#### Issue link:

#### QA notes: 

Need to retest PickerInput list loading behavior, initially selected items load and minCharsToSearch behavior in all cases(Pay attention, that it shouldn't be api calls in network when search length less than minCharsToSearch)