### PR TITLE
Fixed CSS errors in turbopack mode nextjs

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -16,6 +16,7 @@
 **What's Fixed**
 * [NumericInput]: added right margin for arrows
 * [MultiSwitch]: fixed `isReadonly` prop
+* [FilterPanelItemToggler]: removed redundant left padding for postfix (align with figma design)
 
 # 5.13.2 - 04.03.2025
 **What's Fixed**

--- a/uui-components/src/index.scss
+++ b/uui-components/src/index.scss
@@ -3,7 +3,7 @@ body {
     -moz-osx-font-smoothing: grayscale;
 }
 
-:global(.-draggable) {
+.-draggable {
     touch-action: none;
     user-select: none;
 }

--- a/uui/components/filters/FilterPanelItemToggler.module.scss
+++ b/uui/components/filters/FilterPanelItemToggler.module.scss
@@ -93,15 +93,6 @@
                 padding-bottom: 0;
                 color: var(--uui-filters_toggler-text);
 
-                div {
-                    display: inline-block;
-                    margin-right: 3px;
-
-                    :nth-last-child {
-                        margin-right: 0;
-                    }
-                }
-
                 & + span {
                     color: var(--uui-filters_toggler-text);
                 }
@@ -110,7 +101,6 @@
             .postfix {
                 padding-top: 0;
                 padding-bottom: 0;
-                padding-left: 6px;
                 overflow: visible;
                 color: var(--uui-filters_toggler-text);
             }


### PR DESCRIPTION
### Description:
[@epam/uui-components]: fixed invalid global class,
[@epam/uui]: removed invalid pseudo class,
[FilterPanelItemToggler]: removed redundant left padding for postfix.

#### QA notes: 
FilterPanelItemToggler aligned with figma docs - https://www.figma.com/design/qb7WHgBkyBpovFlOZRe30p/UUI-Patterns?node-id=10511-5347&t=xgDWVtaCnRpi4uVT-4