### PR TITLE
feat: add CustomRowExample, updated VerticalTabButton overrides for 4px theme

### DIFF
--- a/app/src/data/propsOverride_4px.ts
+++ b/app/src/data/propsOverride_4px.ts
@@ -342,6 +342,19 @@ const propsOverride: TPropEditorTypeOverride = {
             },
         },
     },
+    '@epam/uui:VerticalTabButtonProps': {
+        size: {
+            editor: {
+                type: TPropEditorType.oneOf,
+                options: ['40', '48'],
+            },
+            comment: {
+                tags: {
+                    '@default': '40',
+                },
+            },
+        },
+    },
 };
 
 export default propsOverride;

--- a/app/src/data/settings_4px.tsx
+++ b/app/src/data/settings_4px.tsx
@@ -253,6 +253,15 @@ const settings_4px = {
             default: '40',
         },
     },
+    verticalTabButton: {
+        sizes: {
+            default: '40',
+            countIndicatorMap: {
+                40: '24',
+                48: '24',
+            },
+        },
+    },
 } as any;
 
 export default settings_4px;

--- a/app/src/docs/_examples/tree/Basic.example.tsx
+++ b/app/src/docs/_examples/tree/Basic.example.tsx
@@ -44,7 +44,7 @@ export default function BasicTreeExample() {
     });
 
     return (
-        <Panel background="surface-main" shadow rawProps={ { style: { width: '250px', height: '300px' } } }>
+        <Panel background="surface-main" shadow rawProps={ { style: { width: '250px', height: '300px', padding: '6px 0' } } }>
             <Tree<ExampleTreeItem>
                 view={ view }
                 size="36"

--- a/app/src/docs/_examples/tree/CustomRowExample.example.tsx
+++ b/app/src/docs/_examples/tree/CustomRowExample.example.tsx
@@ -1,0 +1,77 @@
+import React, { useState } from 'react';
+import { Panel, Tree, VerticalTabButton } from '@epam/uui';
+import { DataRowProps, DataSourceState, useArrayDataSource } from '@epam/uui-core';
+import { ReactComponent as FolderIcon } from '@epam/assets/icons/content-space-outline.svg';
+import { ReactComponent as FileIcon } from '@epam/assets/icons/content-page-outline.svg';
+
+interface ExampleTreeItem {
+    id: string;
+    name: string;
+    parentId?: string;
+    type: 'folder' | 'file';
+}
+
+const treeData: ExampleTreeItem[] = [
+    { id: '1', name: 'Documents', parentId: undefined, type: 'folder' },
+    { id: '2', name: 'Getting Started', parentId: '1', type: 'file' },
+    { id: '3', name: 'Components', parentId: '1', type: 'folder' },
+    { id: '4', name: 'Buttons', parentId: '3', type: 'file' },
+    { id: '5', name: 'Inputs', parentId: '3', type: 'file' },
+    { id: '6', name: 'Layout', parentId: '3', type: 'folder' },
+    { id: '7', name: 'Tree', parentId: '6', type: 'file' },
+    { id: '8', name: 'VirtualList', parentId: '6', type: 'file' },
+    { id: '9', name: 'Advanced', parentId: '1', type: 'folder' },
+    { id: '10', name: 'API Reference', parentId: '9', type: 'file' },
+];
+
+export default function CustomRowExample() {
+    const [value, setValue] = useState<DataSourceState>({
+        selectedId: '7',
+    });
+
+    const dataSource = useArrayDataSource<ExampleTreeItem, string, unknown>(
+        {
+            items: treeData,
+            getId: (item) => item.id,
+            isFoldedByDefault: () => false,
+        },
+        [treeData],
+    );
+
+    const view = dataSource.useView(value, setValue, {
+        getRowOptions: (item) => ({
+            isSelectable: item.type === 'file',
+            link: undefined, // No links in this example
+        }),
+        getSearchFields: (item) => [item.name],
+    });
+
+    const renderRow = (row: DataRowProps<ExampleTreeItem, string>) => {
+        return (
+            <VerticalTabButton
+                icon={ row.value.type === 'folder' ? FolderIcon : FileIcon }
+                caption={ row.value.name }
+                weight="regular"
+                onClick={ row.onSelect ? () => row.onSelect(row) : undefined }
+                onFold={ () => row.onFold(row) }
+                isFolded={ row.isFolded }
+                isFoldable={ row.isFoldable }
+                indent={ row.indent }
+                isActive={ row.isSelected }
+            />
+        );
+    };
+
+    return (
+        <Panel background="surface-main" shadow rawProps={ { style: { width: '250px', height: '300px', padding: '6px 0' } } }>
+            <Tree<ExampleTreeItem>
+                view={ view }
+                size="36"
+                value={ value }
+                onValueChange={ setValue }
+                getCaption={ (item) => item.name }
+                renderRow={ renderRow }
+            />
+        </Panel>
+    );
+}

--- a/app/src/docs/_examples/tree/SimpleNavigation.example.tsx
+++ b/app/src/docs/_examples/tree/SimpleNavigation.example.tsx
@@ -60,7 +60,7 @@ export default function SimpleNavigation() {
     }, []);
 
     return (
-        <Panel shadow>
+        <Panel shadow rawProps={ { style: { padding: '6px 0' } } }>
             {tasks.map((task) => (
                 <VerticalTabButton
                     key={ task.id }

--- a/app/src/docs/pages/components/tree.json
+++ b/app/src/docs/pages/components/tree.json
@@ -5,7 +5,8 @@
   "examples": [
     { "descriptionPath": "tree-descriptions" },
     { "name": "Basic Tree", "componentPath": "tree/Basic.example.tsx" },
-    { "name": "Simple Navigation", "componentPath": "tree/SimpleNavigation.example.tsx" }
+    { "name": "Simple Navigation", "componentPath": "tree/SimpleNavigation.example.tsx" },
+    { "name": "Custom Row", "componentPath": "tree/CustomRowExample.example.tsx", "descriptionPath": "tree-CustomRow" }
   ],
   "tags": ["tree", "virtualList", "dataSources"]
 }

--- a/app/src/docs/pages/components/verticalTabButton.json
+++ b/app/src/docs/pages/components/verticalTabButton.json
@@ -6,6 +6,7 @@
         { "descriptionPath": "vertical-tab-button-descriptions" },
         { "name": "Basic", "componentPath": "verticalTabButton/Basic.example.tsx" },
         { "name": "Basic Tree", "componentPath": "tree/Basic.example.tsx" },
-        { "name": "Simple Navigation", "componentPath": "tree/SimpleNavigation.example.tsx" }
+        { "name": "Simple Navigation", "componentPath": "tree/SimpleNavigation.example.tsx" },
+        { "name": "Custom Row", "componentPath": "tree/CustomRowExample.example.tsx" }
     ]
 }

--- a/public/docs/content/tree-CustomRowExample.json
+++ b/public/docs/content/tree-CustomRowExample.json
@@ -1,0 +1,101 @@
+[
+  {
+    "type": "paragraph",
+    "children": [
+      {
+        "text": "You can customize "
+      },
+      {
+        "type": "link",
+        "url": "/documents?id=tree&mode=doc&category=components",
+        "target": "_blank",
+        "children": [
+          {
+            "text": "Tree"
+          }
+        ]
+      },
+      {
+        "text": " row rendering by providing a "
+      },
+      {
+        "text": "renderRow",
+        "uui-richTextEditor-code": true
+      },
+      {
+        "text": " function."
+      }
+    ]
+  },
+  {
+    "type": "paragraph",
+    "children": [
+      {
+        "text": "This allows you to create custom row layouts with different icons, styling, and behavior while maintaining the "
+      },
+      {
+        "text": "Tree's",
+        "uui-richTextEditor-code": true
+      },
+      {
+        "text": " core functionality. The "
+      },
+      {
+        "text": "renderRow",
+        "uui-richTextEditor-code": true
+      },
+      {
+        "text": " function receives a "
+      },
+      {
+        "text": "DataRowProps",
+        "uui-richTextEditor-code": true
+      },
+      {
+        "text": " object with selection state, folding state, indentation level, and event handlers."
+      }
+    ]
+  },
+  {
+    "type": "note-link",
+    "children": [
+      {
+        "text": "Note: Use "
+      },
+      {
+        "type": "link",
+        "url": "/documents?id=verticalTabButton&mode=doc&category=components",
+        "target": "_blank",
+        "children": [
+          {
+            "text": "VerticalTabButton"
+          }
+        ]
+      },
+      {
+        "text": " as the base component for custom rows since it provides built-in folding functionality and proper event handling. The example below demonstrates how to render different "
+      },
+      {
+        "text": "icons",
+        "uui-richTextEditor-code": true
+      },
+      {
+        "text": " in "
+      },
+      {
+        "text": "VerticalTabButton",
+        "uui-richTextEditor-code": true
+      },
+      {
+        "text": " components based on item type (folders vs files), showing custom selection behavior and proper integration with "
+      },
+      {
+        "text": "Tree's",
+        "uui-richTextEditor-code": true
+      },
+      {
+        "text": " folding and selection system."
+      }
+    ]
+  }
+]

--- a/uui-docs/src/peContexts/VerticalTabButtonContext.tsx
+++ b/uui-docs/src/peContexts/VerticalTabButtonContext.tsx
@@ -20,7 +20,7 @@ export class VerticalTabButtonContext extends React.Component<DemoComponentProps
     render() {
         const { DemoComponent, props } = this.props;
         return (
-            <Panel background="surface-main" margin="24">
+            <Panel background="surface-main" margin="24" rawProps={ { style: { padding: '6px 0' } } }>
                 <FlexRow>
                     <FlexCell grow={ 1 }>
                         <DemoComponent


### PR DESCRIPTION
<!-- **Before submitting your PR, ensure that you made the following:**

- Linked the issue(if exists)
- Lint and unit tests pass locally with my changes
- Changelog is updated or not needed
- Documentation is updated/provided or not needed
- Property explorer is updated/provided or not needed
- TSDoc comments for public interfaces is updated/provided or not needed 
 -->

### Description:
Added CustomRowExample, updated VerticalTabButton overrides for 4px theme

#### Issue link:
#2865, #2853 

#### QA notes: 