### PR TITLE
fix(PickerModal): disable footer Select all during search

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,7 @@
 * [DropdownContainer]: added Shadow DOM support.
 
 **What's Fixed**
+* [PickerModal]: fixed footer **Select all** staying available while searching — the control is now disabled until the search field is cleared.([#3083](https://github.com/epam/UUI/issues/3083))
 * [PresetsPanel]: custom `onCopyLink` is now invoked with `DataTableState` as declared, instead of receiving the click event
 * [DropdownContainer]: fixed `autoFocus` always being `true` even when `false` is passed through params
 * [RTE]: fixed incorrect floating toolbar position when in shadow DOM ([#3073](https://github.com/epam/UUI/issues/3073))

--- a/uui/components/pickers/PickerModal.tsx
+++ b/uui/components/pickers/PickerModal.tsx
@@ -58,6 +58,7 @@ export function PickerModal<TItem, TId>(props: PickerModalProps<TItem, TId>) {
         const isEmptyRowsAndHasNoSelection = (rowsCount === 0 || !hasSelection);
         const showClear = !props.disableClear && (isSingleSelect() ? true : (!view.selectAll || hasSelection));
         const isClearDisabled = isSearching || isEmptyRowsAndHasNoSelection;
+        const isSelectAllDisabled = isSearching;
 
         return (
             <>
@@ -65,6 +66,7 @@ export function PickerModal<TItem, TId>(props: PickerModalProps<TItem, TId>) {
                     <LinkButton
                         caption={ i18n.pickerModal.selectAllButton }
                         onClick={ () => view.selectAll.onValueChange(true) }
+                        isDisabled={ isSelectAllDisabled }
                     />
                 )}
                 {showClear && (


### PR DESCRIPTION
<!-- **Before submitting your PR, ensure that you made the following:**

- Linked the issue(if exists)
- Lint and unit tests pass locally with my changes
- Changelog is updated or not needed
- Documentation is updated/provided or not needed
- Property explorer is updated/provided or not needed
- TSDoc comments for public interfaces is updated/provided or not needed 
 -->

### Description:

Disables the PickerModal footer Select all action while the search field has text, so bulk select cannot run against the full lazy datasource when results are filtered. This aligns with PickerInput, where the dropdown footer (including Select all / Clear all) is hidden while searching.

#### Issue link:

#3083 

#### QA notes: 