### PR TITLE
fix(server): harden docs API path resolution for doc content

### DIFF
--- a/server/api/docs.ts
+++ b/server/api/docs.ts
@@ -5,12 +5,24 @@ import { isDevServer } from '../utils/envUtils';
 
 const router = express.Router();
 
+const docsContentDir = path.resolve(__dirname, '../../../public/docs/content');
+
+function resolveDocJsonPath(name: string | undefined): string | null {
+    if (name == null || typeof name !== 'string') {
+        return null;
+    }
+    const docContentPath = path.resolve(docsContentDir, `${name}.json`);
+    const relativeToContent = path.relative(docsContentDir, docContentPath);
+    if (relativeToContent.startsWith('..') || path.isAbsolute(relativeToContent)) {
+        return null;
+    }
+    return docContentPath;
+}
+
 router.post('/get-doc-content', (req: any, res: any) => {
-    const docContentPath = path.join(__dirname, '../../../', 'public/docs/content/', `${req.body.name}.json`);
+    const docContentPath = resolveDocJsonPath(req.body.name);
 
-    const isPathInsideDocsDirectory = docContentPath.includes(path.normalize('public/docs/content/'));
-
-    if (!isPathInsideDocsDirectory) {
+    if (!docContentPath) {
         return res.status(500).json({ error: "Doc with such file name doesn't exist" });
     }
 
@@ -26,11 +38,9 @@ router.post('/save-doc-content', (req: any, res: any) => {
     if (!isDevServer()) {
         return res.sendStatus(403);
     }
-    const docContentPath = path.join(__dirname, '../../../', 'public/docs/content/', `${req.body.name}.json`);
+    const docContentPath = resolveDocJsonPath(req.body.name);
 
-    const isPathInsideDocsDirectory = docContentPath.includes(path.normalize('public/docs/content/'));
-
-    if (!isPathInsideDocsDirectory) {
+    if (!docContentPath) {
         return res.status(500).json({ error: "File name isn't correct" });
     }
 


### PR DESCRIPTION
## Problem

Snyk SAST (**Javascript/Pt**, CWE-23): `req.body.name` from `POST /get-doc-content` and `POST /save-doc-content` was joined into a filesystem path for `readFileSync` / `writeFileSync` in `server/api/docs.ts`. The previous check (`includes('public/docs/content/')`) is not a reliable path containment guarantee.

## Root cause

User-controlled `name` was combined with the docs content directory using `path.join` and a substring check, which does not strictly prove the resolved path stays under the intended folder (and is weaker than `path.resolve` + `path.relative`).

## Fix

- Introduce `docsContentDir` via `path.resolve(__dirname, '../../../public/docs/content')`.
- Add `resolveDocJsonPath(name)` using `path.relative(docsContentDir, resolvedPath)` and reject when the relative path starts with `..` or is absolute; reject missing/non-string `name`.
- Use this helper for both **get-doc-content** and **save-doc-content** (dev-only write path unchanged aside from validation).

**Files:** `server/api/docs.ts`

## How to verify

- `cd server && yarn build`
- Run the docs server; call the doc content APIs with a normal doc id and with traversal-like `name` values; expect errors / no read outside `public/docs/content` for invalid names.

## Affected areas for QA

- **Affected:** Node **documentation server** (`server/`), routes that load/save doc JSON under `public/docs/content`.
- **Not affected:** Published **`@epam/uui`** packages or main library bundles.
- **Smoke-test:** Docs flows that load or save doc content via these APIs (if used in your setup).
