### PR TITLE
fix: [TimePicker]: fix an unnecessary side effect for onValueChange i…

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,7 +5,7 @@
 **What's Fixed**
 * [RangeDatePicker]: clicking on a disabled date clears the input
 * [DataTable, FiltersPanel]: fixed issue when not possible to type 0-based value (ie 0, 0.12, 0.8, etc) at empty in-range filter
-
+* [TimePicker]: fixed an unnecessary side effect for onValueChange if the Dropdown was closed with a default state.
 
 # 6.4.1 - 29.12.2025
 

--- a/uui/components/inputs/__tests__/TimePicker.test.tsx
+++ b/uui/components/inputs/__tests__/TimePicker.test.tsx
@@ -153,6 +153,18 @@ describe('TimePicker', () => {
         expect(mocks.onValueChange).toHaveBeenCalledWith(null);
     });
 
+    it('should not change null value to object with null properties on blur', async () => {
+        const { dom, mocks } = await setupTestComponent({ value: null });
+        expect(dom.input.value).toEqual('');
+
+        fireEvent.focus(dom.input);
+        fireEvent.blur(dom.input);
+
+        expect(mocks.onValueChange).toHaveBeenCalledWith(null);
+        expect(mocks.onValueChange).not.toHaveBeenCalledWith({ hours: null, minutes: null });
+        expect(dom.input.value).toEqual('');
+    });
+
     it('should increase and decrease hours when icon-button-up/down is clicked', async () => {
         const { dom } = await setupTestComponent({ value: { hours: 18, minutes: 23 } });
         expect(dom.input.value).toEqual('06:23 PM');

--- a/uui/components/inputs/timePicker/TimePicker.tsx
+++ b/uui/components/inputs/timePicker/TimePicker.tsx
@@ -104,7 +104,7 @@ export function TimePickerComponent(props: TimePickerProps, ref: React.Forwarded
     const handleBlur = (e: React.FocusEvent<HTMLInputElement>) => {
         props.onBlur?.(e);
 
-        if (state.value === '' || state.inputValue === '') {
+        if (state.value === '' || state.inputValue === '' || state.value === null) {
             props.onValueChange(null);
             setState((prevState) => ({ ...prevState, value: null, inputValue: null }));
         } else {


### PR DESCRIPTION
### Description: 
[TimePicker] fixed an unnecessary side effect for onValueChange if the Dropdown was closed with a default state.


#### Issue link: [link](https://github.com/epam/UUI/issues/3015)

#### QA notes: 