### PR TITLE
[Async/Array dataSources] Fix `patch`ed items visible with applied filters

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -13,6 +13,7 @@
 * [useForm]: improved router block removal on discard and custom beforeLeave for close action. Rework useLock to unblock router immediately, rather than on next render
 * [Modals]: fixed incorrect order of abort() calls when pressing ESC with nested modals — now only the topmost modal responds to ESC key
 * [Text]: changed `fontSize` and `lineHeight` props typings from strict string literal to more common `number | string` type, to support varied customization cases
+* [Async/Array dataSources]: fixed issue when `patch`ed items visible with applied filters ([#2914](https://github.com/epam/UUI/issues/2914))
 
 # 6.2.0 - 05.08.2025
 **What's New**

--- a/uui-core/src/data/processing/views/tree/hooks/common/usePatchTree.ts
+++ b/uui-core/src/data/processing/views/tree/hooks/common/usePatchTree.ts
@@ -9,7 +9,8 @@ import { TreeState } from '../../treeState';
 export interface UsePatchTreeProps<TItem, TId, TFilter = any> extends PatchOptions<TItem, TId> {
     tree: TreeState<TItem, TId>;
     sorting: DataSourceState<TFilter, TId>['sorting'];
-
+    filter?: TFilter;
+    getFilter?: (filter: TFilter) => (item: TItem) => boolean
 }
 
 export function usePatchTree<TItem, TId, TFilter = any>(
@@ -22,6 +23,8 @@ export function usePatchTree<TItem, TId, TFilter = any>(
         isDeleted,
         sorting,
         sortBy,
+        filter,
+        getFilter,
     }: UsePatchTreeProps<TItem, TId, TFilter>,
 ) {
     const prevPatch = usePrevious(patch);
@@ -53,9 +56,11 @@ export function usePatchTree<TItem, TId, TFilter = any>(
             isDeleted,
             sorting,
             sortBy,
+            filter,
+            getFilter,
             ...tree.visible.getParams(),
         });
-    }, [tree, patch]);
+    }, [tree, filter, patch]);
 
     const applyPatch = useCallback((updated: IMap<TId, TItem> | IImmutableMap<TId, TItem>) => {
         const patchAfterSort = getSortedPatchByParentId(

--- a/uui-core/src/data/processing/views/tree/hooks/strategies/asyncTree/useAsyncTree.ts
+++ b/uui-core/src/data/processing/views/tree/hooks/strategies/asyncTree/useAsyncTree.ts
@@ -141,6 +141,8 @@ export function useAsyncTree<TItem, TId, TFilter = any>(
         fixItemBetweenSortings,
         sorting: dataSourceState.sorting,
         sortBy,
+        filter: dataSourceState.filter,
+        getFilter,
     });
 
     const totalCount = useMemo(() => {

--- a/uui-core/src/data/processing/views/tree/hooks/strategies/syncTree/useSyncTree.ts
+++ b/uui-core/src/data/processing/views/tree/hooks/strategies/syncTree/useSyncTree.ts
@@ -78,6 +78,8 @@ export function useSyncTree<TItem, TId, TFilter = any>(
         fixItemBetweenSortings,
         sorting: dataSourceState.sorting,
         sortBy,
+        filter: dataSourceState.filter,
+        getFilter,
     });
 
     const reload = useCallback(() => {

--- a/uui-core/src/data/processing/views/tree/treeState/TreeState.ts
+++ b/uui-core/src/data/processing/views/tree/treeState/TreeState.ts
@@ -165,10 +165,10 @@ export class TreeState<TItem, TId> {
         return this.withNewTreeStructures({ using: 'visible', treeStructure: newTreeStructure, itemsMap: this.itemsMap });
     }
 
-    private patchTreeStructure(
-        { treeStructure, itemsMap, sortedPatch, patchAtLastSort, getItemTemporaryOrder, isDeleted, sorting, sortBy }: PatchIntoTreeStructureOptions<TItem, TId>,
-    ) {
-        const { treeStructure: newTreeStructure, itemsMap: newItemsMap, newItems } = PatchHelper.patch<TItem, TId>({
+    private patchTreeStructure<TFilter>({
+        treeStructure, itemsMap, sortedPatch, patchAtLastSort, getItemTemporaryOrder, isDeleted, sorting, sortBy, filter, getFilter,
+    }: PatchIntoTreeStructureOptions<TItem, TId, TFilter>) {
+        const { treeStructure: newTreeStructure, itemsMap: newItemsMap, newItems } = PatchHelper.patch<TItem, TId, TFilter>({
             treeStructure,
             itemsMap: itemsMap,
             sortedPatch,
@@ -177,6 +177,8 @@ export class TreeState<TItem, TId> {
             isDeleted,
             sorting,
             sortBy,
+            filter,
+            getFilter,
         });
 
         if (newTreeStructure === treeStructure && newItemsMap === itemsMap && !newItems.length) {
@@ -186,8 +188,8 @@ export class TreeState<TItem, TId> {
         return { treeStructure: newTreeStructure, itemsMap: newItemsMap };
     }
 
-    public patch(
-        { sortedPatch, patchAtLastSort, getItemTemporaryOrder, isDeleted, sorting, sortBy }: ExtendedPatchOptions<TItem, TId>,
+    public patch<TFilter>(
+        { sortedPatch, patchAtLastSort, getItemTemporaryOrder, isDeleted, sorting, sortBy, filter, getFilter }: ExtendedPatchOptions<TItem, TId, TFilter>,
     ): TreeState<TItem, TId> {
         const { treeStructure: newFull } = this.patchTreeStructure({
             treeStructure: this.getTreeStructure('full'),
@@ -209,6 +211,8 @@ export class TreeState<TItem, TId> {
             isDeleted,
             sorting,
             sortBy,
+            filter,
+            getFilter,
         });
 
         if (this.getTreeStructure('full') === newFull && this.getTreeStructure('visible') === newVisible) {

--- a/uui-core/src/data/processing/views/tree/treeState/types.ts
+++ b/uui-core/src/data/processing/views/tree/treeState/types.ts
@@ -82,4 +82,6 @@ export interface ExtendedPatchOptions<TItem, TId, TFilter = any> extends SortCon
     sortedPatch?: SortedPatchByParentId<TItem, TId>,
     patchAtLastSort: IMap<TId, TItem> | IImmutableMap<TId, TItem>,
     sorting: DataSourceState<TFilter, TId>['sorting'];
+    filter?: DataSourceState<TFilter, TId>['filter'];
+    getFilter?: (filter: TFilter) => (item: TItem) => boolean
 }

--- a/uui-core/src/data/processing/views/tree/treeStructure/helpers/PatchHelper.ts
+++ b/uui-core/src/data/processing/views/tree/treeStructure/helpers/PatchHelper.ts
@@ -90,7 +90,7 @@ export class PatchHelper {
         );
     }
 
-    public static patch<TItem, TId>({
+    public static patch<TItem, TId, TFilter>({
         itemsMap: originalItemsMap,
         treeStructure,
         sortedPatch,
@@ -99,7 +99,9 @@ export class PatchHelper {
         isDeleted,
         sorting,
         sortBy,
-    }: PatchIntoTreeStructureOptions<TItem, TId>) {
+        filter,
+        getFilter,
+    }: PatchIntoTreeStructureOptions<TItem, TId, TFilter>) {
         if (!sortedPatch || !sortedPatch.size) return { treeStructure, itemsMap: originalItemsMap, newItems: [] };
 
         const newByParentId = cloneMap(treeStructure.byParentId); // shallow clone, still need to copy arrays inside!
@@ -117,7 +119,11 @@ export class PatchHelper {
             const itemIds = newByParentId.get(patchParentId) ?? [];
 
             // eslint-disable-next-line no-loop-func
-            const isDeletedFn = (id: TId) => isDeleted?.(patchedItemsMap.get(id)) ?? false;
+            const isDeletedFn = (id: TId) => {
+                if (isDeleted && isDeleted(patchedItemsMap.get(id)) === true) return true;
+                if (getFilter && getFilter(filter)(patchedItemsMap.get(id)) === false) return true;
+                return false;
+            };
 
             const [sortedItems, isUpdatedOnPatch] = this.applyPatchWithSorting(
                 sorted.updated,

--- a/uui-core/src/data/processing/views/tree/treeStructure/helpers/types.ts
+++ b/uui-core/src/data/processing/views/tree/treeStructure/helpers/types.ts
@@ -129,7 +129,7 @@ export interface SearchOptions<TItem, TId, TFilter> extends ApplySearchOptions<T
     tree: ITree<TItem, TId>;
 }
 
-export interface PatchIntoTreeStructureOptions<TItem, TId> extends Omit<ExtendedPatchOptions<TItem, TId>, 'getNewItemPosition'> {
+export interface PatchIntoTreeStructureOptions<TItem, TId, TFilter> extends Omit<ExtendedPatchOptions<TItem, TId, TFilter>, 'getNewItemPosition'> {
     treeStructure: TreeStructure<TItem, TId>;
     itemsMap: ItemsMap<TId, TItem>;
 }


### PR DESCRIPTION
### Description:

Forward `filter` and `getFilter` to `usePatchTree` internal calls for `visibleTree` calculations for async/array dataSources's

#### Issue link:

Closes #2914

#### QA notes:

`isDeleted` function name is no longer relevant. Should we rename it along the way?