### PR TITLE
feat: [FiltersPanel] Add support of `min`/`max`/`step` props at `numeric` filter config

### DIFF
--- a/app/src/docs/_examples/tables/FiltersPanelBasic.example.tsx
+++ b/app/src/docs/_examples/tables/FiltersPanelBasic.example.tsx
@@ -147,6 +147,9 @@ export default function FiltersPanelExample() {
             title: 'Salary',
             type: 'numeric',
             predicates: defaultPredicates.numeric,
+            min: 100,
+            max: 1000,
+            step: 100,
         },
         {
             field: 'productionCategory',

--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,7 @@
 * [DropdownMenu]:
     * `IDropdownMenuItemProps` now extends `IHasRawProps`; use `rawProps` to pass any HTML attributes to the menu item element.
     * Menu arrow-key navigation now includes all roles starting with `menuitem` (e.g. `menuitem`, `menuitemradio`, `menuitemcheckbox`).
+* [FiltersPanel]: Added support `min`/`max`/`step` props at numeric filter config ([#3034](https://github.com/epam/UUI/issues/3034]))
 
 **What's Fixed**
 * [DropdownMenuSwitchButton]: prevent calling `onValueChange` multiple times on Switch click ([#3045](https://github.com/epam/UUI/issues/3045))

--- a/uui-components/src/inputs/NumericInput.tsx
+++ b/uui-components/src/inputs/NumericInput.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { IHasRawProps, cx, getCalculatedValue, IHasCX, IClickable, IDisableable, IEditable, IHasPlaceholder, Icon,
     uuiMod, uuiElement, CX, ICanBeReadonly, IAnalyticableOnChange, ICanFocus, uuiMarkers, getMinMaxValidatedValue,
-    getSeparatedValue, useUuiContext, i18n, preventDefaultIfTargetFocused,
+    getSeparatedValue, useUuiContext, i18n, preventDefaultIfTargetFocused, NumericInputCoreProps,
 } from '@epam/uui-core';
 import { IconContainer } from '../layout';
 import css from './NumericInput.module.scss';
@@ -15,30 +15,16 @@ export interface NumericInputProps
     IHasPlaceholder,
     ICanBeReadonly,
     IAnalyticableOnChange<number>,
-    IHasRawProps<React.HTMLAttributes<HTMLDivElement>> {
-    /** Maximum value (default is Number.MAX_SAFE_INTEGER) */
-    max?: number;
-
-    /**
-     * Minimum value (default is 0)
-     * @default 0
-     */
-    min?: number;
-
+    IHasRawProps<React.HTMLAttributes<HTMLDivElement>>,
+    NumericInputCoreProps {
     /** Overrides the up/increase icon */
     upIcon?: Icon;
 
     /** Overrides the down/decrease icon */
     downIcon?: Icon;
 
-    /** Increase/decrease step on up/down icons clicks and up/down arrow keys */
-    step?: number;
-
     /** CSS classes to put directly on the Input element */
     inputCx?: CX;
-
-    /** HTML ID */
-    id?: string;
 
     /** Turn off up/down (increase/decrease) buttons */
     disableArrows?: boolean;

--- a/uui-core/src/types/components/NumericInput.ts
+++ b/uui-core/src/types/components/NumericInput.ts
@@ -1,0 +1,16 @@
+export interface NumericInputCoreProps {
+    /** Maximum value (default is Number.MAX_SAFE_INTEGER) */
+    max?: number;
+
+    /**
+     * Minimum value (default is 0)
+     * @default 0
+     */
+    min?: number;
+
+    /** Increase/decrease step on up/down icons clicks and up/down arrow keys */
+    step?: number;
+
+    /** HTML ID */
+    id?: string;
+}

--- a/uui-core/src/types/components/index.ts
+++ b/uui-core/src/types/components/index.ts
@@ -6,3 +6,4 @@ export * from './LabeledInput';
 export * from './DatePickers';
 export * from './Tooltip';
 export * from './Dropdown';
+export * from './NumericInput';

--- a/uui-core/src/types/tables.ts
+++ b/uui-core/src/types/tables.ts
@@ -18,6 +18,7 @@ import {
     RangeDatePickerProps,
     RangeDatePickerValue,
     TooltipCoreProps,
+    NumericInputCoreProps,
 } from './components';
 import { IFilterItemBodyProps } from './components/filterItemBody';
 
@@ -479,7 +480,7 @@ export type RangeDatePickerFilterConfig<TFilter> = FilterConfigBase<TFilter> & P
     renderFooter?: (props: FilterRangeDatePickerBodyFooterProps) => React.ReactNode;
 };
 
-type NumericFilterConfig<TFilter> = FilterConfigBase<TFilter> & {
+type NumericFilterConfig<TFilter> = FilterConfigBase<TFilter> & Pick<NumericInputCoreProps, 'max' | 'min' | 'step'> & {
     /** Type of the filter */
     type: 'numeric';
 };

--- a/uui/components/filters/FilterNumericBody.tsx
+++ b/uui/components/filters/FilterNumericBody.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { DropdownBodyProps, isMobile } from '@epam/uui-core';
+import { DropdownBodyProps, isMobile, NumericInputCoreProps } from '@epam/uui-core';
 import { FlexSpacer } from '@epam/uui-components';
 import { NumericInput } from '../inputs';
 import { FlexCell, FlexRow } from '../layout';
@@ -20,7 +20,7 @@ interface INumericRangeValue {
     to: number | null;
 }
 
-interface IFilterNumericBodyProps extends DropdownBodyProps {
+interface IFilterNumericBodyProps extends DropdownBodyProps, NumericInputCoreProps {
     /**
      * Called when numeric body value needs to be changed
      */
@@ -35,7 +35,8 @@ interface IFilterNumericBodyProps extends DropdownBodyProps {
     selectedPredicate?: string;
 }
 
-export function FilterNumericBody(props: IFilterNumericBodyProps) {
+export function FilterNumericBody({ min, max, step, ...props }: IFilterNumericBodyProps) {
+    const numericInputProps = { min, max, step };
     const isInRangePredicate = props?.selectedPredicate === 'inRange' || props?.selectedPredicate === 'notInRange';
     const isWrongRange = (from: number | undefined, to: number | undefined) => {
         if (!to && to !== 0) return false;
@@ -109,6 +110,7 @@ export function FilterNumericBody(props: IFilterNumericBodyProps) {
                             onValueChange={ rangeValueHandler('from') }
                             placeholder="Min"
                             formatOptions={ { maximumFractionDigits: 2 } }
+                            { ...numericInputProps }
                         />
                     </FlexCell>
                     <FlexCell width="100%">
@@ -119,6 +121,7 @@ export function FilterNumericBody(props: IFilterNumericBodyProps) {
                             placeholder="Max"
                             formatOptions={ { maximumFractionDigits: 2 } }
                             isInvalid={ isWrongRange(value?.from, value?.to) }
+                            { ...numericInputProps }
                         />
                     </FlexCell>
                 </FlexRow>
@@ -142,6 +145,7 @@ export function FilterNumericBody(props: IFilterNumericBodyProps) {
                         onValueChange={ props.onValueChange }
                         placeholder="Enter a number"
                         formatOptions={ { maximumFractionDigits: 2 } }
+                        { ...numericInputProps }
                     />
                 </FlexCell>
             </FlexRow>


### PR DESCRIPTION
### Description:

Numeric filters in `FiltersPanel` can now be configured with `min`, `max`, and `step` via `NumericFilterConfig`, so range and single inputs respect the same constraints (e.g. salary 0–1M, step 1000).

* **Numeric filter config**
  * `NumericFilterConfig` extended with `min`, `max`, `step` (from `NumericInputCoreProps` in `uui-core`)
  * `FilterNumericBody` passes these props to all `NumericInput` instances (range and single)
* **Shared types**
  * `NumericInput`s `min`, `max`, `step`, `id` props moved into shared `NumericInputCoreProps` in `uui-core`
* **Docs**
  * Salary numeric filter in `FiltersPanelBasic` example updated to use `min`/`max`/`step`

#### Issue link: #3034

#### QA notes: 