### PR TITLE
Fix/3690 springboot add 404

### DIFF
--- a/server/app.ts
+++ b/server/app.ts
@@ -9,7 +9,6 @@ import fileUpload from 'express-fileupload';
 import api from './api';
 import fileUploadApi from './api/fileUpload';
 import { isDevServer } from './utils/envUtils';
-import actuator from 'express-actuator';
 import staticMiddleware from './static';
 import { getCspHeaderValue } from './utils/cspUtil';
 
@@ -47,7 +46,11 @@ app.use((req, res, next) => {
     next();
 });
 
-app.use(actuator({ basePath: '/actuator' }));
+// Expose only the health endpoint publicly. /actuator/metrics and /actuator/info
+// reveal runtime details and must not be accessible on production hosts (EPMSPRT-3690).
+app.get('/actuator/health', (_req, res) => {
+    res.status(200).json({ status: 'UP' });
+});
 
 app.use('/upload', fileUploadApi);
 app.use('/api', api);

--- a/server/app.ts
+++ b/server/app.ts
@@ -51,6 +51,9 @@ app.use((req, res, next) => {
 app.get('/actuator/health', (_req, res) => {
     res.status(200).json({ status: 'UP' });
 });
+app.use('/actuator', (_req, res) => {
+    res.sendStatus(404);
+});
 
 app.use('/upload', fileUploadApi);
 app.use('/api', api);

--- a/server/package.json
+++ b/server/package.json
@@ -14,7 +14,6 @@
     "debug": "~2.6.9",
     "ejs": "3.1.7",
     "express": "~4.16.1",
-    "express-actuator": "1.8.4",
     "express-fileupload": "^1.1.6",
     "lodash": "4.17.21",
     "morgan": "1.10.0",


### PR DESCRIPTION
### Description:
Added explicit 404 handling for all other /actuator/* paths so the production SPA catch-all (app.get('*')) no longer returns 200 + index.html for /actuator/metrics and /actuator/info

#### Affected files:
server/app.ts — actuator routing