### PR TITLE
Feature/async data source cache

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,18 +8,17 @@
       "type": "node",
       "request": "launch",
       "name": "Jest",
-      "program": "${workspaceFolder}/node_modules/.bin/jest",
-      "args": [
-        "--runInBand",
-        "uui-editor/src/__tests__/serialization.test.ts"
-      ],
+      "program": "${workspaceRoot}/node_modules/jest/bin/jest.js",
+      "args": ["--verbose", "-i", "--no-cache", "--testTimeout", "100500", "--testPathPattern", "${fileBasename}"],
       "console": "integratedTerminal",
       "internalConsoleOptions": "neverOpen",
-      "runtimeExecutable": "/Users/dzmitry_tamashevich/.nvm/versions/node/v18.18.0/bin/node",
-      "disableOptimisticBPs": true,
       "windows": {
         "program": "${workspaceFolder}/node_modules/jest/bin/jest"
-      }
+      },
+      "env": {
+        "CI": "true",
+        "DEBUG": "jest"
+      },
     },
     {
       "type": "node",

--- a/uui-core/src/data/processing/__tests__/asyncDataSource.test.tsx
+++ b/uui-core/src/data/processing/__tests__/asyncDataSource.test.tsx
@@ -1,0 +1,70 @@
+import { act, renderHookWithContextAsync } from '@epam/uui-test-utils';
+import { AsyncDataSource } from '../AsyncDataSource';
+
+interface TestItem {
+    id: number;
+    name: string;
+}
+
+describe('AsyncDataSource', () => {
+    let apiCallCount = 0;
+    const mockData: TestItem[] = [
+        { id: 1, name: 'Item 1' },
+        { id: 2, name: 'Item 2' },
+    ];
+
+    const mockApi = async () => {
+        apiCallCount++;
+        return mockData;
+    };
+
+    beforeEach(() => {
+        apiCallCount = 0;
+    });
+
+    it.each([
+        { reloadVia: 'datasource' },
+        { reloadVia: 'view' },
+    ])(
+        'Should cache API calls, reuse results, and handle %s-triggered reloads',
+        async ({ reloadVia }) => {
+            const dataSource = new AsyncDataSource({
+                api: mockApi,
+                getId: (item) => item.id,
+            });
+
+            // First view should trigger API
+            const { result: result1 } = await renderHookWithContextAsync(
+                () => dataSource.useView({}, () => {}, {}),
+            );
+
+            const rows1 = result1.current.getVisibleRows();
+            expect(rows1.length).toBe(2);
+            expect(apiCallCount).toBe(1);
+
+            // Second view should use cache
+            const { result: result2 } = await renderHookWithContextAsync(
+                () => dataSource.useView({}, () => {}, {}),
+            );
+            const rows2 = result2.current.getVisibleRows();
+            expect(rows2.length).toBe(2);
+            expect(apiCallCount).toBe(1); // Should still be 1 as cache was used
+
+            // Trigger reload, either via view, or datasource. This should lead to the same results.
+            await act(async () => {
+                if (reloadVia === 'view') {
+                    result2.current.reload();
+                } else {
+                    dataSource.reload();
+                }
+            });
+
+            const reloadedRows1 = result1.current.getVisibleRows();
+            expect(reloadedRows1.length).toBe(2);
+            const reloadedRows2 = result2.current.getVisibleRows();
+            expect(reloadedRows2.length).toBe(2);
+
+            expect(apiCallCount).toBe(2);
+        },
+    );
+});


### PR DESCRIPTION
### Description:

This PR introduces caching functionality to the AsyncDataSource, allowing two or more Views to reuse the same data.

I've also removed some broken settings into .vscode/launch.json, which prevented running tests with debugger from VSCode.