### PR TITLE
fix(server): harden RTE demo path resolution and prevent path traversal

### DIFF
--- a/server/api/RTEDemoApi.ts
+++ b/server/api/RTEDemoApi.ts
@@ -6,21 +6,21 @@ import { sortBy } from 'lodash';
 const router = express.Router();
 
 router.post('/get-demo-doc-content', (req, res) => {
-    const contentDir = path.join(__dirname, '../../../../../public/rte_contents/');
+    const contentDir = path.resolve(__dirname, '../../../public/rte_contents');
     const docContentPath = path.resolve(contentDir, `${req.body.name}`);
-    if (!docContentPath.startsWith(contentDir)) {
-        res.send(null);
+    const relativeToContentDir = path.relative(contentDir, docContentPath);
+    if (relativeToContentDir.startsWith('..') || path.isAbsolute(relativeToContentDir)) {
+        return res.send(null);
     }
     if (!fs.existsSync(docContentPath)) {
-        res.send(null);
-    } else {
-        const content = JSON.parse(JSON.parse(fs.readFileSync(docContentPath, 'utf8')).content);
-        res.send(content);
+        return res.send(null);
     }
+    const content = JSON.parse(JSON.parse(fs.readFileSync(docContentPath, 'utf8')).content);
+    return res.send(content);
 });
 
 router.get('/get-contents-list', (req, res) => {
-    const propsFilePath = path.join(__dirname, '../../public/rte_contents');
+    const propsFilePath = path.join(__dirname, '../../../public/rte_contents');
     const contentsList = [];
     fs.readdirSync(propsFilePath).forEach((file) => {
         contentsList.push(file);

--- a/server/package.json
+++ b/server/package.json
@@ -25,7 +25,7 @@
   },
   "devDependencies": {
     "@types/chance": "^1.1.0",
-    "@types/express": "^5.0.1",
+    "@types/express": "^4.17.21",
     "@types/node": "^22.15.18",
     "typescript": "^5.8.3",
     "ts-node-dev": "^2.0.0"

--- a/server/yarn.lock
+++ b/server/yarn.lock
@@ -185,24 +185,25 @@
   dependencies:
     "@types/node" "*"
 
-"@types/express-serve-static-core@^5.0.0":
-  version "5.0.6"
-  resolved "https://registry.yarnpkg.com/@types/express-serve-static-core/-/express-serve-static-core-5.0.6.tgz#41fec4ea20e9c7b22f024ab88a95c6bb288f51b8"
-  integrity sha512-3xhRnjJPkULekpSzgtoNYYcTWgEZkp4myc+Saevii5JPnHNvHMRlBSHDbs7Bh1iPPoVTERHEZXyhyLbMEsExsA==
+"@types/express-serve-static-core@^4.17.33":
+  version "4.19.8"
+  resolved "https://registry.yarnpkg.com/@types/express-serve-static-core/-/express-serve-static-core-4.19.8.tgz#99b960322a4d576b239a640ab52ef191989b036f"
+  integrity sha512-02S5fmqeoKzVZCHPZid4b8JH2eM5HzQLZWN2FohQEy/0eXTq8VXZfSN6Pcr3F6N9R/vNrj7cpgbhjie6m/1tCA==
   dependencies:
     "@types/node" "*"
     "@types/qs" "*"
     "@types/range-parser" "*"
     "@types/send" "*"
 
-"@types/express@^5.0.1":
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/@types/express/-/express-5.0.1.tgz#138d741c6e5db8cc273bec5285cd6e9d0779fc9f"
-  integrity sha512-UZUw8vjpWFXuDnjFTh7/5c2TWDlQqeXHi6hcN7F2XSVT5P+WmUnnbFS3KA6Jnc6IsEqI2qCVu2bK0R0J4A8ZQQ==
+"@types/express@^4.17.21":
+  version "4.17.25"
+  resolved "https://registry.yarnpkg.com/@types/express/-/express-4.17.25.tgz#070c8c73a6fee6936d65c195dbbfb7da5026649b"
+  integrity sha512-dVd04UKsfpINUnK0yBoYHDF3xu7xVH4BuDotC/xGuycx4CgbP48X/KF/586bcObxT0HENHXEU8Nqtu6NR+eKhw==
   dependencies:
     "@types/body-parser" "*"
-    "@types/express-serve-static-core" "^5.0.0"
-    "@types/serve-static" "*"
+    "@types/express-serve-static-core" "^4.17.33"
+    "@types/qs" "*"
+    "@types/serve-static" "^1"
 
 "@types/http-errors@*":
   version "2.0.4"
@@ -251,14 +252,22 @@
     "@types/mime" "^1"
     "@types/node" "*"
 
-"@types/serve-static@*":
-  version "1.15.7"
-  resolved "https://registry.yarnpkg.com/@types/serve-static/-/serve-static-1.15.7.tgz#22174bbd74fb97fe303109738e9b5c2f3064f714"
-  integrity sha512-W8Ym+h8nhuRwaKPaDw34QUkwsGi6Rc4yYqvKFo5rm2FUEhCFbzVWrxXUxuKK8TASjWsysJY0nsmNCGhCOIsrOw==
+"@types/send@<1":
+  version "0.17.6"
+  resolved "https://registry.yarnpkg.com/@types/send/-/send-0.17.6.tgz#aeb5385be62ff58a52cd5459daa509ae91651d25"
+  integrity sha512-Uqt8rPBE8SY0RK8JB1EzVOIZ32uqy8HwdxCnoCOsYrvnswqmFZ/k+9Ikidlk/ImhsdvBsloHbAlewb2IEBV/Og==
+  dependencies:
+    "@types/mime" "^1"
+    "@types/node" "*"
+
+"@types/serve-static@^1":
+  version "1.15.10"
+  resolved "https://registry.yarnpkg.com/@types/serve-static/-/serve-static-1.15.10.tgz#768169145a778f8f5dfcb6360aead414a3994fee"
+  integrity sha512-tRs1dB+g8Itk72rlSI2ZrW6vZg0YrLI81iQSTkMmOqnqCaNr/8Ek4VwWcN5vZgCYWbg/JJSGBlUaYGAOP73qBw==
   dependencies:
     "@types/http-errors" "*"
     "@types/node" "*"
-    "@types/send" "*"
+    "@types/send" "<1"
 
 "@types/strip-bom@^3.0.0":
   version "3.0.0"


### PR DESCRIPTION
## Problem

Snyk SAST (rule **Javascript/Pt**, CWE-23): unsanitized input from the HTTP request body was used when resolving the path for `fs.readFileSync` in `server/api/RTEDemoApi.ts` (`POST /get-demo-doc-content`). The handler attempted a path check but did not **return** after rejecting unsafe paths, so execution could still reach `readFileSync` outside the intended `rte_contents` directory.

## Root cause

1. After a failed containment check, the handler called `res.send(null)` but did not **exit**, so the code could continue to `existsSync` / `readFileSync` for the same resolved path.
2. `startsWith(contentDir)` is a weaker pattern than resolving the base directory and using `path.relative` for containment.
3. The base path for `rte_contents` was inconsistent with the compiled server layout (`server/build/api` → repo `public/`), compared to `get-contents-list`.

## Fix

- Resolve `contentDir` with `path.resolve(__dirname, '../../../public/rte_contents')` and require `path.relative(contentDir, docContentPath)` to stay inside the directory (no `..` prefix, not absolute).
- **Return** immediately after `res.send(null)` when the path is invalid or the file is missing.
- Align `get-contents-list` with the same `public/rte_contents` base path.

**Files:** `server/api/RTEDemoApi.ts`

## How to verify

- `cd server && yarn build`
- Run the docs server as usual; call `POST /api/get-demo-doc-content` with a safe `name` (existing JSON under `public/rte_contents`) and confirm a 200 and JSON body.
- Retry with a traversal-style `name` (e.g. containing `..` segments); expect **null** response and **no** read outside `public/rte_contents`.

## Affected areas for QA

- **Affected:** Node **documentation server** only (`server/`), RTE demo API: `POST .../get-demo-doc-content` and `GET .../get-contents-list` if your tests hit those routes.
- **Not affected:** Published **`@epam/uui`** npm packages, app UI bundles, or component library behavior.
- **Smoke-test:** Docs site flows that load RTE demo content from `public/rte_contents` (if used in your environment).

## Jira

- [EPMSPRT-2552](https://jiraeu.epam.com/browse/EPMSPRT-2552)