### PR TITLE
[Basic.example]: adjust padding and font weight for Contacts section

### DIFF
--- a/app/src/docs/_examples/dropdown/Basic.example.tsx
+++ b/app/src/docs/_examples/dropdown/Basic.example.tsx
@@ -84,10 +84,10 @@ export default function BasicDropdownExample() {
 
                 <div className={ css.divider }></div>
 
-                <FlexRow padding="12" vPadding="24">
+                <FlexRow padding="12" vPadding="18">
                     <Panel background="surface-main">
-                        <FlexRow padding="6">
-                            <Text cx={ css.text } lineHeight="18" fontSize="12" color="secondary" fontWeight="600">
+                        <FlexRow size="24">
+                            <Text cx={ css.text } lineHeight="18" fontSize="12" color="secondary" fontWeight="700">
                                 Contacts
                             </Text>
                         </FlexRow>


### PR DESCRIPTION
[Basic.example]: adjust padding and font weight for Contacts section in User details dropdown




<!-- **Before submitting your PR, ensure that you made the following:**

- Linked the issue(if exists)
- Lint and unit tests pass locally with my changes
- Changelog is updated or not needed
- Documentation is updated/provided or not needed
- Property explorer is updated/provided or not needed
- TSDoc comments for public interfaces is updated/provided or not needed 
 -->

### Description:
fix font-weight and paddings 

<img width="534" height="595" alt="Screenshot 2025-11-25 105448" src="https://github.com/user-attachments/assets/ff9ea494-1568-41dc-a4d4-10aa48ba67ac" />

#### Issue link:
https://github.com/epam/UUI/issues/2877
#### QA notes: 