### PR TITLE
[Site][DocsSidebar]: exclude tab-only items from search results and navigation

### DIFF
--- a/app/src/common/docs/DocsSidebar.tsx
+++ b/app/src/common/docs/DocsSidebar.tsx
@@ -44,12 +44,19 @@ export function DocsSidebar() {
         }
     };
 
+    const getSearchFields = (item: DocItem) => {
+        if (item.component) {
+            return [item.name, ...(item.tags || [])];
+        }
+        return [];
+    };
+
     return (
         <Sidebar<DocItem>
             value={ queryParamId }
             onValueChange={ onChange }
             items={ docsMenuStructure }
-            getSearchFields={ (i) => [i.name, ...(i.tags || [])] }
+            getSearchFields={ getSearchFields }
             getItemLink={ (row) =>
                 !row.isFoldable && {
                     pathname: '/documents',


### PR DESCRIPTION
<!-- **Before submitting your PR, ensure that you made the following:**

- Linked the issue(if exists)
- Lint and unit tests pass locally with my changes
- Changelog is updated or not needed
- Documentation is updated/provided or not needed
- Property explorer is updated/provided or not needed
- TSDoc comments for public interfaces is updated/provided or not needed 
 -->

### Description:
[Site][DocsSidebar]: exclude tab-only items from search results and navigation

#### Issue link:
#2850 

#### QA notes: 