### PR TITLE
Fix crash when removing the sole table row

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -14,6 +14,7 @@
 * [RTE]: fixed scroll to the top of the editor after editor modal windows(Add image/link/video etc.) were close
 * [RTE]: fixed error while merging cells without content
 * [RTE]: fixed bug when files added from attachment button inserted in preview mode instead of attachment block
+* [RTE]: fixed crash when removing the sole table row
 
 # 5.11.0 - 15.11.2024
 

--- a/uui-editor/src/plugins/tablePlugin/ToolbarContent.tsx
+++ b/uui-editor/src/plugins/tablePlugin/ToolbarContent.tsx
@@ -14,6 +14,7 @@ import { ToolbarButton } from '../../implementation/ToolbarButton';
 import { useEditorRef } from '@udecode/plate-common';
 import { getTableEntries, insertTableColumn, insertTableRow, deleteRow, deleteTable, unmergeTableCells, deleteColumn } from '@udecode/plate-table';
 import { TABLE_HEADER_CELL_TYPE } from './constants';
+import { temporaryFixDeleteRow } from './temporaryFixDeleteRow';
 
 function StyledRemoveTable() {
     return <RemoveTable className={ css.removeTableIcon } />;
@@ -72,7 +73,7 @@ export function TableToolbarContent({ canUnmerge }:{ canUnmerge:boolean }) {
             />
             <ToolbarButton
                 key="delete-row"
-                onClick={ () => deleteRow(editor) }
+                onClick={ temporaryFixDeleteRow(editor, () => deleteRow(editor)) }
                 icon={ RemoveRow }
             />
             <ToolbarButton

--- a/uui-editor/src/plugins/tablePlugin/temporaryFixDeleteRow.ts
+++ b/uui-editor/src/plugins/tablePlugin/temporaryFixDeleteRow.ts
@@ -1,0 +1,25 @@
+import { isType, type PlateEditor, getBlockAbove } from '@udecode/plate-common';
+import { TABLE_TYPE } from './constants';
+import type { TableElementType } from './types';
+
+/**
+* Remove fix wrapper function when `@udecode/plate-table` will be updated to 40.0.0
+* See {@link https://github.com/udecode/plate/blob/f8fa0e7f4c0b4dd3ab445fd0aa55738db1596de9/packages/table/CHANGELOG.md#4000} for details
+*/
+export const temporaryFixDeleteRow = (editor: PlateEditor, deleteRowFn: () => void) => {
+    return () => {
+        const tableElement = getBlockAbove<TableElementType>(editor, { match: (node) => isType(editor, node, TABLE_TYPE) });
+
+        if (!tableElement) {
+            return;
+        }
+
+        const [tableNode] = tableElement;
+
+        if (tableNode.children.length <= 1) {
+            return;
+        }
+
+        deleteRowFn();
+    };
+};


### PR DESCRIPTION
### Description:

Fixes app crashes when deleting sole table row

#### Issue link:

Closes #2673

#### QA notes:

It is `@udecode/plate-table` bug. Fixed at `v40.0.0` ([plate-table changelog](https://github.com/udecode/plate/blob/f8fa0e7f4c0b4dd3ab445fd0aa55738db1596de9/packages/table/CHANGELOG.md#4000))
I added a temporary fix to prevent the error when removing the sole row in a table and left reference within a comment, mentioning that fix can be removed after upgrade to corresponding version.