### PR TITLE
[PickerInput]: `Esc` key unexpectedly closes modal window when Picker Input dropdown is focused and expanded

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,7 @@
 
 **What's Fixed**
 * [PickerModal]: fixed `disableClear: true` behavior for `selectionMode: multi`, added `Clear` button functionality to `selectionMode: single`
+* [PickerInput] Stop "Escape" key press event propagation when body is opened ([#2839](https://github.com/epam/UUI/pull/2839))
 
 
 # 6.1.2 - 30.05.2025

--- a/uui-components/src/pickers/hooks/usePickerInput.ts
+++ b/uui-components/src/pickers/hooks/usePickerInput.ts
@@ -127,6 +127,7 @@ export function usePickerInput<TItem, TId, TProps>(props: UsePickerInputProps<TI
 
         if (e.key === 'Escape' && opened) {
             e.preventDefault();
+            e.stopPropagation();
             toggleDropdownOpening(false);
         }
 

--- a/uui-components/src/pickers/hooks/usePickerInput.ts
+++ b/uui-components/src/pickers/hooks/usePickerInput.ts
@@ -116,18 +116,18 @@ export function usePickerInput<TItem, TId, TProps>(props: UsePickerInputProps<TI
 
     const handlePickerInputKeyboard = (
         rows: DataRowProps<TItem, TId>[],
-        e: React.KeyboardEvent<HTMLElement>,
+        event: React.KeyboardEvent<HTMLElement>,
         actualSearch?: string,
     ) => {
         if (props.isDisabled || props.isReadonly) return;
 
-        if (e.key === 'Enter' && !opened) {
+        if (event.key === 'Enter' && !opened) {
             return toggleBodyOpening(true);
         }
 
-        if (e.key === 'Escape' && opened) {
-            e.preventDefault();
-            e.stopPropagation();
+        if (event.key === 'Escape' && opened) {
+            event.preventDefault();
+            event.stopPropagation();
             toggleDropdownOpening(false);
         }
 
@@ -140,7 +140,7 @@ export function usePickerInput<TItem, TId, TProps>(props: UsePickerInputProps<TI
                 searchPosition: getSearchPosition(),
                 rows,
             },
-            e,
+            event,
         );
     };
 

--- a/uui/components/overlays/__tests__/Modals.test.tsx
+++ b/uui/components/overlays/__tests__/Modals.test.tsx
@@ -6,7 +6,7 @@ import { Button } from '../../buttons';
 import { Modals } from '@epam/uui-components';
 import { PickerInput } from '../../pickers';
 
-function TestElement(props?: ModalBlockerProps) {
+function TestElement(props: ModalBlockerProps) {
     return (
         <ModalBlocker { ...props }>
             <ModalWindow>

--- a/uui/components/overlays/__tests__/Modals.test.tsx
+++ b/uui/components/overlays/__tests__/Modals.test.tsx
@@ -1,9 +1,10 @@
-import React from 'react';
+import React, { ReactNode, useState } from 'react';
 import { ModalBlocker, ModalHeader, ModalFooter, ModalWindow } from '../Modals';
-import { fireEvent, renderSnapshotWithContextAsync, screen, setupComponentForTest } from '@epam/uui-test-utils';
-import { IModal, ModalBlockerProps, useUuiContext } from '@epam/uui-core';
+import { fireEvent, getDefaultUUiContextWrapper, renderSnapshotWithContextAsync, renderWithContextAsync, screen, setupComponentForTest } from '@epam/uui-test-utils';
+import { IModal, ModalBlockerProps, useArrayDataSource, useUuiContext } from '@epam/uui-core';
 import { Button } from '../../buttons';
 import { Modals } from '@epam/uui-components';
+import { PickerInput } from '../../pickers';
 
 function TestElement(props?: ModalBlockerProps) {
     return (
@@ -163,6 +164,156 @@ describe('Modals', () => {
         document.dispatchEvent(escEvent);
 
         expect(screen.getByText('Test content')).toBeInTheDocument();
+    });
+
+    it('should properly handle closing picker input\'s options and modal window on \'Escape\' key presses', async () => {
+        const successMock = jest.fn();
+        const abortMock = jest.fn();
+        const { wrapper, testUuiCtx } = getDefaultUUiContextWrapper();
+
+        function ModalWindowWithPickerInput(
+            props: IModal<undefined>,
+        ) {
+            interface Option {
+                id: string;
+                name: string;
+            }
+
+            const [
+                option,
+                setOption,
+            ] = useState<Option | undefined>(undefined);
+
+            const dataSource = useArrayDataSource<
+            Option,
+            Option['id'] | undefined,
+            unknown
+            >(
+                {
+                    items: [
+                        {
+                            id: 'option-1',
+                            name: 'Option 1',
+                        },
+                        {
+                            id: 'option-2',
+                            name: 'Option 2',
+                        },
+                    ],
+                },
+                [],
+            );
+
+            return (
+                <ModalBlocker
+                    { ...props }
+                >
+                    <ModalWindow>
+                        <PickerInput
+                            dataSource={ dataSource }
+                            value={ option }
+                            onValueChange={ setOption }
+                            selectionMode="single"
+                            valueType="entity"
+                        />
+                    </ModalWindow>
+                </ModalBlocker>
+            );
+        }
+
+        function TestComponent(): ReactNode {
+            const handleOpenModalWindow = async (): Promise<void> => {
+                try {
+                    await testUuiCtx.uuiModals.show((
+                        modalWindowProps,
+                    ) => {
+                        return (
+                            <ModalWindowWithPickerInput
+                                { ...modalWindowProps }
+                                success={ successMock.mockImplementation(modalWindowProps.success) }
+                                abort={ abortMock.mockImplementation(modalWindowProps.abort) }
+                            />
+                        );
+                    });
+                } catch {}
+            };
+
+            return (
+                <>
+                    <Button
+                        caption="Open modal window"
+                        onClick={ handleOpenModalWindow }
+                    />
+                    <Modals />
+                </>
+            );
+        }
+
+        await renderWithContextAsync(
+            <TestComponent />,
+            {
+                wrapper,
+            },
+        );
+
+        const openModalWindowButton = await screen.findByRole(
+            'button',
+            {
+                name: /open modal window/i,
+            },
+        );
+        fireEvent.click(openModalWindowButton);
+        const pickerInput = await screen.findByRole('searchbox');
+        expect(pickerInput).toBeInTheDocument();
+
+        fireEvent.click(pickerInput);
+        // Checking that picker input's body is opened.
+        expect(
+            await screen.findByRole(
+                'option',
+                {
+                    name: /option 1/i,
+                },
+            ),
+        ).toBeVisible();
+
+        // First 'Escape' key press should close the picker input's options.
+        fireEvent.keyDown(
+            pickerInput,
+            {
+                key: 'Escape',
+            },
+        );
+        // Checking that picker input's body is closed.
+        expect(
+            screen.queryByRole(
+                'option',
+                {
+                    name: /option 1/i,
+                },
+            ),
+        ).not.toBeInTheDocument();
+        expect(pickerInput).toBeInTheDocument();
+        expect(successMock).not.toBeCalled();
+        expect(abortMock).not.toBeCalled();
+
+        // Second 'Escape' key press should close the modal window.
+        fireEvent.keyDown(
+            /*
+                In implementation, after the first 'Escape' key press
+                focus is set back to the picker input element,
+                which is why the event is fired on this element.
+            */
+            pickerInput,
+            {
+                key: 'Escape',
+            },
+        );
+        expect(
+            screen.queryByRole('searchbox'),
+        ).not.toBeInTheDocument();
+        expect(successMock).not.toBeCalled();
+        expect(abortMock).toBeCalled();
     });
 
     // TODO: create test for 'disableCloseOnRouterChange' when our 'setupComponentForTest' be able listen routes


### PR DESCRIPTION
### Description

After discussing the results of the [investigation](https://github.com/epam/UUI/issues/2604#issuecomment-2865279088) with @AlekseyManetov, it was decided to use `event.stopPropagation()` to prevent the event's bubbling up to the modal window.

The following changes were made:

* Stop "Escape" key press event propagation in Picker Input component when its body is opened
* Small code improvements in the touched files

#### Issue link
#2604

#### QA notes