### PR TITLE
[dropdown] added option to control dropdown positioning behavior

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -17,7 +17,7 @@
     * Add `aria-haspopup="menu"` to the "More" button
     * Add `role="menu"` to the container wrapping the list of items
     * Provide an example in the documentation of how to assign `role="menuitem"` to the items only when they are present in the menu
-* [Dropdown]: added `pinToToggler` prop to control dropdown positioning. When set to `true`, the dropdown stays pinned to the toggler and follows its position. When set to `false`, the dropdown remains static at its initial position after opening. Default is `true`.
+* [Dropdown]: added `fixedBodyPosition` prop to control dropdown positioning. Pass `true` to keep the dropdown list fixed in the position where it was first opened.
 
 # 6.3.1 - 08.10.2025
 

--- a/uui-components/src/overlays/Dropdown.tsx
+++ b/uui-components/src/overlays/Dropdown.tsx
@@ -33,13 +33,13 @@ function DropdownComponent(props: DropdownProps, ref: React.ForwardedRef<HTMLEle
         middleware,
         boundaryElement,
         closeOnEscape = true,
-        pinToToggler = true,
+        fixedBodyPosition = false,
     } = props;
 
     const uuiContext = useContext(UuiContext);
 
     const [uncontrolledOpen, setUncontrolledOpen] = useState(false);
-    const fixedPositionRef = useRef<{ x: number, y: number } | null>(null);
+    const initialBodyPosition = useRef<{ x: number, y: number } | null>(null);
 
     const open = controlledOpen ?? uncontrolledOpen;
     const setOpen = setControlledOpen ?? setUncontrolledOpen;
@@ -437,17 +437,17 @@ function DropdownComponent(props: DropdownProps, ref: React.ForwardedRef<HTMLEle
 
     useEffect(() => {
         if (!open) {
-            fixedPositionRef.current = null;
+            initialBodyPosition.current = null;
         }
     }, [open]);
 
     useEffect(() => {
-        if (!pinToToggler) {
-            if (open && fixedPositionRef.current == null && x && y) {
-                fixedPositionRef.current = { x, y };
+        if (fixedBodyPosition) {
+            if (open && initialBodyPosition.current == null && x && y) {
+                initialBodyPosition.current = { x, y };
             }
         }
-    }, [open, x, y, fixedPositionRef, pinToToggler]);
+    }, [open, x, y, initialBodyPosition, fixedBodyPosition]);
 
     return (
         <>
@@ -463,8 +463,8 @@ function DropdownComponent(props: DropdownProps, ref: React.ForwardedRef<HTMLEle
                             onKeyDown={ floating?.onKeyDown }
                             style={ {
                                 position: strategy,
-                                top: (!pinToToggler && fixedPositionRef.current != null) ? fixedPositionRef.current.y : (y ?? 0),
-                                left: (!pinToToggler && fixedPositionRef.current != null) ? fixedPositionRef.current.x : (x ?? 0),
+                                top: (fixedBodyPosition && initialBodyPosition.current != null) ? initialBodyPosition.current.y : (y ?? 0),
+                                left: (fixedBodyPosition && initialBodyPosition.current != null) ? initialBodyPosition.current.x : (x ?? 0),
                                 zIndex: zIndex != null ? zIndex : layerRef.current?.zIndex,
                             } }
                             data-placement={ finalPlacement }

--- a/uui-components/src/overlays/__tests__/Dropdown.test.tsx
+++ b/uui-components/src/overlays/__tests__/Dropdown.test.tsx
@@ -372,9 +372,9 @@ describe('Dropdown', () => {
         });
     });
 
-    describe('pinToToggler', () => {
-        it('should follow the toggler when pinToToggler is true (default)', async () => {
-            const { target } = await setupUncontrolledDropdownForTests({ pinToToggler: true });
+    describe('fixedBodyPosition', () => {
+        it('should follow the toggler by default', async () => {
+            const { target } = await setupUncontrolledDropdownForTests({});
             await userEvent.click(target);
             const dialog = screen.getByRole('dialog');
 
@@ -393,8 +393,8 @@ describe('Dropdown', () => {
             expect(target.getBoundingClientRect()).toMatchObject(movedRect);
         });
 
-        it('should stay at the same position when pinToToggler is false', async () => {
-            const { target } = await setupUncontrolledDropdownForTests({ pinToToggler: false });
+        it('should stay at the same position when fixedBodyPosition is true', async () => {
+            const { target } = await setupUncontrolledDropdownForTests({ fixedBodyPosition: true });
             await userEvent.click(target);
             const dialog = screen.getByRole('dialog');
 

--- a/uui-core/src/types/components/Dropdown.ts
+++ b/uui-core/src/types/components/Dropdown.ts
@@ -84,8 +84,8 @@ export interface DropdownProps extends Partial<IControlled<boolean>> {
      * */
     closeOnEscape?: boolean;
     /**
-     * If true, dropdown will always follow the toggler (pinned). If false, dropdown will stay at the position where it was first opened (static).
-     * @default true
+     * Pass true, if you want to keep the dropdown list fixed in the position where it was first opened.
+     * By default, the dropdown list follows the toggler.
      */
-    pinToToggler?: boolean;
+    fixedBodyPosition?: boolean;
 }


### PR DESCRIPTION
<!-- **Before submitting your PR, ensure that you made the following:**

- Linked the issue(if exists)
- Lint and unit tests pass locally with my changes
- Changelog is updated or not needed
- Documentation is updated/provided or not needed
- Property explorer is updated/provided or not needed
- TSDoc comments for public interfaces is updated/provided or not needed 
 -->

### Description:
[Dropdown]: add pinToToggler prop to control dropdown positioning relative to the toggler

#### Issue link:
https://github.com/epam/UUI/issues/2945

#### QA notes: 
[Dropdown]: added `pinToToggler` prop to control dropdown positioning. 
When set to `true`, the dropdown stays pinned to the toggler and follows its position. 
When set to `false`, the dropdown remains static at its initial position after opening. 
Default is `true`.