### PR TITLE
[Accordion] Add accessibility attributes to Accordion component

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -46,6 +46,7 @@
 * [FiltersPanel]: fixed filters being centered instead of left-aligned inside dropdown popups ([#3065](https://github.com/epam/UUI/issues/3065))
 * [DatePicker]: fixed value disappearing on blur when using formats with day name (e.g. `dddd, D MMMM YYYY`) ([#2560](https://github.com/epam/UUI/issues/2560))
 * [TimePicker]: fixed inconsistent time format between input field and dropdown - both now display hours and minutes with leading zeros (e.g., 01:00 AM) ([#2910](https://github.com/epam/UUI/issues/2910))
+* [Accordion]: added `role="button"`, `aria-expanded`, `aria-controls`, and `aria-labelledby` attributes so screen readers announce accordion header role, current state (collapsed/expanded), and state changes ([#1553](https://github.com/epam/UUI/issues/1553) Case 1).
 * [uui-core]: fix double decoding in `searchToQuery` helper ([#3058](https://github.com/epam/UUI/issues/3058)).
 * [Dropdown]: fixed stale closure in onClose and onValueChange callbacks ([#3011](https://github.com/epam/UUI/issues/3011))
 * [VerticalTabButton]: added `aria-selected` attribute so screen readers announce the selected tab state ([#2742](https://github.com/epam/UUI/issues/2742))

--- a/uui-components/src/layout/Accordion.tsx
+++ b/uui-components/src/layout/Accordion.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useId, useState } from 'react';
 import {
     IHasCX, IDisableable, uuiMod, IHasChildren, Icon, cx, IHasRawProps, IControlled,
 } from '@epam/uui-core';
@@ -35,6 +35,8 @@ const uuiAccordion = {
 const isEditableAccordionProps = (props: AccordionProps): props is EditableAccordionProps => (props as EditableAccordionProps).onValueChange !== undefined;
 
 export const Accordion = React.forwardRef<HTMLDivElement, AccordionProps>((props, ref) => {
+    const headerId = useId();
+    const panelId = useId();
     const [state, setState] = useState<AccordionState>({
         opened: isEditableAccordionProps(props) ? props.value : false,
     });
@@ -65,6 +67,11 @@ export const Accordion = React.forwardRef<HTMLDivElement, AccordionProps>((props
 
         return (
             <div
+                id={ headerId }
+                role="button"
+                aria-expanded={ isAccordionOpened }
+                aria-controls={ panelId }
+                aria-disabled={ props.isDisabled }
                 onKeyDown={ !props.isDisabled ? handleKeyDown : undefined }
                 onClick={ !props.isDisabled ? toggleAccordion : undefined }
                 tabIndex={ !props.isDisabled ? 0 : -1 }
@@ -85,7 +92,12 @@ export const Accordion = React.forwardRef<HTMLDivElement, AccordionProps>((props
     };
 
     const renderBody = () => (
-        <div className={ uuiAccordion.body } role="region">
+        <div
+            id={ panelId }
+            className={ uuiAccordion.body }
+            role="region"
+            aria-labelledby={ headerId }
+        >
             {props.children}
         </div>
     );
@@ -95,8 +107,6 @@ export const Accordion = React.forwardRef<HTMLDivElement, AccordionProps>((props
     return (
         <div
             ref={ ref }
-            aria-disabled={ props.isDisabled }
-            aria-expanded={ isAccordionOpened }
             className={ cx(
                 uuiAccordion.container,
                 css.container,

--- a/uui/components/layout/__tests__/__snapshots__/Accordion.test.tsx.snap
+++ b/uui/components/layout/__tests__/__snapshots__/Accordion.test.tsx.snap
@@ -3,11 +3,14 @@
 exports[`Accordion should be rendered correctly 1`] = `
 <DocumentFragment>
   <div
-    aria-expanded="false"
     class="uui-accordion-container container root mode-block"
   >
     <div
+      aria-controls="«r1»"
+      aria-expanded="false"
       class="uui-accordion-toggler"
+      id="«r0»"
+      role="button"
       tabindex="0"
     >
       <div
@@ -34,12 +37,15 @@ exports[`Accordion should be rendered correctly 1`] = `
 exports[`Accordion should be rendered correctly with props 1`] = `
 <DocumentFragment>
   <div
-    aria-disabled="true"
-    aria-expanded="false"
     class="uui-accordion-container container uui-disabled root mode-inline padding-18"
   >
     <div
+      aria-controls="«r3»"
+      aria-disabled="true"
+      aria-expanded="false"
       class="uui-accordion-toggler uui-disabled"
+      id="«r2»"
+      role="button"
       tabindex="-1"
     >
       <div

--- a/uui/components/tables/columnsConfigurationModal/__tests__/__snapshots__/ColumnsConfigurationModal.test.tsx.snap
+++ b/uui/components/tables/columnsConfigurationModal/__tests__/__snapshots__/ColumnsConfigurationModal.test.tsx.snap
@@ -131,11 +131,14 @@ exports[`ColumnsConfigurationModal should be rendered correctly 1`] = `
                 />
               </div>
               <div
-                aria-expanded="true"
                 class="uui-accordion-container container uui-opened subgroupAccordion"
               >
                 <div
+                  aria-controls="«r2»"
+                  aria-expanded="true"
                   class="uui-accordion-toggler uui-opened"
+                  id="«r1»"
+                  role="button"
                   tabindex="0"
                 >
                   <div
@@ -163,7 +166,9 @@ exports[`ColumnsConfigurationModal should be rendered correctly 1`] = `
                   </div>
                 </div>
                 <div
+                  aria-labelledby="«r1»"
                   class="uui-accordion-body"
+                  id="«r2»"
                   role="region"
                 >
                   <div
@@ -240,11 +245,14 @@ exports[`ColumnsConfigurationModal should be rendered correctly 1`] = `
                 class="root uui-flex-row hDivider"
               />
               <div
-                aria-expanded="true"
                 class="uui-accordion-container container uui-opened subgroupAccordion"
               >
                 <div
+                  aria-controls="«r5»"
+                  aria-expanded="true"
                   class="uui-accordion-toggler uui-opened"
+                  id="«r4»"
+                  role="button"
                   tabindex="0"
                 >
                   <div
@@ -272,7 +280,9 @@ exports[`ColumnsConfigurationModal should be rendered correctly 1`] = `
                   </div>
                 </div>
                 <div
+                  aria-labelledby="«r4»"
                   class="uui-accordion-body"
+                  id="«r5»"
                   role="region"
                 >
                   <div


### PR DESCRIPTION
* Enhanced Accordion component with `role="button"`, `aria-expanded`, `aria-controls`, and `aria-labelledby` attributes for improved screen reader support.
* Updated tests to reflect changes in the Accordion's accessibility features.


#### Issue link: [#1553](https://github.com/epam/UUI/issues/1553) Case №1