### PR TITLE
fix: keep notifications and recovery UI above deep modal stacks (#3095)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,8 @@
 * [RTE]: UUI block and mark components render through `PlateElement` / `PlateLeaf` (with `asChild` where a semantic tag is used) so custom Plate plugins that wrap nodes (e.g. `inject.aboveComponent`) compose correctly ([#3062](https://github.com/epam/UUI/issues/3062)).
 
 **What's Fixed**
+* [Snackbar] / [Notification]: snackbar container `z-index` now follows the layout layer stack (via `uuiLayout.getTopOverlayZIndex()`), capped by the previous default (100500), so notifications stay above modals when many overlays are open ([#3095](https://github.com/epam/UUI/issues/3095)).
+* [ErrorHandler]: recovery `ModalBlocker` uses `uuiLayout.getTopOverlayZIndex()` instead of a hardcoded `z-index` ([#3095](https://github.com/epam/UUI/issues/3095)).
 * [PickerModal]: fixed footer **Select all** staying available while searching — the control is now disabled until the search field is cleared.([#3083](https://github.com/epam/UUI/issues/3083))
 * [PresetsPanel]: custom `onCopyLink` is now invoked with `DataTableState` as declared, instead of receiving the click event
 * [DropdownContainer]: fixed `autoFocus` always being `true` even when `false` is passed through params

--- a/public/docs/docsGenOutput/docsGenOutput.json
+++ b/public/docs/docsGenOutput/docsGenOutput.json
@@ -21020,11 +21020,17 @@
     "typeValue": {
      "raw": "ILayoutContext",
      "print": [
-      "interface ILayoutContext {",
+      "interface ILayoutContext extends IBaseContext {",
       "    /** Returns the new layer. This layer will be higher than previous. */",
       "    getLayer(): LayoutLayer;",
       "    /** Removes provided layer from layers list */",
       "    releaseLayer(layer: LayoutLayer): void;",
+      "    /**",
+      "     * Returns a z-index for global overlays (e.g. snackbar, recovery modal) that should sit above all registered layout layers.",
+      "     * Uses max(layer z-index) + 1, but never below the legacy default (100500), so existing pages that rely on",
+      "     * that stacking level stay unchanged when the layer stack is small.",
+      "     */",
+      "    getTopOverlayZIndex(): number;",
       "    /**",
       "     * Returns portal root node.",
       "     * In simple cases it will be node with 'main' or 'root' id or document.body.",
@@ -21075,6 +21081,25 @@
       "required": true
      },
      {
+      "uid": "getTopOverlayZIndex",
+      "name": "getTopOverlayZIndex",
+      "comment": {
+       "raw": [
+        "Returns a z-index for global overlays (e.g. snackbar, recovery modal) that should sit above all registered layout layers.",
+        " Uses max(layer z-index) + 1, but never below the legacy default (100500), so existing pages that rely on",
+        " that stacking level stay unchanged when the layer stack is small."
+       ]
+      },
+      "typeValue": {
+       "raw": "() => number",
+       "html": "<span class=\"token punctuation\">(</span><span class=\"token punctuation\">)</span> <span class=\"token operator\">=></span> <span class=\"token builtin\">number</span>"
+      },
+      "editor": {
+       "type": "func"
+      },
+      "required": true
+     },
+     {
       "uid": "getPortalRoot",
       "name": "getPortalRoot",
       "comment": {
@@ -21109,6 +21134,60 @@
       "editor": {
        "type": "func"
       },
+      "required": true
+     },
+     {
+      "uid": "subscribe",
+      "name": "subscribe",
+      "comment": {
+       "raw": [
+        "Add your handler, which will be called on context updates"
+       ]
+      },
+      "typeValue": {
+       "raw": "(handler: (state: {}) => void) => void",
+       "html": "<span class=\"token punctuation\">(</span><span class=\"token function-variable function\">handler</span><span class=\"token operator\">:</span> <span class=\"token punctuation\">(</span>state<span class=\"token operator\">:</span> <span class=\"token punctuation\">{</span><span class=\"token punctuation\">}</span><span class=\"token punctuation\">)</span> <span class=\"token operator\">=></span> <span class=\"token keyword\">void</span><span class=\"token punctuation\">)</span> <span class=\"token operator\">=></span> <span class=\"token keyword\">void</span>"
+      },
+      "editor": {
+       "type": "func"
+      },
+      "from": "@epam/uui-core:IBaseContext",
+      "required": true
+     },
+     {
+      "uid": "unsubscribe",
+      "name": "unsubscribe",
+      "comment": {
+       "raw": [
+        "Unsubscribe from context updates"
+       ]
+      },
+      "typeValue": {
+       "raw": "(handler: (state: {}) => void) => void",
+       "html": "<span class=\"token punctuation\">(</span><span class=\"token function-variable function\">handler</span><span class=\"token operator\">:</span> <span class=\"token punctuation\">(</span>state<span class=\"token operator\">:</span> <span class=\"token punctuation\">{</span><span class=\"token punctuation\">}</span><span class=\"token punctuation\">)</span> <span class=\"token operator\">=></span> <span class=\"token keyword\">void</span><span class=\"token punctuation\">)</span> <span class=\"token operator\">=></span> <span class=\"token keyword\">void</span>"
+      },
+      "editor": {
+       "type": "func"
+      },
+      "from": "@epam/uui-core:IBaseContext",
+      "required": true
+     },
+     {
+      "uid": "destroyContext",
+      "name": "destroyContext",
+      "comment": {
+       "raw": [
+        "Manually destroy context and unsubscribe from all listeners"
+       ]
+      },
+      "typeValue": {
+       "raw": "() => void",
+       "html": "<span class=\"token punctuation\">(</span><span class=\"token punctuation\">)</span> <span class=\"token operator\">=></span> <span class=\"token keyword\">void</span>"
+      },
+      "editor": {
+       "type": "func"
+      },
+      "from": "@epam/uui-core:IBaseContext",
       "required": true
      }
     ],
@@ -63394,6 +63473,11 @@
       "interface SnackbarProps extends IHasCX, IHasRawProps<React.HTMLAttributes<HTMLDivElement>>, IHasForwardedRef<HTMLDivElement> {",
       "    closeIcon?: Icon;",
       "    notifications?: NotificationOperation[];",
+      "    /**",
+      "     * When set, applied as root `z-index` (e.g. from `uuiLayout.getTopOverlayZIndex()`).",
+      "     * If omitted, styles use the default from CSS.",
+      "     */",
+      "    zIndex?: number;",
       "}"
      ]
     },
@@ -63416,6 +63500,24 @@
       "typeValue": {
        "raw": "NotificationOperation[]",
        "html": "NotificationOperation<span class=\"token punctuation\">[</span><span class=\"token punctuation\">]</span>"
+      },
+      "required": false
+     },
+     {
+      "uid": "zIndex",
+      "name": "zIndex",
+      "comment": {
+       "raw": [
+        "When set, applied as root `z-index` (e.g. from `uuiLayout.getTopOverlayZIndex()`).",
+        " If omitted, styles use the default from CSS."
+       ]
+      },
+      "typeValue": {
+       "raw": "number",
+       "html": "<span class=\"token builtin\">number</span>"
+      },
+      "editor": {
+       "type": "number"
       },
       "required": false
      },
@@ -98802,6 +98904,25 @@
       "typeValue": {
        "raw": "NotificationOperation[]",
        "html": "NotificationOperation<span class=\"token punctuation\">[</span><span class=\"token punctuation\">]</span>"
+      },
+      "from": "@epam/uui-components:SnackbarProps",
+      "required": false
+     },
+     {
+      "uid": "zIndex",
+      "name": "zIndex",
+      "comment": {
+       "raw": [
+        "When set, applied as root `z-index` (e.g. from `uuiLayout.getTopOverlayZIndex()`).",
+        " If omitted, styles use the default from CSS."
+       ]
+      },
+      "typeValue": {
+       "raw": "number",
+       "html": "<span class=\"token builtin\">number</span>"
+      },
+      "editor": {
+       "type": "number"
       },
       "from": "@epam/uui-components:SnackbarProps",
       "required": false

--- a/uui-components/src/overlays/Snackbar.tsx
+++ b/uui-components/src/overlays/Snackbar.tsx
@@ -11,6 +11,10 @@ const offset = 30;
 export interface SnackbarProps extends IHasCX, IHasRawProps<React.HTMLAttributes<HTMLDivElement>>, IHasForwardedRef<HTMLDivElement> {
     closeIcon?: Icon;
     notifications?: NotificationOperation[];
+    /**
+     * When set, applied as root `z-index` (e.g. from `uuiLayout.getTopOverlayZIndex()`).
+     * If omitted, styles use the default from CSS.
+     */
     zIndex?: number;
 }
 

--- a/uui-components/src/overlays/Snackbar.tsx
+++ b/uui-components/src/overlays/Snackbar.tsx
@@ -11,6 +11,7 @@ const offset = 30;
 export interface SnackbarProps extends IHasCX, IHasRawProps<React.HTMLAttributes<HTMLDivElement>>, IHasForwardedRef<HTMLDivElement> {
     closeIcon?: Icon;
     notifications?: NotificationOperation[];
+    zIndex?: number;
 }
 
 const uuiSnackbar = {
@@ -140,8 +141,22 @@ export class Snackbar extends React.Component<SnackbarProps> {
 
         const botCenterItems = items.filter((item: NotificationOperation) => item.config.position === 'bot-center').map(this.renderItemWithOffset(botCenterOffset));
 
+        const rawProps = this.props.rawProps ?? {};
+        const { style: rawStyle, ...restRawProps } = rawProps;
+        const rootStyle = this.props.zIndex !== undefined || rawStyle
+            ? {
+                ...(rawStyle ?? {}),
+                ...(this.props.zIndex !== undefined ? { zIndex: this.props.zIndex } : {}),
+            }
+            : undefined;
+
         return (
-            <div className={ cx(css.container, uuiSnackbar.snackbar, this.props.cx) } { ...this.props.rawProps } ref={ this.props.forwardedRef }>
+            <div
+                className={ cx(css.container, uuiSnackbar.snackbar, this.props.cx) }
+                { ...restRawProps }
+                style={ rootStyle }
+                ref={ this.props.forwardedRef }
+            >
                 <TransitionGroup>
                     {botLeftItems}
                     {botRightItems}

--- a/uui-core/src/services/LayoutContext.ts
+++ b/uui-core/src/services/LayoutContext.ts
@@ -27,6 +27,9 @@ function getPortalRootById(id: string) {
     return root;
 }
 
+/** Legacy default top-overlay z-index (former snackbar value); used as a floor so existing apps keep the same stacking when few layers exist */
+export const LEGACY_TOP_OVERLAY_Z_INDEX = 100500;
+
 function maxBy<T>(arr: T[], getMax: (item: T) => number) {
     let maxItem: T;
     arr.forEach((value) => {
@@ -83,5 +86,13 @@ export class LayoutContext extends BaseContext {
             id = layer.id;
         }
         this.layers = this.layers.filter((l) => l.id !== id);
+    }
+
+    public getTopOverlayZIndex(): number {
+        if (this.layers.length === 0) {
+            return LEGACY_TOP_OVERLAY_Z_INDEX;
+        }
+        const maxZ = Math.max(...this.layers.map((l) => l.zIndex));
+        return Math.max(LEGACY_TOP_OVERLAY_Z_INDEX, maxZ + 1);
     }
 }

--- a/uui-core/src/services/__tests__/LayoutContext.test.ts
+++ b/uui-core/src/services/__tests__/LayoutContext.test.ts
@@ -18,4 +18,27 @@ describe('LayoutContext', () => {
         context.releaseLayer(layer1);
         expect(context.layers.length).toBe(1);
     });
+
+    describe('getTopOverlayZIndex', () => {
+        it('returns legacy default when there are no layers', () => {
+            const context = new LayoutContext();
+            expect(context.getTopOverlayZIndex()).toBe(100500);
+        });
+
+        it('returns legacy default when max layer z-index is below legacy floor', () => {
+            const context = new LayoutContext();
+            context.getLayer(); // zIndex 2000
+            expect(context.getTopOverlayZIndex()).toBe(100500);
+        });
+
+        it('returns max z-index + 1 when above legacy floor', () => {
+            const context = new LayoutContext();
+            for (let i = 0; i < 986; i++) {
+                context.getLayer();
+            }
+            const top = context.layers[context.layers.length - 1];
+            expect(top.zIndex).toBeGreaterThanOrEqual(100500);
+            expect(context.getTopOverlayZIndex()).toBe(top.zIndex + 1);
+        });
+    });
 });

--- a/uui-core/src/services/dnd/__tests__/DragGhost.test.tsx
+++ b/uui-core/src/services/dnd/__tests__/DragGhost.test.tsx
@@ -27,6 +27,7 @@ describe('DragGhost', () => {
     let mockLayoutContext: {
         getLayer: jest.Mock;
         releaseLayer: jest.Mock;
+        getTopOverlayZIndex: jest.Mock;
         getPortalRoot?: ILayoutContext['getPortalRoot'];
         getPortalRootId?: ILayoutContext['getPortalRootId'];
     };
@@ -39,6 +40,7 @@ describe('DragGhost', () => {
         mockLayoutContext = {
             getLayer: jest.fn(() => ({ zIndex: 1000 })),
             releaseLayer: jest.fn(),
+            getTopOverlayZIndex: jest.fn(() => 100500),
         };
 
         mockUuiContext = {

--- a/uui-core/src/types/contexts.ts
+++ b/uui-core/src/types/contexts.ts
@@ -38,11 +38,17 @@ export interface INotificationContext extends IBaseContext {
     clearAll(): void;
 }
 
-export interface ILayoutContext {
+export interface ILayoutContext extends IBaseContext {
     /** Returns the new layer. This layer will be higher than previous. */
     getLayer(): LayoutLayer;
     /** Removes provided layer from layers list */
     releaseLayer(layer: LayoutLayer): void;
+    /**
+     * Returns a z-index for global overlays (e.g. snackbar, recovery modal) that should sit above all registered layout layers.
+     * Uses max(layer z-index) + 1, but never below the legacy default (100500), so existing pages that rely on
+     * that stacking level stay unchanged when the layer stack is small.
+     */
+    getTopOverlayZIndex(): number;
     /**
      * Returns portal root node.
      * In simple cases it will be node with 'main' or 'root' id or document.body.

--- a/uui/components/errors/ErrorHandler.tsx
+++ b/uui/components/errors/ErrorHandler.tsx
@@ -24,7 +24,7 @@ export interface ErrorHandlerProps extends IHasCX, IHasChildren {
 }
 
 export function ErrorHandler(props: ErrorHandlerProps) {
-    const { uuiNotifications, uuiModals, uuiApi } = useUuiContext();
+    const { uuiNotifications, uuiModals, uuiApi, uuiLayout } = useUuiContext();
     const { errorType, errorInfo } = useUuiError({
         getErrorInfo: props.getErrorInfo,
         options: { errorConfig: getErrorPageConfig(), recoveryConfig: getRecoveryMessageConfig() },
@@ -52,7 +52,14 @@ export function ErrorHandler(props: ErrorHandlerProps) {
         const { title, subtitle } = errorInform;
 
         return (
-            <ModalBlocker key="recovery-blocker" cx={ css.modalBlocker } isActive={ true } zIndex={ 100500 } success={ () => {} } abort={ () => {} }>
+            <ModalBlocker
+                key="recovery-blocker"
+                cx={ css.modalBlocker }
+                isActive={ true }
+                zIndex={ uuiLayout.getTopOverlayZIndex() }
+                success={ () => {} }
+                abort={ () => {} }
+            >
                 <ModalWindow>
                     <ModalHeader borderBottom title={ title } />
                     <Spinner cx={ css.recoverySpinner } />

--- a/uui/components/overlays/Snackbar.tsx
+++ b/uui/components/overlays/Snackbar.tsx
@@ -25,7 +25,13 @@ export function Snackbar(props: SnackbarProps) {
         items = [clearOperation].concat(items);
     }
 
-    return <UuiSnackbar forwardedRef={ props.forwardedRef } notifications={ items } />;
+    return (
+        <UuiSnackbar
+            forwardedRef={ props.forwardedRef }
+            notifications={ items }
+            zIndex={ uuiCtx.uuiLayout.getTopOverlayZIndex() }
+        />
+    );
 }
 
 /**


### PR DESCRIPTION
## Summary

- Fixes [#3095](https://github.com/epam/UUI/issues/3095): with many stacked layers (e.g. large grids of tooltips/buttons), modal `z-index` could exceed the old fixed snackbar value (100500), so notifications appeared behind the modal.
- Snackbar / notification host stacking now follows `uuiLayout.getTopOverlayZIndex()`, keeping the previous value as a minimum so existing apps do not regress.
- `LayoutContext` exposes a stable top-overlay index based on registered layers; `ErrorHandler` recovery `ModalBlocker` uses the same source instead of a hardcoded `z-index`.

#### Issue link:
[3095](https://github.com/epam/UUI/issues/3095)
