### PR TITLE
fix: radio-button shifts out of center (zoom related)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,7 @@
 * [LazyDataSource] / [AsyncDataSource] / [uui-core]: fixed stale response being applied when a filter or search change triggers a new request while a previous one is still in-flight. `isOutdated` now uses `signal.aborted` — the same `AbortSignal` passed to the API — so superseded results are reliably discarded. Previous requests are aborted via `AbortController` when `abortInProgress` is set ([#3099](https://github.com/epam/UUI/issues/3099)).
 * [ApiContext] / [uui-core]: fixed "Network connection down" modal appearing after an intentional request abort (e.g. on filter or search change). The `AbortError` handler no longer falls through to the `connection-lost` recovery path.
 * [ApiContext] / [uui-core]: fixed new requests being blocked after a request abort. The API context no longer transitions to `error` status on `AbortError` — abort is an intentional cancellation, not a network failure, so subsequent requests are dispatched normally.
+* [RadioInput]: fixed the checked-state dot rendering off-center at fractional browser/OS zoom levels.
 
 
 # 6.5.1 - 19.06.2026

--- a/uui/components/inputs/RadioInput.module.scss
+++ b/uui/components/inputs/RadioInput.module.scss
@@ -55,12 +55,11 @@
             :global(.uui-icon) {
                 fill: var(--uui-radio_input-fill-checked);
                 position: absolute;
-                top: calc(0px - var(--uui-radio_input-border-width));
-                left: calc(0px - var(--uui-radio_input-border-width));
+                inset: calc((var(--uui-radio_input-size) - var(--uui-radio_input-bullet-size)) / 2);
 
                 svg {
-                    height: var(--uui-radio_input-bullet-size);
-                    width: var(--uui-radio_input-bullet-size);
+                    height: 100%;
+                    width: 100%;
                 }
             }
         }


### PR DESCRIPTION
<!-- **Before submitting your PR, ensure that you made the following:**

- Linked the issue(if exists)
- Lint and unit tests pass locally with my changes
- Changelog is updated or not needed
- Documentation is updated/provided or not needed
- Property explorer is updated/provided or not needed
- TSDoc comments for public interfaces is updated/provided or not needed 
 -->

### Description:

Cause: The dot's position and size were computed via two separate calc() expressions, which could round to different device pixels independently.

Fix: RadioInput.module.scss now resolves the dot's box with a single inset calc(), and the inner svg inherits that box at 100% instead of re-resolving the size variable — one rounding pass instead of two.

#### Issue link:

#### QA notes: 