### PR TITLE
Add support of portal loop lookups when they are nested >1 level in s…

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,7 @@
-# 6.x.x - xx.xx.2026
+# 6.5.1 - XX.XX.2026
+
+**What's Fixed**
+* [PortalRoot] / [uui-core]: fixed portal root lookup when nested more than one level inside Shadow DOM — shadow hosts now store comma-separated portal IDs along the hierarchy, and `LayoutContext` discovers the correct root across nested shadow trees.
 
 
 # 6.5.0 - 26.05.2026

--- a/uui-components/src/overlays/PortalRoot.tsx
+++ b/uui-components/src/overlays/PortalRoot.tsx
@@ -1,27 +1,6 @@
 import React from 'react';
 import { isClientSide, useUuiContext } from '@epam/uui-core';
-
-/**
- * Adds a marker to the shadow host which helps the LayoutContext
- * to find this portal root element if it's located under shadow DOM.
- *
- * @param node
- * @param id
- */
-function makePortalRootDiscoverable(node: HTMLElement, id: string): () => void {
-    if (node) {
-        const root = node.getRootNode();
-        if (root instanceof ShadowRoot) {
-            const hostElem = root.host;
-            const name = 'data-shadow-host-id';
-            hostElem.setAttribute(name, id);
-            return () => {
-                hostElem.removeAttribute(name);
-            };
-        }
-    }
-    return () => {};
-}
+import { makePortalRootDiscoverable } from './PortalRootHelpers';
 
 export function PortalRoot() {
     const { uuiLayout } = useUuiContext();

--- a/uui-components/src/overlays/PortalRootHelpers.ts
+++ b/uui-components/src/overlays/PortalRootHelpers.ts
@@ -1,0 +1,62 @@
+/**
+ * Name of the data attribute which is used by UUI lib to store IDs of any nested UUI Portal roots.
+ */
+const DATA_ATTR_FOR_PORTAL_ROOT_IDS = 'data-shadow-host-id';
+const LIST_SEPARATOR = ',';
+
+/**
+ * Adds a marker to the shadow host which helps the LayoutContext
+ * to find this portal root element if it's located under shadow DOM.
+ *
+ * @see uui-core/src/services/LayoutContextHelpers.ts
+ *
+ * @param node
+ * @param id
+ */
+export function makePortalRootDiscoverable(node: HTMLElement, id: string): () => void {
+    if (node) {
+        const destructors: (() => void)[] = [];
+        for (const sr of getAllParentShadowRoots(node)) {
+            const host = sr.host;
+            updateHostDataAttribute({ host, id, mode: 'add' });
+            destructors.push(() => {
+                updateHostDataAttribute({ host, id, mode: 'remove' });
+            });
+        }
+        return () => {
+            destructors.forEach((d) => {
+                try {
+                    d();
+                } catch (err) {
+                    console.error(err);
+                }
+            });
+        };
+    }
+    return () => {};
+}
+
+function* getAllParentShadowRoots(node: HTMLElement) {
+    let next = node.getRootNode();
+    while (next instanceof ShadowRoot) {
+        yield next;
+        next = next.host.getRootNode();
+    }
+}
+
+function updateHostDataAttribute(params: { host: Element, mode: 'add' | 'remove', id: string }) {
+    const { host, id, mode } = params;
+    const prev = host.getAttribute(DATA_ATTR_FOR_PORTAL_ROOT_IDS);
+    const ids = prev ? new Set(prev.split(LIST_SEPARATOR)) : new Set<string>();
+    if (mode === 'add') {
+        ids.add(id);
+    } else if (mode === 'remove') {
+        ids.delete(id);
+    }
+    const next = [...ids].join(LIST_SEPARATOR);
+    if (next) {
+        host.setAttribute(DATA_ATTR_FOR_PORTAL_ROOT_IDS, next);
+    } else {
+        host.removeAttribute(DATA_ATTR_FOR_PORTAL_ROOT_IDS);
+    }
+}

--- a/uui-components/src/overlays/__tests__/PortalRootHelpers.test.ts
+++ b/uui-components/src/overlays/__tests__/PortalRootHelpers.test.ts
@@ -1,0 +1,101 @@
+import { makePortalRootDiscoverable } from '../PortalRootHelpers';
+
+const DATA_ATTR_FOR_PORTAL_ROOT_IDS = 'data-shadow-host-id';
+
+describe('makePortalRootDiscoverable', () => {
+    afterEach(() => {
+        document.body.innerHTML = '';
+    });
+
+    test('returns noop cleanup when node is falsy', () => {
+        const cleanup = makePortalRootDiscoverable(null as unknown as HTMLElement, 'portal-id');
+
+        expect(cleanup).toEqual(expect.any(Function));
+        expect(() => cleanup()).not.toThrow();
+    });
+
+    test('does not set attribute when node is not inside shadow DOM', () => {
+        const node = document.createElement('div');
+        document.body.appendChild(node);
+
+        const cleanup = makePortalRootDiscoverable(node, 'portal-id');
+
+        expect(document.body.getAttribute(DATA_ATTR_FOR_PORTAL_ROOT_IDS)).toBeNull();
+        cleanup();
+    });
+
+    test('sets portal id on shadow host when node is inside shadow DOM', () => {
+        const host = document.createElement('div');
+        const shadowRoot = host.attachShadow({ mode: 'open' });
+        const node = document.createElement('div');
+        shadowRoot.appendChild(node);
+        document.body.appendChild(host);
+
+        const cleanup = makePortalRootDiscoverable(node, 'portal-id');
+
+        expect(host.getAttribute(DATA_ATTR_FOR_PORTAL_ROOT_IDS)).toBe('portal-id');
+
+        cleanup();
+
+        expect(host.hasAttribute(DATA_ATTR_FOR_PORTAL_ROOT_IDS)).toBe(false);
+    });
+
+    test('appends portal id to existing shadow host ids', () => {
+        const host = document.createElement('div');
+        host.setAttribute(DATA_ATTR_FOR_PORTAL_ROOT_IDS, 'existing-id');
+        const shadowRoot = host.attachShadow({ mode: 'open' });
+        const node = document.createElement('div');
+        shadowRoot.appendChild(node);
+        document.body.appendChild(host);
+
+        const cleanup = makePortalRootDiscoverable(node, 'portal-id');
+
+        expect(host.getAttribute(DATA_ATTR_FOR_PORTAL_ROOT_IDS)).toBe('existing-id,portal-id');
+
+        cleanup();
+
+        expect(host.getAttribute(DATA_ATTR_FOR_PORTAL_ROOT_IDS)).toBe('existing-id');
+    });
+
+    test('sets portal id on all nested shadow hosts', () => {
+        const outerHost = document.createElement('div');
+        const outerShadow = outerHost.attachShadow({ mode: 'open' });
+        const innerHost = document.createElement('div');
+        outerShadow.appendChild(innerHost);
+        const innerShadow = innerHost.attachShadow({ mode: 'open' });
+        const node = document.createElement('div');
+        innerShadow.appendChild(node);
+        document.body.appendChild(outerHost);
+
+        const cleanup = makePortalRootDiscoverable(node, 'portal-id');
+
+        expect(outerHost.getAttribute(DATA_ATTR_FOR_PORTAL_ROOT_IDS)).toBe('portal-id');
+        expect(innerHost.getAttribute(DATA_ATTR_FOR_PORTAL_ROOT_IDS)).toBe('portal-id');
+
+        cleanup();
+
+        expect(outerHost.hasAttribute(DATA_ATTR_FOR_PORTAL_ROOT_IDS)).toBe(false);
+        expect(innerHost.hasAttribute(DATA_ATTR_FOR_PORTAL_ROOT_IDS)).toBe(false);
+    });
+
+    test('logs errors thrown during cleanup without rethrowing', () => {
+        const host = document.createElement('div');
+        const shadowRoot = host.attachShadow({ mode: 'open' });
+        const node = document.createElement('div');
+        shadowRoot.appendChild(node);
+        document.body.appendChild(host);
+
+        const cleanup = makePortalRootDiscoverable(node, 'portal-id');
+        const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+        jest.spyOn(host, 'removeAttribute').mockImplementation(() => {
+            throw new Error('cleanup failed');
+        });
+
+        expect(() => cleanup()).not.toThrow();
+        expect(consoleErrorSpy).toHaveBeenCalled();
+
+        consoleErrorSpy.mockRestore();
+        jest.restoreAllMocks();
+    });
+});

--- a/uui-core/src/services/LayoutContext.ts
+++ b/uui-core/src/services/LayoutContext.ts
@@ -1,5 +1,6 @@
 import { BaseContext } from './BaseContext';
 import { isClientSide } from '../helpers/ssr';
+import { discoverPortalRootById } from './LayoutContextHelpers';
 
 export interface LayoutLayer {
     /** ID of the layer */
@@ -11,20 +12,6 @@ export interface LayoutLayer {
 }
 function genUniqueId() {
     return [Math.random(), Math.random()].reduce((acc, n) => (acc + n.toString(36).substring(2)), '');
-}
-
-function getPortalRootById(id: string) {
-    let root = document.getElementById(id);
-    if (!root) {
-        /*
-         * document.getElementById doesn't find elements by ID if they are located in shadow DOM.
-         * so, as a fallback, we try to find shadow host by attribute name like this: [data-<id>]
-         * and after that - try to find by id in the shadow root.
-         */
-        const shadow = document.querySelector(`[data-shadow-host-id="${id}"]`);
-        root = shadow?.shadowRoot?.getElementById(id);
-    }
-    return root;
 }
 
 /** Legacy default top-overlay z-index (former snackbar value); used as a floor so existing apps keep the same stacking when few layers exist */
@@ -56,7 +43,7 @@ export class LayoutContext extends BaseContext {
          * TODO: we should remove this part: document.getElementById('main') || document.getElementById('root')
          */
         if (isClientSide) {
-            return getPortalRootById(this.portalRootId) || document.getElementById('main') || document.getElementById('root') || document.body;
+            return discoverPortalRootById(this.portalRootId) || document.getElementById('main') || document.getElementById('root') || document.body;
         }
     }
 

--- a/uui-core/src/services/LayoutContextHelpers.ts
+++ b/uui-core/src/services/LayoutContextHelpers.ts
@@ -1,0 +1,45 @@
+/**
+ * Name of the data attribute which is used by UUI lib to store IDs of any nested UUI Portal roots.
+ */
+const DATA_ATTR_FOR_PORTAL_ROOT_IDS = 'data-shadow-host-id';
+const LIST_SEPARATOR = ',';
+
+type PortalSearchRoot = Document | ShadowRoot;
+
+function findPortalInMarkedShadowHosts(root: PortalSearchRoot, id: string): HTMLElement | null {
+    const hosts = root.querySelectorAll(`[${DATA_ATTR_FOR_PORTAL_ROOT_IDS}*="${id}"]`);
+
+    for (let i = 0; i < hosts.length; i++) {
+        const host = hosts[i];
+        const attr = host.getAttribute(DATA_ATTR_FOR_PORTAL_ROOT_IDS);
+        if (!attr || !attr.split(LIST_SEPARATOR).includes(id)) {
+            continue;
+        }
+
+        const { shadowRoot } = host;
+        if (!shadowRoot) {
+            continue;
+        }
+
+        const direct = shadowRoot.getElementById(id);
+        if (direct) {
+            return direct;
+        }
+
+        const nested = findPortalInMarkedShadowHosts(shadowRoot, id);
+        if (nested) {
+            return nested;
+        }
+    }
+
+    return null;
+}
+
+export function discoverPortalRootById(id: string): HTMLElement | null {
+    const root = document.getElementById(id);
+    if (root) {
+        return root;
+    }
+
+    return findPortalInMarkedShadowHosts(document, id);
+}

--- a/uui-core/src/services/__tests__/LayoutContextHelpers.test.ts
+++ b/uui-core/src/services/__tests__/LayoutContextHelpers.test.ts
@@ -1,0 +1,115 @@
+import { discoverPortalRootById } from '../LayoutContextHelpers';
+
+const DATA_ATTR_FOR_PORTAL_ROOT_IDS = 'data-shadow-host-id';
+
+describe('discoverPortalRootById', () => {
+    afterEach(() => {
+        document.body.innerHTML = '';
+    });
+
+    test('returns element when found in document by id', () => {
+        const portalRoot = document.createElement('div');
+        portalRoot.id = 'portal-id';
+        document.body.appendChild(portalRoot);
+
+        expect(discoverPortalRootById('portal-id')).toBe(portalRoot);
+    });
+
+    test('returns null when element is not found', () => {
+        expect(discoverPortalRootById('missing-id')).toBeNull();
+    });
+
+    test('returns element from shadow DOM when shadow host is marked with portal id', () => {
+        const host = document.createElement('div');
+        host.setAttribute(DATA_ATTR_FOR_PORTAL_ROOT_IDS, 'portal-id');
+        const shadowRoot = host.attachShadow({ mode: 'open' });
+        const portalRoot = document.createElement('div');
+        portalRoot.id = 'portal-id';
+        shadowRoot.appendChild(portalRoot);
+        document.body.appendChild(host);
+
+        expect(discoverPortalRootById('portal-id')).toBe(portalRoot);
+    });
+
+    test('returns element from shadow DOM when portal id is among multiple host ids', () => {
+        const host = document.createElement('div');
+        host.setAttribute(DATA_ATTR_FOR_PORTAL_ROOT_IDS, 'other-id,portal-id,another-id');
+        const shadowRoot = host.attachShadow({ mode: 'open' });
+        const portalRoot = document.createElement('div');
+        portalRoot.id = 'portal-id';
+        shadowRoot.appendChild(portalRoot);
+        document.body.appendChild(host);
+
+        expect(discoverPortalRootById('portal-id')).toBe(portalRoot);
+    });
+
+    test('does not match portal id by substring in shadow host attribute', () => {
+        const host = document.createElement('div');
+        host.setAttribute(DATA_ATTR_FOR_PORTAL_ROOT_IDS, 'portal-id-extended');
+        const shadowRoot = host.attachShadow({ mode: 'open' });
+        const portalRoot = document.createElement('div');
+        portalRoot.id = 'portal-id';
+        shadowRoot.appendChild(portalRoot);
+        document.body.appendChild(host);
+
+        expect(discoverPortalRootById('portal-id')).toBeNull();
+    });
+
+    test('returns null when shadow host is marked but portal root is missing in shadow DOM', () => {
+        const host = document.createElement('div');
+        host.setAttribute(DATA_ATTR_FOR_PORTAL_ROOT_IDS, 'portal-id');
+        host.attachShadow({ mode: 'open' });
+        document.body.appendChild(host);
+
+        expect(discoverPortalRootById('portal-id')).toBeNull();
+    });
+
+    test('returns element from nested shadow DOM when shadow hosts are marked', () => {
+        const outerHost = document.createElement('div');
+        outerHost.setAttribute(DATA_ATTR_FOR_PORTAL_ROOT_IDS, 'portal-id');
+        const outerShadow = outerHost.attachShadow({ mode: 'open' });
+        const innerHost = document.createElement('div');
+        innerHost.setAttribute(DATA_ATTR_FOR_PORTAL_ROOT_IDS, 'portal-id');
+        outerShadow.appendChild(innerHost);
+        const innerShadow = innerHost.attachShadow({ mode: 'open' });
+        const portalRoot = document.createElement('div');
+        portalRoot.id = 'portal-id';
+        innerShadow.appendChild(portalRoot);
+        document.body.appendChild(outerHost);
+
+        expect(discoverPortalRootById('portal-id')).toBe(portalRoot);
+    });
+
+    test('skips marked shadow host without portal and checks next host', () => {
+        const hostWithoutPortal = document.createElement('div');
+        hostWithoutPortal.setAttribute(DATA_ATTR_FOR_PORTAL_ROOT_IDS, 'portal-id');
+        hostWithoutPortal.attachShadow({ mode: 'open' });
+        document.body.appendChild(hostWithoutPortal);
+
+        const hostWithPortal = document.createElement('div');
+        hostWithPortal.setAttribute(DATA_ATTR_FOR_PORTAL_ROOT_IDS, 'portal-id');
+        const shadowRoot = hostWithPortal.attachShadow({ mode: 'open' });
+        const portalRoot = document.createElement('div');
+        portalRoot.id = 'portal-id';
+        shadowRoot.appendChild(portalRoot);
+        document.body.appendChild(hostWithPortal);
+
+        expect(discoverPortalRootById('portal-id')).toBe(portalRoot);
+    });
+
+    test('prefers document element over shadow DOM lookup', () => {
+        const documentPortalRoot = document.createElement('div');
+        documentPortalRoot.id = 'portal-id';
+        document.body.appendChild(documentPortalRoot);
+
+        const host = document.createElement('div');
+        host.setAttribute(DATA_ATTR_FOR_PORTAL_ROOT_IDS, 'portal-id');
+        const shadowRoot = host.attachShadow({ mode: 'open' });
+        const shadowPortalRoot = document.createElement('div');
+        shadowPortalRoot.id = 'portal-id';
+        shadowRoot.appendChild(shadowPortalRoot);
+        document.body.appendChild(host);
+
+        expect(discoverPortalRootById('portal-id')).toBe(documentPortalRoot);
+    });
+});


### PR DESCRIPTION
…hadow dom hierarchy. the idea:

1) Existing data attr. is used for backwards compatibility: [data-shadow-host-id] 2) When same shadow DOM contains more than 1 portal root - the value of this attr. contain all the IDs separated by comma. 3) When portal root is nested under the hierarchy of shadow roots - the ID of this portal is added to all relevant nodes in this hierarchy. They are properly cleaned up when the portal root is destroyed.

<!-- **Before submitting your PR, ensure that you made the following:**

- Linked the issue(if exists)
- Lint and unit tests pass locally with my changes
- Changelog is updated or not needed
- Documentation is updated/provided or not needed
- Property explorer is updated/provided or not needed
- TSDoc comments for public interfaces is updated/provided or not needed 
 -->

### Description:


#### Issue link:

#### QA notes: 