### PR TITLE
[PickerModal]: disabled "Show only selected" when search is active

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,13 +2,14 @@
 **What's New**
 * [RangeDatePicker]: improved a11y, updated so that when a date is typed in the input fields, the calendar body immediately reflects and selects the new value, providing instant feedback and better usability.
 * [DatePicker]: improved a11y.
+* [@epam/uui-test-utils]: added global mock for "getBoundingClientRect" to "setupJsDom"
 
 **What's Fixed**
 * [RangeDatePicker]: fixed switching of the calendar panel depending on which field the action was on.
 * [PickerInput]: fixed returning to the previous focused element via shift+tab press
 * [Rating]: fixed wrong rating calculations in 'block' container and 'sticky' value on hover
 * [Modals][Eectric]: increased border radius to 12 px
-
+* [PickerModal]: disabled "Show only selected" when search is active
 
 # 6.1.0 - 08.05.2025
 

--- a/test-utils/src/internal/jsdomMockUtils.ts
+++ b/test-utils/src/internal/jsdomMockUtils.ts
@@ -1,16 +1,16 @@
-export function mockGetBoundingClientRect(callback: (elem: HTMLElement) => Partial<DOMRect>) {
+export function mockGetBoundingClientRect(callback?: (elem: HTMLElement) => Partial<DOMRect>) {
     Object.assign(window.Element.prototype, {
         getBoundingClientRect: function mockForTest(this: HTMLElement) {
-            const res = callback(this) as DOMRect;
+            const res = callback ? callback(this) as DOMRect : {} as DOMRect;
             const fallback: Partial<DOMRect> = {
                 x: 0,
                 y: 0,
-                width: 0,
-                height: 0,
+                width: 1,
+                height: 1,
                 top: 0,
                 left: 0,
-                bottom: 0,
-                right: 0,
+                bottom: 1,
+                right: 1,
             };
             return {
                 ...fallback,

--- a/test-utils/src/jsdom/setupJsDom.js
+++ b/test-utils/src/jsdom/setupJsDom.js
@@ -5,6 +5,7 @@
  */
 import React from 'react';
 import { testRunner } from '../internal/testRunnerUtils';
+import { mockGetBoundingClientRect } from '../internal/jsdomMockUtils';
 
 /**
  * Adds UUI-specific mocks to the jsdom
@@ -25,9 +26,13 @@ export function setupJsDom(global, options = {}) {
             writeText: () => {},
         },
     };
+
+    mockGetBoundingClientRect();
+
     const elementPrototypeMock = {
         scrollTo: () => {},
     };
+
     const consoleMock = (() => {
         const consoleErrorPrev = global.console.error;
         const error = (/** @type {[any]} */ ...args) => {

--- a/uui-components/src/adaptivePanel/__tests__/__snapshots__/adaptivePanel.test.tsx.snap
+++ b/uui-components/src/adaptivePanel/__tests__/__snapshots__/adaptivePanel.test.tsx.snap
@@ -4,6 +4,7 @@ exports[`AdaptivePanel should render no items provided 1`] = `
 <DocumentFragment>
   <div
     class="mainWrapper"
+    data-testid="adaptive-panel"
   >
     <div
       class="itemsWrapper"
@@ -16,6 +17,7 @@ exports[`AdaptivePanel should render some items 1`] = `
 <DocumentFragment>
   <div
     class="mainWrapper"
+    data-testid="adaptive-panel"
   >
     <div
       class="itemsWrapper"
@@ -49,11 +51,33 @@ exports[`AdaptivePanel should render some items with itemsGap 1`] = `
 <DocumentFragment>
   <div
     class="mainWrapper"
+    data-testid="adaptive-panel"
   >
     <div
       class="itemsWrapper"
       style="column-gap: 6px;"
-    />
+    >
+      <div
+        data-label="Item snapshot-0"
+        data-testid="adaptive-item"
+      />
+      <div
+        data-label="Item snapshot-1"
+        data-testid="adaptive-item"
+      />
+      <div
+        data-label="Item snapshot-2"
+        data-testid="adaptive-item"
+      />
+      <div
+        data-label="Item snapshot-3"
+        data-testid="adaptive-item"
+      />
+      <div
+        data-label="Item snapshot-4"
+        data-testid="adaptive-item"
+      />
+    </div>
   </div>
 </DocumentFragment>
 `;

--- a/uui-components/src/adaptivePanel/__tests__/adaptivePanel.test.tsx
+++ b/uui-components/src/adaptivePanel/__tests__/adaptivePanel.test.tsx
@@ -62,17 +62,20 @@ async function setupAdaptivePanel({ width, itemWidth, itemsGap }: { width: numbe
 
 describe('AdaptivePanel', () => {
     it('should render no items provided', async () => {
-        const tree = await renderSnapshotWithContextAsync(<AdaptivePanel items={ [] } />);
+        mockAdaptivePanelLayout({ width: 500, itemWidth: 20 });
+        const tree = await renderSnapshotWithContextAsync(<AdaptivePanel rawProps={ { 'data-testid': 'adaptive-panel' } } items={ [] } />);
         expect(tree).toMatchSnapshot();
     });
 
     it('should render some items', async () => {
-        const tree = await renderSnapshotWithContextAsync(<AdaptivePanel items={ getNItems('snapshot', 5) } />);
+        mockAdaptivePanelLayout({ width: 500, itemWidth: 20 });
+        const tree = await renderSnapshotWithContextAsync(<AdaptivePanel rawProps={ { 'data-testid': 'adaptive-panel' } } items={ getNItems('snapshot', 5) } />);
         expect(tree).toMatchSnapshot();
     });
 
     it('should render some items with itemsGap', async () => {
-        const tree = await renderSnapshotWithContextAsync(<AdaptivePanel itemsGap={ 6 } items={ getNItems('snapshot', 5) } />);
+        mockAdaptivePanelLayout({ width: 500, itemWidth: 20 });
+        const tree = await renderSnapshotWithContextAsync(<AdaptivePanel rawProps={ { 'data-testid': 'adaptive-panel' } } itemsGap={ 6 } items={ getNItems('snapshot', 5) } />);
         expect(tree).toMatchSnapshot();
     });
 

--- a/uui/components/filters/PresetPanel/__tests__/presetsPanel.test.tsx
+++ b/uui/components/filters/PresetPanel/__tests__/presetsPanel.test.tsx
@@ -105,6 +105,19 @@ async function setupPresetsPanel({ hasPresetChanged }: Partial<PresetsPanelProps
 }
 
 describe('PresetsPanel', () => {
+    beforeEach(() => {
+        mockAdaptivePanelLayout({
+            isAdaptivePanelRoot: (elem) => {
+                const p = elem.parentElement?.parentElement;
+                if (p && p.getAttribute('data-testid') === 'presets-panel') {
+                    return true;
+                }
+            },
+            width: 500,
+            itemWidth: 15,
+        });
+    });
+
     it('should render with minimum props', async () => {
         const component = await renderSnapshotWithContextAsync(
             <PresetsPanel

--- a/uui/components/pickers/DataPickerBody.tsx
+++ b/uui/components/pickers/DataPickerBody.tsx
@@ -120,6 +120,8 @@ export function DataPickerBody<TItem, TId>({ highlightSearchMatches = true, ...p
 
     const renderedDataRows = useMemo(() => props.rows.map((row) => renderRow(row, props.value)), [props.rows, props.value]);
 
+    // console.log('props.rows', props.rows);
+
     return (
         <>
             {showSearch && (

--- a/uui/components/pickers/PickerModal.tsx
+++ b/uui/components/pickers/PickerModal.tsx
@@ -87,6 +87,7 @@ export function PickerModal<TItem, TId>(props: PickerModalProps<TItem, TId>) {
     };
 
     const dataRows = getRows();
+    const isSearching = dataSourceState.search && dataSourceState.search.length > 0;
 
     return (
         <ModalBlocker { ...props }>
@@ -117,7 +118,7 @@ export function PickerModal<TItem, TId>(props: PickerModalProps<TItem, TId>) {
                             cx={ css.switch }
                             size={ settings.pickerInput.sizes.body.footerSwitchMap[settings.pickerInput.sizes.body.row] }
                             { ...getFooterProps().showSelected }
-                            isDisabled={ view.getSelectedRowsCount() < 1 }
+                            isDisabled={ isSearching || view.getSelectedRowsCount() < 1 }
                             label="Show only selected"
                         />
                     )}

--- a/uui/components/pickers/__tests__/PickerModal.test.tsx
+++ b/uui/components/pickers/__tests__/PickerModal.test.tsx
@@ -535,5 +535,39 @@ describe('PickerModal', () => {
 
             expect(await PickerModalTestObject.findUncheckedOptions()).toEqual([]);
         });
+
+        it('should be disabled "Show only selected" when search field do not empty', async () => {
+            const { dom } = await setupPickerModalForTest<TestItemType, number>({
+                initialValue: [4, 2, 6, 8],
+                selectionMode: 'multi',
+            });
+
+            fireEvent.click(dom.toggler);
+            expect(await PickerModalTestObject.findDialog()).toBeInTheDocument();
+
+            await PickerModalTestObject.waitForOptionsToBeReady();
+
+            expect(await PickerModalTestObject.findCheckedOptions()).toEqual(['A1', 'A2', 'B1', 'B2']);
+            expect(await PickerModalTestObject.findUncheckedOptions()).toEqual(['A1+', 'A2+', 'B1+', 'B2+', 'C1', 'C1+', 'C2']);
+
+            const searchInput = await PickerModalTestObject.findSearchInput();
+
+            fireEvent.change(searchInput, { target: { value: 'A' } });
+
+            await delayAct(500);
+
+            await waitFor(async () => {
+                expect(await PickerModalTestObject.findCheckedOptions()).toEqual(['A1', 'A2']);
+            }, { timeout: 200 });
+            expect(await PickerModalTestObject.findUncheckedOptions()).toEqual(['A1+', 'A2+']);
+
+            await PickerModalTestObject.clickShowOnlySelected();
+
+            await waitFor(async () => {
+                expect(await PickerModalTestObject.findCheckedOptions()).toEqual(['A1', 'A2']);
+            });
+
+            expect(await PickerModalTestObject.findUncheckedOptions()).toEqual(['A1+', 'A2+']);
+        });
     });
 });

--- a/uui/components/tables/__tests__/__snapshots__/ColumnHeaderDropdown.test.tsx.snap
+++ b/uui/components/tables/__tests__/__snapshots__/ColumnHeaderDropdown.test.tsx.snap
@@ -25,9 +25,9 @@ exports[`ColumnHeaderDropdown should be rendered correctly 1`] = `
   <div
     aria-hidden="false"
     class="uui-popper"
-    data-placement="bottom-start"
+    data-placement="top-start"
     role="dialog"
-    style="position: fixed; top: 1px; left: 0px; z-index: 2000;"
+    style="position: fixed; top: -1px; left: 0px; z-index: 2000;"
   >
     <div
       class="uui-dropdown-body -lock-focus root container container"


### PR DESCRIPTION
<!-- **Before submitting your PR, ensure that you made the following:**

- Linked the issue(if exists)
- Lint and unit tests pass locally with my changes
- Changelog is updated or not needed
- Documentation is updated/provided or not needed
- Property explorer is updated/provided or not needed
- TSDoc comments for public interfaces is updated/provided or not needed 
 -->

### Description:
- [PickerModal]: disabled "Show only selected" when search is active, it affected all components that use 'PickerModal', such as PickerList, PickerInput.
- added global mock for "getBoundingClientRect"

#### Issue link:
#2816 

#### QA notes: 