### PR TITLE
[RTE] PlateElement/PlateLeaf rendering and todo/iframe migration alignment

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -19,6 +19,7 @@
     * [RangeDatePickerBody]: fixed separator direction in RTL.
     * [DataRowAddons]: fixed drag handle position in RTL.
     * [PickerToggler]: fixed search input text direction in RTL.
+* [RTE]: Todo list items migrate legacy `element.data.checked` to `element.checked`. Iframe nodes normalize `url` from `url` or legacy `data.src`.
 
 
 # 6.4.4 - 01.04.2026

--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,7 @@
 * [PresetsPanel]: custom `onCopyLink` is now invoked with `DataTableState` as declared, instead of receiving the click event
 * [DropdownContainer]: fixed `autoFocus` always being `true` even when `false` is passed through params
 * [RTE]: fixed incorrect floating toolbar position when in shadow DOM ([#3073](https://github.com/epam/UUI/issues/3073))
+    * floating toolbar now respects target element client rects (ie multiline selections)
 * [PresetsPanel]: fixed preset tab rendering nested `<button>` elements (preset actions `IconButton` inside the tab control), which caused invalid HTML and a React console warning.
 * Fixed multiple RTL layout issues across components ([#2548](https://github.com/epam/UUI/issues/2548)):
     * [Slider], [RangeSlider]: fixed RTL layout and interaction (track fill, handle, scale marks, pointer position, arrow keys).

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,7 @@
 
 **What's New**
 * [DropdownContainer]: added Shadow DOM support.
+* [RTE]: UUI block and mark components render through `PlateElement` / `PlateLeaf` (with `asChild` where a semantic tag is used) so custom Plate plugins that wrap nodes (e.g. `inject.aboveComponent`) compose correctly ([#3062](https://github.com/epam/UUI/issues/3062)).
 
 **What's Fixed**
 * [PickerModal]: fixed footer **Select all** staying available while searching — the control is now disabled until the search field is cleared.([#3083](https://github.com/epam/UUI/issues/3083))

--- a/uui-docs/src/demoData/slateInitialValue.ts
+++ b/uui-docs/src/demoData/slateInitialValue.ts
@@ -79,9 +79,7 @@ export const slateInitialValue = [
     },
     {
         type: 'toDoItem',
-        data: {
-            checked: false,
-        },
+        checked: true,
         children: [
             {
                 text: ' An item',

--- a/uui-editor/src/__tests__/__snapshots__/normalizers.test.ts.snap
+++ b/uui-editor/src/__tests__/__snapshots__/normalizers.test.ts.snap
@@ -73,15 +73,14 @@ Array [
     "type": "paragraph",
   },
   Object {
+    "checked": false,
     "children": Array [
       Object {
         "text": " An item",
         "uui-richTextEditor-span-mark": true,
       },
     ],
-    "data": Object {
-      "checked": false,
-    },
+    "data": Object {},
     "type": "toDoItem",
   },
   Object {
@@ -405,6 +404,17 @@ Array [
       "checked": false,
     },
     "type": "paragraph",
+  },
+  Object {
+    "children": Array [
+      Object {
+        "text": "",
+        "uui-richTextEditor-span-mark": true,
+      },
+    ],
+    "data": Object {},
+    "type": "iframe",
+    "url": "https://www.youtube.com/embed/5qap5aO4i9A",
   },
   Object {
     "children": Array [

--- a/uui-editor/src/__tests__/data/plate-migration.ts
+++ b/uui-editor/src/__tests__/data/plate-migration.ts
@@ -426,6 +426,18 @@ export const initialValue = [
     },
     {
         data: {
+            src: 'https://www.youtube.com/embed/5qap5aO4i9A',
+        },
+        type: 'iframe',
+        children: [
+            {
+                text: '',
+                'uui-richTextEditor-span-mark': true,
+            },
+        ],
+    },
+    {
+        data: {
             checked: false,
         },
         type: 'paragraph',

--- a/uui-editor/src/components.tsx
+++ b/uui-editor/src/components.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { MARK_BOLD, MARK_CODE, MARK_ITALIC, MARK_SUPERSCRIPT, MARK_UNDERLINE } from '@udecode/plate-basic-marks';
-import { PlatePluginComponent } from '@udecode/plate-common';
+import { PlateElement, PlateLeaf, PlatePluginComponent } from '@udecode/plate-common';
 import { ELEMENT_H1, ELEMENT_H2, ELEMENT_H3, ELEMENT_H4, ELEMENT_H5, ELEMENT_H6 } from '@udecode/plate-heading';
 import { ELEMENT_PARAGRAPH } from '@udecode/plate-paragraph';
 
@@ -24,18 +24,42 @@ export const createPlateUI = <T extends string = string>(
     >,
 ) => {
     const components: { [key: string]: PlatePluginComponent } = {
-        [ELEMENT_H1]: (props) => <h1 { ...props.attributes }>{ props.children }</h1>,
-        [ELEMENT_H2]: (props) => <h2 { ...props.attributes }>{ props.children }</h2>,
-        [ELEMENT_H3]: (props) => <h3 { ...props.attributes }>{ props.children }</h3>,
-        [ELEMENT_H4]: (props) => <h4 { ...props.attributes }>{ props.children }</h4>,
-        [ELEMENT_H5]: (props) => <h5 { ...props.attributes }>{ props.children }</h5>,
-        [ELEMENT_H6]: (props) => <h6 { ...props.attributes }>{ props.children }</h6>,
-        [ELEMENT_PARAGRAPH]: (props) => <p { ...props.attributes }>{ props.children }</p>,
-        [MARK_BOLD]: (props) => <strong { ...props.attributes }>{ props.children }</strong>,
-        [MARK_CODE]: (props) => <code { ...props.attributes }>{ props.children }</code>,
-        [MARK_ITALIC]: (props) => <em { ...props.attributes }>{ props.children }</em>,
-        [MARK_SUPERSCRIPT]: (props) => <sup { ...props.attributes }>{ props.children }</sup>,
-        [MARK_UNDERLINE]: (props) => <u { ...props.attributes }>{ props.children }</u>,
+        [ELEMENT_H1]: (props) => (
+            <PlateElement as="h1" { ...props } />
+        ),
+        [ELEMENT_H2]: (props) => (
+            <PlateElement as="h2" { ...props } />
+        ),
+        [ELEMENT_H3]: (props) => (
+            <PlateElement as="h3" { ...props } />
+        ),
+        [ELEMENT_H4]: (props) => (
+            <PlateElement as="h4" { ...props } />
+        ),
+        [ELEMENT_H5]: (props) => (
+            <PlateElement as="h5" { ...props } />
+        ),
+        [ELEMENT_H6]: (props) => (
+            <PlateElement as="h6" { ...props } />
+        ),
+        [ELEMENT_PARAGRAPH]: (props) => (
+            <PlateElement as="p" { ...props } />
+        ),
+        [MARK_BOLD]: (props) => (
+            <PlateLeaf as="strong" { ...props } />
+        ),
+        [MARK_CODE]: (props) => (
+            <PlateLeaf as="code" { ...props } />
+        ),
+        [MARK_ITALIC]: (props) => (
+            <PlateLeaf as="em" { ...props } />
+        ),
+        [MARK_SUPERSCRIPT]: (props) => (
+            <PlateLeaf as="sup" { ...props } />
+        ),
+        [MARK_UNDERLINE]: (props) => (
+            <PlateLeaf as="u" { ...props } />
+        ),
     };
 
     if (overrideByKey) {

--- a/uui-editor/src/implementation/PositionedToolbar.helpers.ts
+++ b/uui-editor/src/implementation/PositionedToolbar.helpers.ts
@@ -1,0 +1,44 @@
+import { findNode, isExpanded, toDOMNode, toDOMRange } from '@udecode/plate-common';
+import { getCellTypes } from '@udecode/plate-table';
+import { Range } from 'slate';
+import { useEditorState } from '@udecode/plate-common';
+import type { VirtualElement } from '@floating-ui/react';
+
+const toVirtualElement = (target: VirtualElement): VirtualElement => {
+    const boundingRect = target.getBoundingClientRect();
+    const clientRects = target.getClientRects();
+
+    return {
+        getBoundingClientRect: () => boundingRect,
+        getClientRects: () => clientRects,
+    };
+};
+
+export const getVirtualReferenceElement = (editor: ReturnType<typeof useEditorState>, { isTable }: { isTable?: boolean }): VirtualElement | null => {
+    if (isTable) {
+        const [selectedNode] = findNode(editor, {
+            at: Range.start(editor.selection),
+            match: { type: getCellTypes(editor) },
+        });
+
+        const domNode = toDOMNode(editor, selectedNode);
+
+        if (!domNode) {
+            return null;
+        }
+
+        return toVirtualElement(domNode);
+    }
+
+    if (!isExpanded(editor.selection)) {
+        return null;
+    }
+
+    const range = toDOMRange(editor, editor.selection);
+
+    if (!range) {
+        return null;
+    }
+
+    return toVirtualElement(range);
+};

--- a/uui-editor/src/implementation/PositionedToolbar.tsx
+++ b/uui-editor/src/implementation/PositionedToolbar.tsx
@@ -1,12 +1,12 @@
 import { Dropdown } from '@epam/uui';
-import { findNode, toDOMNode, toDOMRange, useEditorState, useEventEditorSelectors } from '@udecode/plate-common';
-import { getCellTypes } from '@udecode/plate-table';
+import { useForceUpdate } from '@epam/uui-core';
+import { useEditorState, useEventEditorSelectors } from '@udecode/plate-common';
 import cx from 'classnames';
-import React from 'react';
-import { Range } from 'slate';
-import { offset } from '@floating-ui/react';
+import React, { useEffect, useRef } from 'react';
+import { offset, inline, type VirtualElement } from '@floating-ui/react';
 
 import { isImageSelected, isTextSelected } from '../helpers';
+import { getVirtualReferenceElement } from './PositionedToolbar.helpers';
 import css from './PositionedToolbar.module.scss';
 
 interface ToolbarProps {
@@ -18,40 +18,13 @@ interface ToolbarProps {
 
 export function FloatingToolbar(props: ToolbarProps): any {
     const editor = useEditorState();
+    const forceUpdate = useForceUpdate();
+    const virtualTarget = useRef<VirtualElement | null>(null);
 
     // useEventEditorSelectors.focus() hook is not working correctly at Safari in ShadowDOM,
     // editor focus state changes on tripple click
     // TODO: Consider upgrading Plate @udecode/* to check if this is fixed
     const inFocus = useEventEditorSelectors.focus() === editor.id;
-
-    const getVirtualReferenceElement = () => {
-        if (props.isTable) {
-            const [selectedNode] = findNode(editor, {
-                at: Range.start(editor.selection),
-                match: { type: getCellTypes(editor) },
-            });
-
-            const domNode = toDOMNode(editor, selectedNode);
-
-            if (!domNode) {
-                return null;
-            }
-
-            return {
-                getBoundingClientRect(): DOMRect {
-                    return domNode.getBoundingClientRect();
-                },
-            };
-        }
-
-        return {
-            getBoundingClientRect(): DOMRect {
-                const range = toDOMRange(editor, editor.selection);
-
-                return range.getBoundingClientRect();
-            },
-        };
-    };
 
     let isToolbarVisible: boolean;
     if (props.isImage) {
@@ -60,14 +33,22 @@ export function FloatingToolbar(props: ToolbarProps): any {
         isToolbarVisible = !!props.isTable || isTextSelected(editor, inFocus);
     }
 
+    useEffect(() => {
+        virtualTarget.current = isToolbarVisible
+            ? getVirtualReferenceElement(editor, { isTable: props.isTable })
+            : null;
+        forceUpdate();
+    }, [JSON.stringify(editor.selection), isToolbarVisible, props.isTable]);
+
     return isToolbarVisible && (
         <Dropdown
             value={ isToolbarVisible }
-            virtualTarget={ getVirtualReferenceElement() }
+            virtualTarget={ virtualTarget.current }
             renderTarget={ (p) => <div { ...p }></div> }
             placement={ props.placement || 'top' }
             middleware={ [
                 offset(12),
+                inline(),
             ] }
             renderBody={ (bodyProps) => (
                 <div

--- a/uui-editor/src/migrations/normalizers.ts
+++ b/uui-editor/src/migrations/normalizers.ts
@@ -1,4 +1,5 @@
 import { Value, setNodes, PlateEditor, TNodeEntry } from '@udecode/plate-common';
+import { TTodoListItemElement } from '@udecode/plate-list';
 import { TLinkElement } from '@udecode/plate-link';
 import { TTableCellElement, TTableElement } from '@udecode/plate-table';
 import { TAttachmentElement } from '../plugins/attachmentPlugin/types';
@@ -6,6 +7,7 @@ import { TIframeElement } from '../plugins/iframePlugin/types';
 import { TImageElement } from '../plugins/imagePlugin/types';
 import { toNewAlign } from './legacy_migrations';
 import { DepreactedTTableElement, DeprecatedImageElement, DeprecatedTAttachmentElement, DeprecatedTIframeElement, DeprecatedTLinkElement, DeprecatedTTableCellElement } from './types';
+import { isLegacyTodoListItemElement } from './utils';
 
 /**
  * Migration property functions
@@ -116,14 +118,20 @@ export const normalizeIframeElement = (editor: PlateEditor<Value>, entry: TNodeE
     const iframeNode = node as DeprecatedTIframeElement;
 
     if (iframeNode.data) {
-        const { src, ...otherData } = iframeNode.data;
+        const { data: { src, ...otherData }, url } = iframeNode;
 
         // removing props
         if (!src) {
             return;
         }
 
-        const iframe: TIframeElement = { ...iframeNode, data: { ...otherData } };
+        const newUrl = url || src;
+
+        const iframe: TIframeElement = {
+            ...iframeNode,
+            url: newUrl,
+            data: { ...otherData },
+        };
 
         setNodes<TTableCellElement>(
             editor,
@@ -171,6 +179,31 @@ export const normaizeColoredText = (editor: PlateEditor<Value>, entry: TNodeEntr
         setNodes<TTableCellElement>(
             editor,
             { ...node, color: WORD_TO_COLOR[node.color] },
+            { at: path },
+        );
+    }
+};
+
+/** migrate checked property if needed */
+export const migrateCheckedPropertyIfNeeded = <V extends Value>(
+    editor: PlateEditor<V>,
+    entry: TNodeEntry<TTodoListItemElement>,
+) => {
+    const [node, path] = entry;
+
+    if (isLegacyTodoListItemElement(node)) {
+        const { data: { checked, ...otherData }, ...otherNodeData } = node;
+        const updatedNode: TTodoListItemElement = {
+            ...otherNodeData,
+            data: {
+                ...otherData,
+            },
+            checked: checked,
+        };
+
+        setNodes<TTodoListItemElement>(
+            editor,
+            updatedNode,
             { at: path },
         );
     }

--- a/uui-editor/src/migrations/types.ts
+++ b/uui-editor/src/migrations/types.ts
@@ -1,5 +1,6 @@
 import { TLinkElement } from '@udecode/plate-link';
 import { TTableCellElement, TTableElement } from '@udecode/plate-table';
+import { TTodoListItemElement } from '@udecode/plate-list';
 import { TAttachmentElement } from '../plugins/attachmentPlugin/types';
 import { TIframeElement } from '../plugins/iframePlugin/types';
 import { TImageElement } from '../plugins/imagePlugin/types';
@@ -48,6 +49,12 @@ export type DeprecatedTIframeElement = TIframeElement & {
 export type DeprecatedTAttachmentElement = TAttachmentElement & {
     data?: TAttachmentElement['data'] & {
         src?: string; // removed
+    }
+};
+
+export type DeprecatedTTodoListItemElement = TTodoListItemElement & {
+    data?: TTodoListItemElement['data'] & {
+        checked?: boolean; // removed
     }
 };
 

--- a/uui-editor/src/migrations/utils.ts
+++ b/uui-editor/src/migrations/utils.ts
@@ -1,7 +1,7 @@
-import { Value } from '@udecode/plate-common';
+import { TElement, Value } from '@udecode/plate-common';
 import { EditorValue } from '../types';
 import { migrateLegacySchema } from './legacy_migrations';
-import { SlateSchema } from './types';
+import { DeprecatedTTodoListItemElement, SlateSchema } from './types';
 
 /** type guard to distinct slate format */
 export const isSlateSchema = (value: EditorValue): value is SlateSchema => {
@@ -21,3 +21,7 @@ export const getMigratedPlateValue = (value: EditorValue): Value | undefined => 
 export const isPlateValue = (value: EditorValue): value is Value => {
     return Array.isArray(value);
 };
+
+export const isLegacyTodoListItemElement = (element: TElement): element is DeprecatedTTodoListItemElement =>
+    element.data !== undefined
+    && 'checked' in (element.data as Record<string, unknown>);

--- a/uui-editor/src/plugins/attachmentPlugin/AttachmentBlock.tsx
+++ b/uui-editor/src/plugins/attachmentPlugin/AttachmentBlock.tsx
@@ -15,25 +15,20 @@ import { ReactComponent as TextIcon } from '../../icons/file-file_text-24.svg';
 import { ReactComponent as MailIcon } from '../../icons/file-file_eml-24.svg';
 
 import css from './AttachmentBlock.module.scss';
-import { AnyObject, PlateEditor, PlatePluginComponent, setElements } from '@udecode/plate-common';
+import { PlateElement, PlateElementProps, setElements, useElement } from '@udecode/plate-common';
 import { useFocused, useReadOnly, useSelected } from 'slate-react';
 import { TAttachmentElement } from './types';
 
-export const AttachmentBlock: PlatePluginComponent<{
-    editor: PlateEditor,
-    attributes: AnyObject,
-    children: React.ReactNode,
-    element: TAttachmentElement
-}> = function AttachmentComp(props) {
+export const AttachmentBlock = function AttachmentComp({ children, ...props }: PlateElementProps) {
+    const element = useElement<TAttachmentElement>();
     const isFocused = useFocused();
     const isSelected = useSelected() && isFocused;
     const isReadonly = useReadOnly();
 
-    const { element, editor, children } = props;
     const [fileName, setFileName] = useState(element.data.fileName || '');
 
     const changeName = (name: string) => {
-        setElements(editor, {
+        setElements(props.editor, {
             ...element,
             data: {
                 ...element.data,
@@ -100,7 +95,7 @@ export const AttachmentBlock: PlatePluginComponent<{
     };
 
     return (
-        <div { ...props.attributes }>
+        <PlateElement as="div" { ...props }>
             <FlexRow
                 rawProps={ {
                     contentEditable: false,
@@ -146,6 +141,6 @@ export const AttachmentBlock: PlatePluginComponent<{
                 </FlexCell>
             </FlexRow>
             { children }
-        </div>
+        </PlateElement>
     );
 };

--- a/uui-editor/src/plugins/baseMarksPlugin/baseMarksPlugin.tsx
+++ b/uui-editor/src/plugins/baseMarksPlugin/baseMarksPlugin.tsx
@@ -1,5 +1,5 @@
 import {
-    PlateEditor, PlatePluginComponent, isMarkActive, PlatePlugin,
+    PlateEditor, PlateLeaf, PlateLeafProps, isMarkActive, PlatePlugin,
 } from '@udecode/plate-common';
 import React from 'react';
 
@@ -17,32 +17,9 @@ import { ReactComponent as UnderlineIcon } from '../../icons/underline.svg';
 import { handleMarkButtonClick } from '../../utils/handleMarkButtonClick';
 import { BOLD_KEY, ITALIC_KEY, UNDERLINE_KEY } from './constants';
 
-// eslint-disable-next-line react/function-component-definition
-const Bold: PlatePluginComponent = (props) => {
-    const { attributes, children } = props;
-
-    return (
-        <span { ...attributes }><strong>{ children }</strong></span>
-    );
-};
-
-// eslint-disable-next-line react/function-component-definition
-const Italic: PlatePluginComponent = (props) => {
-    const { attributes, children } = props;
-
-    return (
-        <span { ...attributes }><i>{ children }</i></span>
-    );
-};
-
-// eslint-disable-next-line react/function-component-definition
-const Underline: PlatePluginComponent = (props) => {
-    const { attributes, children } = props;
-
-    return (
-        <span { ...attributes }><u>{ children }</u></span>
-    );
-};
+const Bold = (props: PlateLeafProps) => <PlateLeaf as="strong" { ...props } />;
+const Italic = (props: PlateLeafProps) => <PlateLeaf as="i" { ...props } />;
+const Underline = (props: PlateLeafProps) => <PlateLeaf as="u" { ...props } />;
 
 export const boldPlugin = (): PlatePlugin => createBoldPlugin<WithToolbarButton>({
     type: BOLD_KEY,

--- a/uui-editor/src/plugins/iframePlugin/IframeBlock.tsx
+++ b/uui-editor/src/plugins/iframePlugin/IframeBlock.tsx
@@ -4,18 +4,14 @@ import { uuiMod } from '@epam/uui-core';
 import cx from 'classnames';
 import { sanitizeUrl } from '@braintree/sanitize-url';
 import { useSelected } from 'slate-react';
-import { AnyObject, PlatePluginComponent } from '@udecode/plate-common';
+import { PlateElement, PlateElementProps, useElement } from '@udecode/plate-common';
 import { TIframeElement } from './types';
 
 const IFRAME_GLOBAL_CLASS = 'uui-rte-iframe';
 const PDF_GLOBAL_CLASS = 'uui-rte-iframe-pdf';
 
-export const IframeBlock: PlatePluginComponent<{
-    attributes: AnyObject,
-    children: React.ReactNode,
-    element: TIframeElement
-}> = function IframeComp(props) {
-    const { attributes, children, element } = props;
+export const IframeBlock = function IframeComp({ children, ...props }: PlateElementProps) {
+    const element = useElement<TIframeElement>();
     const isSelected = useSelected();
 
     const isPdf = element.data?.extension === 'pdf';
@@ -24,8 +20,7 @@ export const IframeBlock: PlatePluginComponent<{
     const url: string = element.url || element.src as string; // element.src it's previous editor format structure
 
     return (
-        // style attr needed for serialization
-        <div { ...attributes }>
+        <PlateElement as="div" { ...props }>
             <iframe
                 title={ url }
                 allowFullScreen={ true }
@@ -34,6 +29,6 @@ export const IframeBlock: PlatePluginComponent<{
                 className={ cx(css.content, isSelected && uuiMod.focus, IFRAME_GLOBAL_CLASS, isPdf && PDF_GLOBAL_CLASS) }
             />
             { children }
-        </div>
+        </PlateElement>
     );
 };

--- a/uui-editor/src/plugins/iframePlugin/IframeBlock.tsx
+++ b/uui-editor/src/plugins/iframePlugin/IframeBlock.tsx
@@ -17,7 +17,7 @@ export const IframeBlock = function IframeComp({ children, ...props }: PlateElem
     const isPdf = element.data?.extension === 'pdf';
     const style = element.data?.style;
 
-    const url: string = element.url || element.src as string; // element.src it's previous editor format structure
+    const url: string = element.url;
 
     return (
         <PlateElement as="div" { ...props }>

--- a/uui-editor/src/plugins/iframePlugin/iframePlugin.tsx
+++ b/uui-editor/src/plugins/iframePlugin/iframePlugin.tsx
@@ -1,5 +1,5 @@
 import {
-    PlateEditor, createPluginFactory, getBlockAbove, getEndPoint, getPluginType, insertEmptyElement, selectEditor, PlatePlugin, isElement,
+    PlateEditor, createPluginFactory, getBlockAbove, getEndPoint, getPluginType, insertEmptyElement, selectEditor, PlatePlugin,
 } from '@udecode/plate-common';
 import React from 'react';
 
@@ -14,7 +14,7 @@ import { WithToolbarButton } from '../../implementation/Toolbars';
 import { IFRAME_PLUGIN_KEY, IFRAME_TYPE } from './constants';
 import { useFilesUploader } from '../uploadFilePlugin/file_uploader';
 import { PARAGRAPH_TYPE } from '../paragraphPlugin/constants';
-import { normalizeIframeElement } from '../../migrations';
+import { withIframe } from './withIframe';
 
 // TODO: implement iframe resize
 export const iframePlugin = (): PlatePlugin => {
@@ -66,22 +66,7 @@ export const iframePlugin = (): PlatePlugin => {
         options: {
             bottomBarButton: IframeButton,
         },
-        // move to common function / plugin
-        withOverrides: (editor) => {
-            const { normalizeNode } = editor;
-
-            editor.normalizeNode = (entry) => {
-                const [node] = entry;
-
-                if (isElement(node) && node.type === IFRAME_TYPE) {
-                    normalizeIframeElement(editor, entry);
-                }
-
-                normalizeNode(entry);
-            };
-
-            return editor;
-        },
+        withOverrides: withIframe,
     });
 
     return createIframePlugin();

--- a/uui-editor/src/plugins/iframePlugin/withIframe.ts
+++ b/uui-editor/src/plugins/iframePlugin/withIframe.ts
@@ -1,0 +1,19 @@
+import { isElement, Value, PlateEditor } from '@udecode/plate-common';
+import { normalizeIframeElement } from '../../migrations';
+import { IFRAME_TYPE } from './constants';
+
+export const withIframe = (editor: PlateEditor<Value>) => {
+    const { normalizeNode } = editor;
+
+    editor.normalizeNode = (entry) => {
+        const [node] = entry;
+
+        if (isElement(node) && node.type === IFRAME_TYPE) {
+            normalizeIframeElement(editor, entry);
+        }
+
+        normalizeNode(entry);
+    };
+
+    return editor;
+};

--- a/uui-editor/src/plugins/inlineCodePlugin/inlineCodePlugin.tsx
+++ b/uui-editor/src/plugins/inlineCodePlugin/inlineCodePlugin.tsx
@@ -1,6 +1,6 @@
 import { createCodePlugin } from '@udecode/plate-basic-marks';
 import {
-    PlateEditor, PlateElementProps, isMarkActive, PlatePlugin,
+    PlateEditor, PlateLeaf, PlateLeafProps, isMarkActive, PlatePlugin,
 } from '@udecode/plate-common';
 import React from 'react';
 
@@ -11,12 +11,9 @@ import { handleMarkButtonClick } from '../../utils/handleMarkButtonClick';
 import { WithToolbarButton } from '../../implementation/Toolbars';
 import { INLINE_CODE_KEY, INLINE_CODE_TYPE } from './constants';
 
-function Code(props: PlateElementProps) {
-    const { attributes, children } = props;
-    return (
-        <span { ...attributes }><code>{ children }</code></span>
-    );
-}
+const Code = (props: PlateLeafProps) => (
+    <PlateLeaf as="code" { ...props } />
+);
 
 export const codeBlockPlugin = (): PlatePlugin => createCodePlugin<WithToolbarButton>({
     key: INLINE_CODE_KEY,

--- a/uui-editor/src/plugins/linkPlugin/linkPlugin.tsx
+++ b/uui-editor/src/plugins/linkPlugin/linkPlugin.tsx
@@ -3,7 +3,7 @@ import { useUuiContext } from '@epam/uui-core';
 
 import { ToolbarButton } from '../../implementation/ToolbarButton';
 
-import { isElement, PlateEditor, PlatePlugin, someNode } from '@udecode/plate-common';
+import { isElement, PlateEditor, PlateElement, PlatePlugin, someNode } from '@udecode/plate-common';
 import { ELEMENT_LINK, LinkPlugin, createLinkPlugin, withLink } from '@udecode/plate-link';
 import { useIsPluginActive } from '../../helpers';
 import { ReactComponent as LinkIcon } from '../../icons/link.svg';
@@ -17,15 +17,14 @@ export const linkPlugin = (): PlatePlugin => createLinkPlugin<WithToolbarButton 
     overrideByKey: {
         [ELEMENT_LINK]: {
             component: (props) => (
-                <a
-                    { ...props.attributes }
+                <PlateElement
+                    as="a"
+                    { ...props }
                     style={ { display: 'inline' } }
                     target="_blank"
                     rel="noopener noreferrer"
                     href={ props.element.url }
-                >
-                    { props.children }
-                </a>
+                />
             ),
         },
     },

--- a/uui-editor/src/plugins/listPlugin/listPlugin.tsx
+++ b/uui-editor/src/plugins/listPlugin/listPlugin.tsx
@@ -1,5 +1,5 @@
 import {
-    PlateEditor, PlateElementProps, focusEditor, PlatePlugin,
+    PlateEditor, PlateElement, PlateElementProps, focusEditor, PlatePlugin,
     KEY_DESERIALIZE_HTML,
     traverseHtmlElements,
     isHtmlBlockElement,
@@ -36,9 +36,9 @@ export const listPlugin = (): PlatePlugin => createListPlugin<WithToolbarButton>
         [ELEMENT_LI]: {
             type: LI_TYPE,
             isElement: true,
-            component: ({ children, attributes }: PlateElementProps) => {
-                return <li { ...attributes }>{children}</li>;
-            },
+            component: (props: PlateElementProps) => (
+                <PlateElement as="li" { ...props } />
+            ),
             deserializeHtml: { rules: [{ validNodeName: 'LI' }] },
         },
         [ELEMENT_LIC]: {

--- a/uui-editor/src/plugins/notePlugin/NotePluginBlock.tsx
+++ b/uui-editor/src/plugins/notePlugin/NotePluginBlock.tsx
@@ -2,22 +2,20 @@ import cx from 'classnames';
 import * as React from 'react';
 
 import css from './NotePluginBlock.module.scss';
-import { PlateElementProps } from '@udecode/plate-common';
-import { NoteNodeProps } from './types';
+import { PlateElement, PlateElementProps } from '@udecode/plate-common';
 
-export function NotePluginBlock({ attributes, children, nodeProps }: PlateElementProps) {
-    let style;
-    if (nodeProps) {
-        const { borderColor, backgroundColor } = nodeProps as NoteNodeProps;
-        style = {
-            borderColor,
-            backgroundColor,
-        };
-    }
-
+export function NotePluginBlock({ className, nodeProps, ...rest }: PlateElementProps) {
     return (
-        <div { ...attributes } style={ style } className={ cx(css.wrapper) }>
-            { children }
-        </div>
+        <PlateElement
+            as="div"
+            { ...rest }
+            style={ {
+                ...(nodeProps && {
+                    borderColor: nodeProps.borderColor,
+                    backgroundColor: nodeProps.backgroundColor,
+                }),
+            } }
+            className={ cx(className, css.wrapper) }
+        />
     );
 }

--- a/uui-editor/src/plugins/paragraphPlugin/paragraphPlugin.tsx
+++ b/uui-editor/src/plugins/paragraphPlugin/paragraphPlugin.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { ELEMENT_DEFAULT, PlatePlugin } from '@udecode/plate-common';
+import { ELEMENT_DEFAULT, PlateElement, PlatePlugin } from '@udecode/plate-common';
 import { createParagraphPlugin } from '@udecode/plate-paragraph';
 import { PARAGRAPH_TYPE } from './constants';
 
@@ -10,11 +10,9 @@ export const paragraphPlugin = (): PlatePlugin => {
         type: PARAGRAPH_TYPE,
         overrideByKey: {
             [ELEMENT_DEFAULT]: {
-                component: (props): JSX.Element => {
-                    const { attributes, children } = props;
-
-                    return <p { ...attributes }>{ children }</p>;
-                },
+                component: (props): JSX.Element => (
+                    <PlateElement as="p" { ...props } />
+                ),
                 type: PARAGRAPH_TYPE,
             },
         },

--- a/uui-editor/src/plugins/placeholderPlugin/PlaceholderBlock.tsx
+++ b/uui-editor/src/plugins/placeholderPlugin/PlaceholderBlock.tsx
@@ -3,19 +3,22 @@ import css from './PlaceholderPlugin.module.scss';
 import cx from 'classnames';
 import { useSelected } from 'slate-react';
 import { uuiMod } from '@epam/uui-core';
+import { PlateElement, PlateElementProps, useElement } from '@udecode/plate-common';
+import { TPlaceholderElement } from './types';
 
-export function PlaceholderBlock(props: any) {
-    const { attributes, element, children } = props;
+export function PlaceholderBlock({ className, children, ...props }: PlateElementProps) {
+    const element = useElement<TPlaceholderElement>();
     const selected = useSelected();
     const src = element.data.name;
 
     return (
-        <span
-            { ...attributes }
-            className={ cx(css.placeholderBlock, selected && uuiMod.focus) }
+        <PlateElement
+            as="span"
+            className={ cx(className, css.placeholderBlock, selected && uuiMod.focus) }
+            { ...props }
         >
             { src }
             { children }
-        </span>
+        </PlateElement>
     );
 }

--- a/uui-editor/src/plugins/placeholderPlugin/placeholderPlugin.tsx
+++ b/uui-editor/src/plugins/placeholderPlugin/placeholderPlugin.tsx
@@ -11,6 +11,7 @@ import {
 import { PLACEHOLDER_PLUGIN_KEY } from './constants';
 import { WithToolbarButton } from '../../implementation/Toolbars';
 import css from './PlaceholderPlugin.module.scss';
+import { TPlaceholderElement } from './types';
 
 export interface PlaceholderPluginParams {
     /** Placeholder items */
@@ -62,7 +63,7 @@ export function PlaceholderButton({ editor }: IPlaceholderButton): any {
                                         data: i,
                                         type: 'placeholder',
                                         children: [{ text: '' }],
-                                    },
+                                    } satisfies TPlaceholderElement,
                                 );
                             } }
                         >

--- a/uui-editor/src/plugins/placeholderPlugin/types.ts
+++ b/uui-editor/src/plugins/placeholderPlugin/types.ts
@@ -1,0 +1,8 @@
+import { TElement } from '@udecode/plate-common';
+
+export interface TPlaceholderElement extends TElement {
+    data: {
+        name: string;
+        [key: string]: any;
+    };
+}

--- a/uui-editor/src/plugins/quotePlugin/quotePlugin.tsx
+++ b/uui-editor/src/plugins/quotePlugin/quotePlugin.tsx
@@ -2,9 +2,10 @@ import React from 'react';
 
 import { ELEMENT_BLOCKQUOTE, createBlockquotePlugin } from '@udecode/plate-block-quote';
 import {
-    PlateEditor, PlatePluginComponent, focusEditor, toggleNodeType, PlatePlugin, getBlockAbove,
+    PlateEditor, PlateElement, focusEditor, toggleNodeType, PlatePlugin, getBlockAbove,
+    PlateElementProps,
 } from '@udecode/plate-common';
-
+import cx from 'classnames';
 import { useIsPluginActive } from '../../helpers';
 import { ReactComponent as QuoteIcon } from '../../icons/quote.svg';
 import { ToolbarButton } from '../../implementation/ToolbarButton';
@@ -12,14 +13,13 @@ import css from './quote.module.scss';
 import { WithToolbarButton } from '../../implementation/Toolbars';
 import { QUOTE_PLUGIN_KEY, QUOTE_TYPE } from './constants';
 
-const Quote: PlatePluginComponent = function QuoteComponent(props) {
+const Quote = function QuoteComponent({ className, ...props }: PlateElementProps) {
     return (
-        <blockquote
-            { ...props.attributes }
-            className={ css.quote }
-        >
-            { props.children }
-        </blockquote>
+        <PlateElement
+            as="blockquote"
+            className={ cx(className, css.quote) }
+            { ...props }
+        />
     );
 };
 

--- a/uui-editor/src/plugins/separatorPlugin/Separator.tsx
+++ b/uui-editor/src/plugins/separatorPlugin/Separator.tsx
@@ -6,21 +6,17 @@ import { uuiMod } from '@epam/uui-core';
 
 import css from './Separator.module.scss';
 
-const Separator = React.forwardRef<React.ElementRef<typeof PlateElement>, PlateElementProps>(({ className, ...props }, ref) => {
-    const { children } = props;
-
+const Separator = function SeparatorComponent({ className, ...props }: PlateElementProps) {
     const selected = useSelected();
 
     return (
-        <PlateElement ref={ ref } { ...props }>
-            <div
-                contentEditable={ false }
-                className={ cx(css.separator, selected && uuiMod.focus) }
-            >
-            </div>
-            { children }
-        </PlateElement>
+        <PlateElement
+            as="div"
+            { ...props }
+            contentEditable={ false }
+            className={ cx(css.separator, selected && uuiMod.focus) }
+        />
     );
-});
+};
 
 export { Separator };

--- a/uui-editor/src/plugins/toDoListPlugin/ToDoItem.tsx
+++ b/uui-editor/src/plugins/toDoListPlugin/ToDoItem.tsx
@@ -4,38 +4,43 @@ import { FlexRow, Checkbox } from '@epam/uui';
 import css from './ToDoItem.module.scss';
 import { useReadOnly } from 'slate-react';
 import { TTodoListItemElement } from '@udecode/plate-list';
-import { setNodes, findNodePath } from '@udecode/plate-common';
+import { PlateElement, PlateElementProps, setNodes, findNodePath, Value, useElement } from '@udecode/plate-common';
 
-export function ToDoItem(props: any): any {
+export function ToDoItem(props: PlateElementProps<Value, TTodoListItemElement>) {
+    const element = useElement<TTodoListItemElement>();
     const isReadonly = useReadOnly();
-    const { element, editor, attributes, children } = props;
+    const {
+        className, editor, attributes, children,
+    } = props;
 
     const checked = element.data?.checked || false;
 
     return (
-        <FlexRow rawProps={ attributes }>
-            <div className={ css.checkboxContainer } style={ { userSelect: 'none' } }>
-                <Checkbox
-                    isReadonly={ isReadonly }
-                    isDisabled={ false }
-                    value={ checked }
-                    rawProps={ { contentEditable: false } }
-                    onValueChange={ (value) => {
-                        if (isReadonly) return;
-                        const path = findNodePath(editor, element);
-                        if (!path) return;
+        <PlateElement asChild { ...{ ...props, rawProps: attributes } }>
+            <FlexRow cx={ className }>
+                <div className={ css.checkboxContainer } style={ { userSelect: 'none' } }>
+                    <Checkbox
+                        isReadonly={ isReadonly }
+                        isDisabled={ false }
+                        value={ checked }
+                        rawProps={ { contentEditable: false } }
+                        onValueChange={ (value) => {
+                            if (isReadonly) return;
+                            const path = findNodePath(editor, element);
+                            if (!path) return;
 
-                        setNodes<TTodoListItemElement>(
-                            editor,
-                            { data: { checked: value } },
-                            { at: path },
-                        );
-                    } }
-                />
-            </div>
-            <div className={ css.textContainer }>
-                { children }
-            </div>
-        </FlexRow>
+                            setNodes<TTodoListItemElement>(
+                                editor,
+                                { data: { checked: value } },
+                                { at: path },
+                            );
+                        } }
+                    />
+                </div>
+                <div className={ css.textContainer }>
+                    { children }
+                </div>
+            </FlexRow>
+        </PlateElement>
     );
 }

--- a/uui-editor/src/plugins/toDoListPlugin/ToDoItem.tsx
+++ b/uui-editor/src/plugins/toDoListPlugin/ToDoItem.tsx
@@ -13,7 +13,7 @@ export function ToDoItem(props: PlateElementProps<Value, TTodoListItemElement>) 
         className, editor, attributes, children,
     } = props;
 
-    const checked = element.data?.checked || false;
+    const checked = element?.checked || false;
 
     return (
         <PlateElement asChild { ...{ ...props, rawProps: attributes } }>
@@ -31,7 +31,7 @@ export function ToDoItem(props: PlateElementProps<Value, TTodoListItemElement>) 
 
                             setNodes<TTodoListItemElement>(
                                 editor,
-                                { data: { checked: value } },
+                                { checked: value },
                                 { at: path },
                             );
                         } }

--- a/uui-editor/src/plugins/toDoListPlugin/normalizers.ts
+++ b/uui-editor/src/plugins/toDoListPlugin/normalizers.ts
@@ -1,0 +1,26 @@
+import {
+    isElement,
+    PlateEditor,
+    TNodeEntry,
+    Value,
+} from '@udecode/plate-common';
+import { TTodoListItemElement } from '@udecode/plate-list';
+import { migrateCheckedPropertyIfNeeded } from '../../migrations/normalizers';
+import { TODO_TYPE } from './constants';
+
+const isTodoListItemElementEntry = (entry: TNodeEntry): entry is TNodeEntry<TTodoListItemElement> =>
+    isElement(entry[0]) && entry[0].type === TODO_TYPE;
+
+export const normalizeTodoListElement = <V extends Value>(
+    editor: PlateEditor<V>,
+) => {
+    const { normalizeNode } = editor;
+
+    return (entry: TNodeEntry) => {
+        if (isTodoListItemElementEntry(entry)) {
+            migrateCheckedPropertyIfNeeded(editor, entry);
+        }
+
+        normalizeNode(entry);
+    };
+};

--- a/uui-editor/src/plugins/toDoListPlugin/toDoListPlugin.tsx
+++ b/uui-editor/src/plugins/toDoListPlugin/toDoListPlugin.tsx
@@ -12,6 +12,7 @@ import { ELEMENT_TODO_LI, createTodoListPlugin } from '@udecode/plate-list';
 import { ToDoItem } from './ToDoItem';
 import { WithToolbarButton } from '../../implementation/Toolbars';
 import { TODO_PLUGIN_KEY, TODO_TYPE } from './constants';
+import { withTodoList } from './withTodoList';
 
 export const toDoListPlugin = (): PlatePlugin<WithToolbarButton> => {
     // TODO: implement withOverrides for toggling between lists and todo lists
@@ -23,6 +24,7 @@ export const toDoListPlugin = (): PlatePlugin<WithToolbarButton> => {
                 component: ToDoItem,
             },
         },
+        withOverrides: withTodoList,
         options: {
             bottomBarButton: ToDoListButton,
         },

--- a/uui-editor/src/plugins/toDoListPlugin/withTodoList.ts
+++ b/uui-editor/src/plugins/toDoListPlugin/withTodoList.ts
@@ -1,0 +1,9 @@
+import { PlateEditor } from '@udecode/plate-core';
+import { Value } from '@udecode/plate-common';
+import { normalizeTodoListElement } from './normalizers';
+
+export const withTodoList = (editor: PlateEditor<Value>) => {
+    editor.normalizeNode = normalizeTodoListElement(editor);
+
+    return editor;
+};


### PR DESCRIPTION
* Rendering (`PlateElement` / `PlateLeaf`)
  * Headings and default paragraph use `PlateElement`; bold/code/italic/superscript/underline use `PlateLeaf` with `as`
  * Attachment, iframe, placeholder blocks, quote, link anchor, list LI, paragraph override, Note block, and Separator refactored to `PlateElement` / `useElement`; `Separator` simplified (no forwardRef, contentEditable false on element)
  * Base marks: nested span wrappers replaced with `PlateLeaf`; inline code uses `PlateLeaf` + `PlateLeafProps`
  * `ToDoItem` wrapped in `PlateElement` with `asChild` around `FlexRow` for correct Slate attributes
  * Added types.ts (e.g. `TPlaceholderElement`) for typed placeholder inserts

* Todo list migration
  * `checked` moved from `data` to element root; `ToDoItem` reads/toggles there
  * Legacy helpers: `DeprecatedTTodoListItemElement`, `isLegacyTodoListItemElement, migrateCheckedPropertyIfNeeded`
  * `withTodoList` + `normalizeTodoListElement` registered on the plugin

* Iframe migration
  * `normalizeIframeElement` sets `url` from `url` or legacy `data.src`; keeps other `data` without `src`
  * `IframeBlock` uses `element.url` only (no element.src fallback)
  * `withIframe` extracts normalize wiring from the iframe plugin

### Description:

Aligns the Plate-based editor with Plate’s element/leaf primitives and tightens legacy Slate data migration for todo items and iframes.

#### Issue link: #3062