### PR TITLE
[DatePicker]: enhance locale customization

### DIFF
--- a/app/src/docs/pages/components/datePicker.json
+++ b/app/src/docs/pages/components/datePicker.json
@@ -9,6 +9,7 @@
         { "name": "Render footer", "componentPath": "datePicker/Footer.example.tsx" },
         { "name": "Disable dates", "componentPath": "datePicker/Filter.example.tsx" },
         { "name": "Prevent from being empty", "componentPath": "datePicker/PreventEmpty.example.tsx" },
-        { "name": "Customize day render", "componentPath": "datePicker/CustomRenderDay.example.tsx" }
+        { "name": "Customize day render", "componentPath": "datePicker/CustomRenderDay.example.tsx" },
+        { "name": "Locale override", "descriptionPath": "datePicker-local-override" }
     ]
 }

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,8 @@
+# 6.?.? - ??.??.2025
+
+**What's Fixed**
+* [Calendar]: fixed calendar matrix calculation to use locale-specific `firstDayOfWeek` from dayjs instead of hardcoded i18n configuration, ensuring correct calendar layout for any locale.
+
 # 6.3.0 - 26.09.2025
 
 **What's New**

--- a/public/docs/content/datePicker-local-override.json
+++ b/public/docs/content/datePicker-local-override.json
@@ -1,0 +1,85 @@
+[
+  {
+    "type": "paragraph",
+    "children": [
+      {
+        "text": "DatePicker",
+        "uui-richTextEditor-code": true
+      },
+      {
+        "text": " supports locale customization. This is useful for international applications that need to support different regional settings."
+      }
+    ]
+  },
+  {
+    "type": "paragraph",
+    "children": [
+      {
+        "text": "To override locale settings in your application:"
+      }
+    ]
+  },
+  {
+    "type": "ordered-list",
+    "children": [
+      {
+        "type": "list-item",
+        "children": [
+          {
+            "type": "list-item-child",
+            "children": [
+              {
+                "text": "Import the required dayjs locales:",
+                "uui-richTextEditor-bold": true
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "note-quote",
+    "children": [
+      {
+        "text": "import 'dayjs/locale/de'; // German locale\n"
+      },
+      {
+        "text": "import 'dayjs/locale/ar'; // Arabic locale\nimport 'dayjs/locale/fr'; // French locale",
+        "color": "rgb(48, 50, 64)"
+      }
+    ]
+  },
+  {
+    "type": "paragraph",
+    "children": [
+      {
+        "text": "2. "
+      },
+      {
+        "text": "Reset i18n configuration and set locale using uuiDayjs:",
+        "uui-richTextEditor-bold": true
+      }
+    ]
+  },
+  {
+    "type": "note-quote",
+    "children": [
+      {
+        "text": "import { i18n, uuiDayjs } from '@epam/uui-components';\n\n// Reset datePicker configuration\ni18n.datePicker = {};\n\n// Set German locale\nuuiDayjs.dayjs.locale('de');\n\n// Optionally override first day of week (0=Sunday, 1=Monday, 6=Saturday)\n"
+      },
+      {
+        "text": "uuiDayjs.dayjs.updateLocale('de', { weekStart: 1 }); // Monday first",
+        "color": "rgb(48, 50, 64)"
+      }
+    ]
+  },
+  {
+    "type": "note-warning",
+    "children": [
+      {
+        "text": "**Note:** Locale changes affect the entire application globally. Consider the impact on other date components when changing locale settings."
+      }
+    ]
+  }
+]

--- a/uui-components/src/helpers/dayJsHelper.ts
+++ b/uui-components/src/helpers/dayJsHelper.ts
@@ -25,18 +25,16 @@ function TREE_SHAKEABLE_INIT() {
                 extended = true;
             }
 
-            if (dayjs.locale() !== i18n.datePicker.locale) {
+            if (i18n.datePicker.locale && dayjs.locale() !== i18n.datePicker.locale) {
                 dayjs.locale(i18n.datePicker.locale);
             }
 
             /**
-             * Currently, locales which starts from Sunday used.
-             * That is why it's safe to set weekStart: 1 for all locales to start for Monday
+             * Update locale settings if provided at the library level.
+             * This allows customizing weekStart and other locale-specific settings.
              */
-            if (dayjs.localeData().firstDayOfWeek() !== 1) {
-                dayjs.updateLocale(i18n.datePicker.locale, {
-                    weekStart: 1,
-                });
+            if (i18n.datePicker.localeUpdate) {
+                dayjs.updateLocale(i18n.datePicker.locale, i18n.datePicker.localeUpdate);
             }
 
             return dayjs;

--- a/uui-components/src/i18n.tsx
+++ b/uui-components/src/i18n.tsx
@@ -4,7 +4,8 @@ export const i18n = {
     },
     datePicker: {
         locale: 'en',
-    },
+        localeUpdate: { weekStart: 1 },
+    } as { locale?: string; localeUpdate?: Record<string, unknown> },
     pickerList: {
         rowsSelected: (rows: number) => ` (${rows} selected)`,
         showAll: 'SHOW ALL',

--- a/uui-components/src/inputs/DatePicker/MonthSelection.tsx
+++ b/uui-components/src/inputs/DatePicker/MonthSelection.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { uuiDayjs } from '../../helpers/dayJsHelper';
-import type { Dayjs } from '../../helpers/dayJsHelper';
+import { uuiDayjs, type Dayjs } from '../../helpers';
 import { IEditable, IHasCX, arrayToMatrix, cx, IHasRawProps, IHasForwardedRef } from '@epam/uui-core';
 
 import css from './MonthSelection.module.scss';


### PR DESCRIPTION
<!-- **Before submitting your PR, ensure that you made the following:**

- Linked the issue(if exists)
- Lint and unit tests pass locally with my changes
- Changelog is updated or not needed
- Documentation is updated/provided or not needed
- Property explorer is updated/provided or not needed
- TSDoc comments for public interfaces is updated/provided or not needed 
 -->

### Description:
* [Calendar]: fixed calendar matrix calculation to use locale-specific `firstDayOfWeek` from dayjs instead of hardcoded i18n configuration, ensuring correct calendar layout for any locale.

#### Issue link:

#### QA notes: 