### PR TITLE
[DataTable]: fix virtualization height calculation in tables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,5 @@ public/docs/docsGenOutput/docsGenStats.json
 
 #icon source
 /icons-source/
+
+.kiro

--- a/uui/components/tables/DataRowsContainer/DataRowsContainer.module.scss
+++ b/uui/components/tables/DataRowsContainer/DataRowsContainer.module.scss
@@ -1,6 +1,8 @@
 .listContainer {
     margin-top: 1px;
     isolation: isolate;
+    display: grid;
+    grid-template-rows: 1fr;
 }
 
 .header {

--- a/uui/components/tables/DataRowsContainer/DataRowsContainer.tsx
+++ b/uui/components/tables/DataRowsContainer/DataRowsContainer.tsx
@@ -12,7 +12,7 @@ export interface DataRowsContainerProps<TItem, TId, List extends HTMLDivElement 
     headerRef?: React.MutableRefObject<HTMLDivElement>;
 }
 
-export function DataRowsContainer<TItem, TId, List extends HTMLDivElement = any>({ 
+export function DataRowsContainer<TItem, TId, List extends HTMLDivElement = any>({
     estimatedHeight, listContainerRef, offsetY, rows, renderRow, headerRef,
 }: DataRowsContainerProps<TItem, TId, List>) {
     return (


### PR DESCRIPTION
<!-- **Before submitting your PR, ensure that you made the following:**

- Linked the issue(if exists)
- Lint and unit tests pass locally with my changes
- Changelog is updated or not needed
- Documentation is updated/provided or not needed
- Property explorer is updated/provided or not needed
- TSDoc comments for public interfaces is updated/provided or not needed 
 -->

### Description:
Fixed CSS grid layout that was breaking virtualization math, causing 
incorrect container heights, excess empty space and infinite loops in tables.

#### Issue link:
- #2939 

#### QA notes: 