### PR TITLE
fix: [SliderRating] unexpected NA values

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,9 +6,10 @@
 * [RangeDatePicker]: clicking on a disabled date clears the input
 * [DataTable, FiltersPanel]: fixed issue when not possible to type 0-based value (ie 0, 0.12, 0.8, etc) at empty in-range filter
 * [TimePicker]: fixed an unnecessary side effect for onValueChange if the Dropdown was closed with a default state.
-* [ScrollBars]: added `elementEvents` property. 
+* [ScrollBars]: added `elementEvents` property.
   The given Event(s) from the elements with the given selector(s) will trigger an update.
   Useful for cases where OverlayScrollbars' default logic does not detect changes, such as shadow DOM size changes.
+* [SliderRating]: fixed issue where clicking before slider start could set '0' value, bypassing 'n/a' button restriction when `withoutNa` prop is true
 
 # 6.4.1 - 29.12.2025
 

--- a/loveship/components/inputs/SliderRating.tsx
+++ b/loveship/components/inputs/SliderRating.tsx
@@ -154,6 +154,13 @@ export class SliderRating extends React.Component<SliderRatingProps<number>> {
         }
     }
 
+    handleValueChange = (value: number) => {
+        if (this.props.withoutNa && value === 0) {
+            return;
+        }
+        this.props.onValueChange(value);
+    };
+
     render() {
         return (
             <div className={ css.container } { ...this.props.rawProps }>
@@ -164,6 +171,7 @@ export class SliderRating extends React.Component<SliderRatingProps<number>> {
                     renderRating={ this.renderRating }
                     { ...this.props }
                     value={ this.props.value === 0 ? null : this.props.value }
+                    onValueChange={ this.handleValueChange }
                     cx={ css.baseRatingContainer }
                 />
                 {!this.props.withoutNa && <div className={ css.naIconContainer }>{this.renderNa()}</div>}

--- a/uui-components/src/inputs/Rating/BaseRating.tsx
+++ b/uui-components/src/inputs/Rating/BaseRating.tsx
@@ -85,8 +85,8 @@ export class BaseRating extends React.Component<BaseRatingProps<number>, BaseRat
 
     getRatingFromWidth(width: number): number {
         const step = this.props.step || 1;
-
-        return step * Math.ceil(width / this.getMarkWidth()) + (this.props.from - step);
+        const calculatedRating = step * Math.ceil(width / this.getMarkWidth()) + (this.props.from - step);
+        return Math.max(calculatedRating, this.props.from);
     }
 
     onPointerMove(e: React.PointerEvent<HTMLDivElement>) {
@@ -130,12 +130,18 @@ export class BaseRating extends React.Component<BaseRatingProps<number>, BaseRat
 
     onPointerUp(e: React.PointerEvent<HTMLDivElement>) {
         const width = e.pageX - this.getContainerOffsetLeft();
+        if (width < 0) {
+            return;
+        }
         this.props.onValueChange(this.checkRating(this.getRatingFromWidth(width)));
     }
 
     onTouchEnd(e: React.TouchEvent<HTMLDivElement>) {
         const touch = e.changedTouches[0];
         const width = touch.pageX - this.getContainerOffsetLeft();
+        if (width < 0) {
+            return;
+        }
         this.props.onValueChange(this.checkRating(this.getRatingFromWidth(width)));
     }
 


### PR DESCRIPTION
### Description:

Fixes issue where clicking before the slider start could set the value to 0,
bypassing the 'n/a' button restriction when `withoutNa` prop is set to true.

Changes:
- Added validation in BaseRating to ignore clicks before slider start (width < 0)
- Added safeguard in getRatingFromWidth to ensure values never go below 'from'
- Added handleValueChange wrapper in SliderRating to prevent 0 value when withoutNa is true

#### Issue link:
https://github.com/epam/UUI/issues/2768