### PR TITLE
fix: [DatePicker] prevent redundant DatePicker value updates onBlur

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -11,6 +11,8 @@
   The given Event(s) from the elements with the given selector(s) will trigger an update.
   Useful for cases where OverlayScrollbars' default logic does not detect changes, such as shadow DOM size changes.
 * [SliderRating]: fixed issue where clicking before slider start could set '0' value, bypassing 'n/a' button restriction when `withoutNa` prop is true
+* [Date Picker]: prevent redundant DatePicker value updates on blur which caused tab order cycling inside dropdowns
+
 
 # 6.4.1 - 29.12.2025
 

--- a/uui/components/datePickers/DatePicker.tsx
+++ b/uui/components/datePickers/DatePicker.tsx
@@ -41,7 +41,9 @@ export function DatePickerComponent(props: DatePickerProps, ref: React.Forwarded
     }, [value, setInputValue]);
 
     const onValueChange = (newValue: string | null) => {
-        if (value !== newValue) {
+        const isValueChanged = (value || '') !== (newValue || '');
+
+        if (isValueChanged) {
             props.onValueChange(newValue);
 
             if (props.getValueChangeAnalyticsEvent) {
@@ -113,7 +115,7 @@ export function DatePickerComponent(props: DatePickerProps, ref: React.Forwarded
         );
     };
 
-    const renderBody = useMemo(() => (renderProps: DropdownBodyProps) => {
+    const renderBody = useMemo(() => function (renderProps: DropdownBodyProps) {
         return (
             <DropdownContainer { ...renderProps }>
                 <DatePickerBody

--- a/uui/components/datePickers/__tests__/DatePicker.test.tsx
+++ b/uui/components/datePickers/__tests__/DatePicker.test.tsx
@@ -309,6 +309,22 @@ describe('DatePicker', () => {
         expect(mocks.onValueChange).not.toHaveBeenCalledWith(null);
     });
 
+    it('should not fire onValueChange when value is "" and the same on blur', async () => {
+        const {
+            dom, mocks, result,
+        } = await setupDatePicker({
+            value: '',
+        });
+        expect(dom.input.value).toEqual('');
+
+        await userEvent.type(dom.input, '2019-10-47');
+        expect(dom.input.value).toEqual('2019-10-47');
+
+        await userEvent.click(result.container);
+        expect(dom.input.value).toEqual('');
+        expect(mocks.onValueChange).not.toHaveBeenCalledWith(null);
+    });
+
     it('should fire onValuChange event clearing input manually', async () => {
         const {
             dom: { input }, mocks, result,


### PR DESCRIPTION
<!-- **Before submitting your PR, ensure that you made the following:**

- Linked the issue(if exists)
- Lint and unit tests pass locally with my changes
- Changelog is updated or not needed
- Documentation is updated/provided or not needed
- Property explorer is updated/provided or not needed
- TSDoc comments for public interfaces is updated/provided or not needed 
 -->

### Description:
**Case 1**: prevent redundant DatePicker value updates on blur, which caused tab order cycling inside dropdowns
**Case 2**: already fixed 

#### Issue link:
https://github.com/epam/UUI/issues/2951

#### QA notes: 