### PR TITLE
fix(PresetsPanel): pass tableState to onCopyLink

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,7 @@
 * [DropdownContainer]: added Shadow DOM support.
 
 **What's Fixed**
+* [PresetsPanel]: custom `onCopyLink` is now invoked with `DataTableState` as declared, instead of receiving the click event
 * [DropdownContainer]: fixed `autoFocus` always being `true` even when `false` is passed through params
 * [RTE]: fixed incorrect floating toolbar position when in shadow DOM ([#3073](https://github.com/epam/UUI/issues/3073))
 * [PresetsPanel]: fixed preset tab rendering nested `<button>` elements (preset actions `IconButton` inside the tab control), which caused invalid HTML and a React console warning.

--- a/uui/components/filters/PresetPanel/PresetActionsDropdown.tsx
+++ b/uui/components/filters/PresetPanel/PresetActionsDropdown.tsx
@@ -42,7 +42,13 @@ export function PresetActionsDropdown(props: ITubButtonDropdownProps) {
         successNotificationHandler('Link copied!');
     }, [props.activePresetId, props.preset, props.hasPresetChanged, props.getPresetLink, props.tableState]);
 
-    const onCopyLink = props.onCopyLink ? props.onCopyLink : copyUrlToClipboard;
+    const onCopyLink = useCallback(() => {
+        if (props.onCopyLink) {
+            props.onCopyLink(props.tableState);
+        } else {
+            copyUrlToClipboard();
+        }
+    }, [props.onCopyLink, copyUrlToClipboard]);
 
     const saveInCurrent = useCallback(
         async (preset: ITablePreset) => {


### PR DESCRIPTION
<!-- **Before submitting your PR, ensure that you made the following:**

- Linked the issue(if exists)
- Lint and unit tests pass locally with my changes
- Changelog is updated or not needed
- Documentation is updated/provided or not needed
- Property explorer is updated/provided or not needed
- TSDoc comments for public interfaces is updated/provided or not needed 
 -->

### Description:

PresetsPanel: onCopyLink is now called with DataTableState as the type says. Before, it was bound to the menu onClick, so it got the click event instead of table state.

#### Issue link:

#### QA notes: 