### PR TITLE
[PickerModal]: add clear button functionality and improve its state management

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,11 @@
+# 6.x.x - xx.xx.2025
+**What's New**
+* []: add or remove
+
+**What's Fixed**
+* [PickerModal]: fixed `disableClear: true` behavior for `selectionMode: multi`, added `Clear` button functionality to `selectionMode: single`
+
+
 # 6.1.1 - 29.05.2025
 **What's New**
 * [uui-test-utils]: added global mock for "getBoundingClientRect" to "setupJsDom"

--- a/test-utils/src/testObjects/PickerModal.ts
+++ b/test-utils/src/testObjects/PickerModal.ts
@@ -21,4 +21,58 @@ export class PickerModalTestObject extends PickerTestObject {
         const selectButton = within(modal).getByRole('button', { name: 'Select' });
         fireEvent.click(selectButton);
     }
+
+    static async clickCancelButton() {
+        const modal = await this.findDialog();
+        const cancelButton = within(modal).getByRole('button', { name: /cancel/i });
+        fireEvent.click(cancelButton);
+    }
+
+    static async findClearButton() {
+        const modal = await this.findDialog();
+        return within(modal).queryByRole('button', { name: /clear/i });
+    }
+
+    static async clickClearButton() {
+        const clearButton = await this.findClearButton();
+        if (clearButton) {
+            fireEvent.click(clearButton);
+        }
+    }
+
+    static async findShowOnlySelectedSwitch() {
+        const modal = await this.findDialog();
+        return within(modal).queryByLabelText(/show only selected/i);
+    }
+
+    static async findSelectAllButton() {
+        const modal = await this.findDialog();
+        return within(modal).queryByRole('button', { name: /select all/i });
+    }
+
+    static async findCustomElement(testId: string) {
+        const modal = await this.findDialog();
+        return within(modal).queryByTestId(testId);
+    }
+
+    static async getModalTitle() {
+        const modal = await this.findDialog();
+        const header = within(modal).getByRole('banner');
+        return within(header).getByRole('heading');
+    }
+
+    static async isSearchInputFocused() {
+        const searchInput = await this.findSearchInput();
+        return document.activeElement === searchInput;
+    }
+
+    static async typeInSearch(text: string) {
+        const searchInput = await this.findSearchInput();
+        fireEvent.change(searchInput, { target: { value: text } });
+    }
+
+    static async pressKeyInSearch(key: string, code?: string) {
+        const searchInput = await this.findSearchInput();
+        fireEvent.keyDown(searchInput, { key, code: code || key });
+    }
 }

--- a/uui-components/src/pickers/hooks/types.ts
+++ b/uui-components/src/pickers/hooks/types.ts
@@ -72,6 +72,8 @@ export interface PickerModalOptions<TItem, TId> extends IHasRawProps<React.HTMLA
      * @default false
      */
     disallowClickOutside?: boolean;
+    /** Disallow to clear Picker value */
+    disableClear?: boolean;
 }
 
 export type PickerModalScalarProps<TId, TItem> =

--- a/uui-components/src/pickers/hooks/usePickerModal.ts
+++ b/uui-components/src/pickers/hooks/usePickerModal.ts
@@ -71,6 +71,7 @@ export function usePickerModal<TItem, TId>(props: UsePickerModalProps<TItem, TId
             search: dataSourceState.search,
             success: () => props.success(selection as any),
             abort: props.abort,
+            disableClear: props.disableClear,
         };
     };
 

--- a/uui-core/src/types/pickers.ts
+++ b/uui-core/src/types/pickers.ts
@@ -152,6 +152,9 @@ export type PickerBaseOptions<TItem, TId> = {
     getSearchFields?(item: TItem): string[];
     /** Component ref */
     ref?: React.Ref<PickerInputElement>;
+
+    /** Disallow to clear Picker value */
+    disableClear?: boolean;
 };
 
 export type PickerInputBaseProps<TItem, TId> = PickerBaseProps<TItem, TId>

--- a/uui/components/pickers/PickerModal.tsx
+++ b/uui/components/pickers/PickerModal.tsx
@@ -34,6 +34,7 @@ export function PickerModal<TItem, TId>(props: PickerModalProps<TItem, TId>) {
         isSingleSelect,
         handleDataSourceValueChange,
     } = usePickerModal<TItem, TId>(props);
+    const isSearching = dataSourceState.search && dataSourceState.search.length > 0;
 
     const renderRow = (rowProps: PickerRenderRowParams<TItem, TId>) => {
         return props.renderRow ? (
@@ -53,14 +54,23 @@ export function PickerModal<TItem, TId>(props: PickerModalProps<TItem, TId>) {
     const renderFooter = () => {
         const hasSelection = view.getSelectedRowsCount() > 0;
         const rowsCount = view.getListProps().rowsCount;
-        const isEmptyRowsAndHasNoSelection = (rowsCount === 0 && !hasSelection);
+        const isEmptyRowsAndHasNoSelection = (rowsCount === 0 || !hasSelection);
+        const showClear = !props.disableClear && (isSingleSelect() ? true : (!view.selectAll || hasSelection));
+        const isClearDisabled = isSearching || isEmptyRowsAndHasNoSelection;
+
         return (
             <>
-                {view.selectAll && (
+                {view.selectAll && !hasSelection && (
                     <LinkButton
-                        caption={ hasSelection ? i18n.pickerModal.clearAllButton : i18n.pickerModal.selectAllButton }
-                        onClick={ hasSelection ? () => clearSelection() : () => view.selectAll.onValueChange(true) }
-                        isDisabled={ isEmptyRowsAndHasNoSelection }
+                        caption={ i18n.pickerModal.selectAllButton }
+                        onClick={ () => view.selectAll.onValueChange(true) }
+                    />
+                )}
+                {showClear && (
+                    <LinkButton
+                        caption={ isSingleSelect() ? i18n.pickerModal.clearButton : i18n.pickerModal.clearAllButton }
+                        onClick={ () => clearSelection() }
+                        isDisabled={ isClearDisabled }
                     />
                 )}
                 <FlexSpacer />
@@ -87,7 +97,6 @@ export function PickerModal<TItem, TId>(props: PickerModalProps<TItem, TId>) {
     };
 
     const dataRows = getRows();
-    const isSearching = dataSourceState.search && dataSourceState.search.length > 0;
 
     return (
         <ModalBlocker { ...props }>

--- a/uui/components/pickers/__tests__/__snapshots__/PickerList.test.tsx.snap
+++ b/uui/components/pickers/__tests__/__snapshots__/PickerList.test.tsx.snap
@@ -698,6 +698,18 @@ exports[`PickerList should open body 1`] = `
         <div
           class="root modalFooter uui-modal-footer"
         >
+          <button
+            aria-disabled="true"
+            class="uui-button-box uui-disabled uui-link_button root uui-size-36 uui-no-left-icon uui-no-right-icon uui-color-primary"
+            tabindex="-1"
+            type="button"
+          >
+            <div
+              class="uui-caption uui-link-button-weight-semibold"
+            >
+              CLEAR
+            </div>
+          </button>
           <div
             class="flexSpacer"
           />

--- a/uui/components/pickers/__tests__/__snapshots__/PickerModal.test.tsx.snap
+++ b/uui/components/pickers/__tests__/__snapshots__/PickerModal.test.tsx.snap
@@ -209,6 +209,18 @@ exports[`PickerModal should be rendered correctly 1`] = `
       <div
         class="root modalFooter uui-modal-footer"
       >
+        <button
+          aria-disabled="true"
+          class="uui-button-box uui-disabled uui-link_button root uui-size-36 uui-no-left-icon uui-no-right-icon uui-color-primary"
+          tabindex="-1"
+          type="button"
+        >
+          <div
+            class="uui-caption uui-link-button-weight-semibold"
+          >
+            CLEAR
+          </div>
+        </button>
         <div
           class="flexSpacer"
         />
@@ -967,7 +979,6 @@ exports[`PickerModal should be rendered correctly with maximum props 1`] = `
         class="root modalFooter uui-modal-footer"
       >
         <button
-          aria-disabled="false"
           class="uui-button-box uui-enabled -clickable uui-link_button root uui-size-36 uui-no-left-icon uui-no-right-icon uui-color-primary"
           tabindex="0"
           type="button"
@@ -1248,6 +1259,18 @@ exports[`PickerModal should open body 1`] = `
         <div
           class="root modalFooter uui-modal-footer"
         >
+          <button
+            aria-disabled="true"
+            class="uui-button-box uui-disabled uui-link_button root uui-size-36 uui-no-left-icon uui-no-right-icon uui-color-primary"
+            tabindex="-1"
+            type="button"
+          >
+            <div
+              class="uui-caption uui-link-button-weight-semibold"
+            >
+              CLEAR
+            </div>
+          </button>
           <div
             class="flexSpacer"
           />

--- a/uui/i18n.ts
+++ b/uui/i18n.ts
@@ -14,6 +14,7 @@ const TREE_SHAKEABLE_INIT = () => ({
         searchPlaceholder: 'Type text for quick search',
         cancelButton: 'Cancel',
         selectButton: 'Select',
+        clearButton: 'CLEAR',
         clearAllButton: 'CLEAR ALL',
         selectAllButton: 'SELECT ALL',
     },


### PR DESCRIPTION
<!-- **Before submitting your PR, ensure that you made the following:**

- Linked the issue(if exists)
- Lint and unit tests pass locally with my changes
- Changelog is updated or not needed
- Documentation is updated/provided or not needed
- Property explorer is updated/provided or not needed
- TSDoc comments for public interfaces is updated/provided or not needed 
 -->

### Description:
[PickerModal]: fixed `disableClear: true` behavior for `selectionMode: multi`, added `Clear` button functionality to `selectionMode: single`

#### Issue link:
#2561 

#### QA notes: 