### PR TITLE
[RangeDatePickerInput]: use selected date value instead of input value

### DIFF
--- a/uui/components/datePickers/RangeDatePickerInput.tsx
+++ b/uui/components/datePickers/RangeDatePickerInput.tsx
@@ -150,7 +150,7 @@ export const RangeDatePickerInput = forwardRef<HTMLDivElement, RangeDatePickerIn
 
     const clearAllowed = !disableClear && !isReadonly && !isDisabled
         && !(preventEmptyFromDate && preventEmptyToDate)
-        && ((inputValue.from && !preventEmptyFromDate) || (inputValue.to && !preventEmptyToDate));
+        && ((value.from && !preventEmptyFromDate) || (value.to && !preventEmptyToDate));
 
     return (
         // eslint-disable-next-line jsx-a11y/no-static-element-interactions


### PR DESCRIPTION
<!-- **Before submitting your PR, ensure that you made the following:**

- Linked the issue(if exists)
- Lint and unit tests pass locally with my changes
- Changelog is updated or not needed
- Documentation is updated/provided or not needed
- Property explorer is updated/provided or not needed
- TSDoc comments for public interfaces is updated/provided or not needed 
 -->

### Description:
Fixed use selected date instead of input value

#### Issue link:
https://github.com/epam/UUI/issues/2880

#### QA notes: 