### PR TITLE
feat: add decline action to the unsaved-changes notification

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,6 @@
 # 6.5.xx - xx.xx.2026
 **What's New**
+* [Form] / [useForm]: added a **Decline** action to the unsaved-changes notification so drafts can be discarded and removed from storage ([#3025](https://github.com/epam/UUI/issues/3025)).
 * Remove support of deprecated `@epam/cra-template-uui` package. Create React App has been [officially deprecated](https://react.dev/blog/2025/02/14/sunsetting-create-react-app) by the React team. The package will no longer receive new updates or releases. Use the [Vite](https://github.com/epam/UUI/tree/main/templates/uui-vite-template) or [Next.js](https://github.com/epam/UUI/tree/main/templates/uui-nextjs-template) templates instead.
 
 **What's Fixed**

--- a/epam-promo/i18n.ts
+++ b/epam-promo/i18n.ts
@@ -28,7 +28,8 @@ export const i18n = {
     form: {
         notifications: {
             actionButtonCaption: 'Restore',
-            unsavedChangesMessage: 'You have unsaved changes. Click Restore button if you would like to recover the data',
+            declineButtonCaption: 'Decline',
+            unsavedChangesMessage: 'You have unsaved changes. Click Restore to recover the data, or Decline to discard it',
         },
         modals: {
             beforeLeaveMessage: 'Your data may be lost. Do you want to save data?',

--- a/loveship/i18n.ts
+++ b/loveship/i18n.ts
@@ -9,7 +9,8 @@ export const i18n = {
     form: {
         notifications: {
             actionButtonCaption: 'Restore',
-            unsavedChangesMessage: 'You have unsaved changes. Click Restore button if you would like to recover the data',
+            declineButtonCaption: 'Decline',
+            unsavedChangesMessage: 'You have unsaved changes. Click Restore to recover the data, or Decline to discard it',
         },
         modals: {
             beforeLeaveMessage: 'Your data may be lost. Do you want to save data?',

--- a/public/docs/docsGenOutput/docsGenOutput.json
+++ b/public/docs/docsGenOutput/docsGenOutput.json
@@ -1,5 +1,5 @@
 {
- "version": "6.4.4",
+ "version": "6.5.2",
  "docsGenTypes": {
   "@epam/uui-core:AcceptDropParams": {
    "summary": {
@@ -14793,11 +14793,14 @@
       "    beforeLeave?: ((nextLocation: Link, currentLocation: Link) => Promise<boolean | 'remain'>) | null;",
       "    /**",
       "     * Used to restore unsaved user edits from the last session (usually to localstorage, via uuiUserSettings context)",
-      "     * If unsaved changes are detected, this callback is called. If it is resolved - the form restores unsaved edits.",
-      "     * The common use-case is to show a modal with \"You have unsaved changes, restore them?\" dialog",
+      "     * If unsaved changes are detected, this callback is called.",
+      "     * If it is resolved with a truthy value or void - the form restores unsaved edits.",
+      "     * If it is resolved with false - unsaved edits are discarded and removed from storage.",
+      "     * If it is rejected - unsaved edits are kept in storage.",
+      "     * The common use-case is to show a notification with \"You have unsaved changes, restore them?\" dialog",
       "     * Skins usually implement this as default behavior. To prevent it, you can pass null to this prop to override it.",
       "     */",
-      "    loadUnsavedChanges?: () => Promise<void>;",
+      "    loadUnsavedChanges?: () => Promise<void | boolean>;",
       "    /**",
       "     * Called after successful save.",
       "     * @param state Saved state",
@@ -14919,14 +14922,17 @@
       "comment": {
        "raw": [
         "Used to restore unsaved user edits from the last session (usually to localstorage, via uuiUserSettings context)",
-        " If unsaved changes are detected, this callback is called. If it is resolved - the form restores unsaved edits.",
-        " The common use-case is to show a modal with \"You have unsaved changes, restore them?\" dialog",
+        " If unsaved changes are detected, this callback is called.",
+        " If it is resolved with a truthy value or void - the form restores unsaved edits.",
+        " If it is resolved with false - unsaved edits are discarded and removed from storage.",
+        " If it is rejected - unsaved edits are kept in storage.",
+        " The common use-case is to show a notification with \"You have unsaved changes, restore them?\" dialog",
         " Skins usually implement this as default behavior. To prevent it, you can pass null to this prop to override it."
        ]
       },
       "typeValue": {
-       "raw": "() => Promise<void>",
-       "html": "<span class=\"token punctuation\">(</span><span class=\"token punctuation\">)</span> <span class=\"token operator\">=></span> <span class=\"token builtin\">Promise</span><span class=\"token operator\">&lt;</span><span class=\"token keyword\">void</span><span class=\"token operator\">></span>"
+       "raw": "() => Promise<boolean | void>",
+       "html": "<span class=\"token punctuation\">(</span><span class=\"token punctuation\">)</span> <span class=\"token operator\">=></span> <span class=\"token builtin\">Promise</span><span class=\"token operator\">&lt;</span><span class=\"token builtin\">boolean</span> <span class=\"token operator\">|</span> <span class=\"token keyword\">void</span><span class=\"token operator\">></span>"
       },
       "editor": {
        "type": "func"
@@ -42431,14 +42437,17 @@
       "comment": {
        "raw": [
         "Used to restore unsaved user edits from the last session (usually to localstorage, via uuiUserSettings context)",
-        " If unsaved changes are detected, this callback is called. If it is resolved - the form restores unsaved edits.",
-        " The common use-case is to show a modal with \"You have unsaved changes, restore them?\" dialog",
+        " If unsaved changes are detected, this callback is called.",
+        " If it is resolved with a truthy value or void - the form restores unsaved edits.",
+        " If it is resolved with false - unsaved edits are discarded and removed from storage.",
+        " If it is rejected - unsaved edits are kept in storage.",
+        " The common use-case is to show a notification with \"You have unsaved changes, restore them?\" dialog",
         " Skins usually implement this as default behavior. To prevent it, you can pass null to this prop to override it."
        ]
       },
       "typeValue": {
-       "raw": "() => Promise<void>",
-       "html": "<span class=\"token punctuation\">(</span><span class=\"token punctuation\">)</span> <span class=\"token operator\">=></span> <span class=\"token builtin\">Promise</span><span class=\"token operator\">&lt;</span><span class=\"token keyword\">void</span><span class=\"token operator\">></span>"
+       "raw": "() => Promise<boolean | void>",
+       "html": "<span class=\"token punctuation\">(</span><span class=\"token punctuation\">)</span> <span class=\"token operator\">=></span> <span class=\"token builtin\">Promise</span><span class=\"token operator\">&lt;</span><span class=\"token builtin\">boolean</span> <span class=\"token operator\">|</span> <span class=\"token keyword\">void</span><span class=\"token operator\">></span>"
       },
       "editor": {
        "type": "func"

--- a/uui-core/src/data/forms/Form.tsx
+++ b/uui-core/src/data/forms/Form.tsx
@@ -51,11 +51,14 @@ export interface FormProps<T> {
 
     /**
      * Used to restore unsaved user edits from the last session (usually to localstorage, via uuiUserSettings context)
-     * If unsaved changes are detected, this callback is called. If it is resolved - the form restores unsaved edits.
-     * The common use-case is to show a modal with "You have unsaved changes, restore them?" dialog
+     * If unsaved changes are detected, this callback is called.
+     * If it is resolved with a truthy value or void - the form restores unsaved edits.
+     * If it is resolved with false - unsaved edits are discarded and removed from storage.
+     * If it is rejected - unsaved edits are kept in storage.
+     * The common use-case is to show a notification with "You have unsaved changes, restore them?" dialog
      * Skins usually implement this as default behavior. To prevent it, you can pass null to this prop to override it.
      */
-    loadUnsavedChanges?: () => Promise<void>;
+    loadUnsavedChanges?: () => Promise<void | boolean>;
 
     /**
      * Called after successful save.

--- a/uui-core/src/data/forms/__tests__/useForm.test.tsx
+++ b/uui-core/src/data/forms/__tests__/useForm.test.tsx
@@ -548,6 +548,55 @@ describe('useForm', () => {
             svc.uuiUserSettings.set('form-test', null);
         });
 
+        it('Should discard unsaved data from local storage when loadUnsavedChanges resolves false', async () => {
+            const loadUnsavedChangesMock = jest.fn().mockResolvedValue(false);
+            const props: UseFormProps<IFoo> = {
+                value: testData,
+                settingsKey: 'form-test-decline',
+                onSave: () => Promise.resolve(),
+                beforeLeave: null,
+                getMetadata: () => testMetadata,
+                loadUnsavedChanges: loadUnsavedChangesMock,
+            };
+
+            const { result: firstRenderResult, unmount } = await renderHookWithContextAsync<UseFormProps<IFoo>, IFormApi<IFoo>>(() => useForm(props));
+
+            act(() => firstRenderResult.current.lens.prop('dummy').set('hi'));
+
+            unmount();
+
+            const { result: secondRenderResult, svc } = await renderHookWithContextAsync<UseFormProps<IFoo>, IFormApi<IFoo>>(() => useForm(props));
+
+            expect(loadUnsavedChangesMock).toHaveBeenCalled();
+            expect(secondRenderResult.current.lens.prop('dummy').get()).toBe('');
+            expect(svc.uuiUserSettings.get('form-test-decline')).toBe(null);
+        });
+
+        it('Should keep unsaved data in local storage when loadUnsavedChanges is rejected', async () => {
+            const loadUnsavedChangesMock = jest.fn().mockRejectedValue(undefined);
+            const props: UseFormProps<IFoo> = {
+                value: testData,
+                settingsKey: 'form-test-dismiss',
+                onSave: () => Promise.resolve(),
+                beforeLeave: null,
+                getMetadata: () => testMetadata,
+                loadUnsavedChanges: loadUnsavedChangesMock,
+            };
+
+            const { result: firstRenderResult, unmount } = await renderHookWithContextAsync<UseFormProps<IFoo>, IFormApi<IFoo>>(() => useForm(props));
+
+            act(() => firstRenderResult.current.lens.prop('dummy').set('hi'));
+
+            unmount();
+
+            const { result: secondRenderResult, svc } = await renderHookWithContextAsync<UseFormProps<IFoo>, IFormApi<IFoo>>(() => useForm(props));
+
+            expect(loadUnsavedChangesMock).toHaveBeenCalled();
+            expect(secondRenderResult.current.lens.prop('dummy').get()).toBe('');
+            expect(svc.uuiUserSettings.get<IFoo>('form-test-dismiss').dummy).toBe('hi');
+            svc.uuiUserSettings.set('form-test-dismiss', null);
+        });
+
         it('Should not invoke loadUnsavedChanges callback if localStorage value equal initial from value', async () => {
             const loadUnsavedChangesMock = jest.fn().mockResolvedValue(true);
             const props: UseFormProps<IFoo> = {

--- a/uui-core/src/data/forms/useForm.ts
+++ b/uui-core/src/data/forms/useForm.ts
@@ -143,7 +143,13 @@ export function useForm<T>(props: UseFormProps<T>): IFormApi<T> {
         if (!unsavedChanges || !props.loadUnsavedChanges || isEqual(unsavedChanges, initialForm.current.form)) return;
         props
             .loadUnsavedChanges()
-            .then(() => handleFormUpdate(() => unsavedChanges))
+            .then((shouldRestore) => {
+                if (shouldRestore === false) {
+                    removeUnsavedChanges();
+                } else {
+                    handleFormUpdate(() => unsavedChanges);
+                }
+            })
             .catch(() => null);
     }, []);
 

--- a/uui/components/forms/Form.tsx
+++ b/uui/components/forms/Form.tsx
@@ -1,10 +1,8 @@
 import * as React from 'react';
-import {
-    Form as UuiForm, FormProps, useUuiContext, INotification,
-} from '@epam/uui-core';
-import { Text, RichTextView } from '../typography';
-import { ConfirmationModal, WarningNotification } from '../overlays';
+import { Form as UuiForm, FormProps, useUuiContext } from '@epam/uui-core';
+import { ConfirmationModal } from '../overlays';
 import { i18n } from '../../i18n';
+import { showUnsavedChangesNotification } from './showUnsavedChangesNotification';
 
 export function Form<T>(props: FormProps<T>) {
     const context = useUuiContext();
@@ -13,26 +11,8 @@ export function Form<T>(props: FormProps<T>) {
         return context.uuiModals.show<boolean>((modalProps) => <ConfirmationModal caption={ i18n.form.modals.beforeLeaveMessage } { ...modalProps } />);
     }, [context.uuiModals]);
 
-    const loadUnsavedChanges = (): Promise<void> => {
-        return context.uuiNotifications
-            .show(
-                (props: INotification) => (
-                    <WarningNotification
-                        { ...props }
-                        actions={ [
-                            {
-                                name: i18n.form.notifications.actionButtonCaption,
-                                action: props.onSuccess,
-                            },
-                        ] }
-                    >
-                        <RichTextView>
-                            <Text>{i18n.form.notifications.unsavedChangesMessage}</Text>
-                        </RichTextView>
-                    </WarningNotification>
-                ),
-                { duration: 5, position: 'bot-left' },
-            );
+    const loadUnsavedChanges = (): Promise<void | boolean> => {
+        return showUnsavedChangesNotification(context.uuiNotifications);
     };
 
     return <UuiForm<T> loadUnsavedChanges={ loadUnsavedChanges } beforeLeave={ beforeLeave } { ...props } />;

--- a/uui/components/forms/showUnsavedChangesNotification.tsx
+++ b/uui/components/forms/showUnsavedChangesNotification.tsx
@@ -4,12 +4,12 @@ import { WarningNotification } from '../overlays';
 import { Text, RichTextView } from '../typography';
 import { i18n } from '../../i18n';
 
-export function showUnsavedChangesNotification(
+export async function showUnsavedChangesNotification(
     notifications: INotificationContext,
-): Promise<void | boolean> {
-    let isDeclined = false;
+): Promise<boolean> {
+    let restore = false;
 
-    return notifications
+    await notifications
         .show(
             (props: INotification) => (
                 <WarningNotification
@@ -17,13 +17,16 @@ export function showUnsavedChangesNotification(
                     actions={ [
                         {
                             name: i18n.form.notifications.actionButtonCaption,
-                            action: props.onSuccess,
+                            action: () => {
+                                restore = true;
+                                props.onSuccess();
+                            },
                         },
                         {
                             name: i18n.form.notifications.declineButtonCaption,
                             action: () => {
-                                isDeclined = true;
-                                props.onClose();
+                                restore = false;
+                                props.onSuccess();
                             },
                         },
                     ] }
@@ -34,11 +37,7 @@ export function showUnsavedChangesNotification(
                 </WarningNotification>
             ),
             { duration: 5, position: 'bot-left' },
-        )
-        .catch(() => {
-            if (isDeclined) {
-                return false;
-            }
-            return Promise.reject();
-        });
+        );
+
+    return restore;
 }

--- a/uui/components/forms/showUnsavedChangesNotification.tsx
+++ b/uui/components/forms/showUnsavedChangesNotification.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { INotification, INotificationContext } from '@epam/uui-core';
+import { WarningNotification } from '../overlays';
+import { Text, RichTextView } from '../typography';
+import { i18n } from '../../i18n';
+
+export function showUnsavedChangesNotification(
+    notifications: INotificationContext,
+): Promise<void | boolean> {
+    let isDeclined = false;
+
+    return notifications
+        .show(
+            (props: INotification) => (
+                <WarningNotification
+                    { ...props }
+                    actions={ [
+                        {
+                            name: i18n.form.notifications.actionButtonCaption,
+                            action: props.onSuccess,
+                        },
+                        {
+                            name: i18n.form.notifications.declineButtonCaption,
+                            action: () => {
+                                isDeclined = true;
+                                props.onClose();
+                            },
+                        },
+                    ] }
+                >
+                    <RichTextView>
+                        <Text>{ i18n.form.notifications.unsavedChangesMessage }</Text>
+                    </RichTextView>
+                </WarningNotification>
+            ),
+            { duration: 5, position: 'bot-left' },
+        )
+        .catch(() => {
+            if (isDeclined) {
+                return false;
+            }
+            return Promise.reject();
+        });
+}

--- a/uui/components/forms/useForm.tsx
+++ b/uui/components/forms/useForm.tsx
@@ -1,11 +1,8 @@
 import React, { useCallback } from 'react';
-import {
-    useUuiContext, UseFormProps, useForm as uuiUseForm, INotification,
-} from '@epam/uui-core';
-import { WarningNotification } from '../overlays';
-import { Text, RichTextView } from '../typography';
+import { useUuiContext, UseFormProps, useForm as uuiUseForm } from '@epam/uui-core';
 import { ConfirmationModal } from '../overlays/ConfirmationModal';
 import { i18n } from '../../i18n';
+import { showUnsavedChangesNotification } from './showUnsavedChangesNotification';
 
 export function useForm<T>(props: UseFormProps<T>) {
     const context = useUuiContext();
@@ -14,25 +11,8 @@ export function useForm<T>(props: UseFormProps<T>) {
         return context.uuiModals.show<boolean>((modalProps) => <ConfirmationModal caption={ i18n.form.modals.beforeLeaveMessage } { ...modalProps } />);
     }, [context.uuiModals]);
 
-    const loadUnsavedChanges = (): Promise<void> => {
-        return context.uuiNotifications.show(
-            (props: INotification) => (
-                <WarningNotification
-                    { ...props }
-                    actions={ [
-                        {
-                            name: i18n.form.notifications.actionButtonCaption,
-                            action: props.onSuccess,
-                        },
-                    ] }
-                >
-                    <RichTextView>
-                        <Text>{i18n.form.notifications.unsavedChangesMessage}</Text>
-                    </RichTextView>
-                </WarningNotification>
-            ),
-            { duration: 5, position: 'bot-left' },
-        );
+    const loadUnsavedChanges = (): Promise<void | boolean> => {
+        return showUnsavedChangesNotification(context.uuiNotifications);
     };
 
     return uuiUseForm({ beforeLeave, loadUnsavedChanges, ...props });

--- a/uui/i18n.ts
+++ b/uui/i18n.ts
@@ -31,7 +31,8 @@ const TREE_SHAKEABLE_INIT = () => ({
     form: {
         notifications: {
             actionButtonCaption: 'Restore',
-            unsavedChangesMessage: 'You have unsaved changes. Click Restore button if you would like to recover the data',
+            declineButtonCaption: 'Decline',
+            unsavedChangesMessage: 'You have unsaved changes. Click Restore to recover the data, or Decline to discard it',
         },
         modals: {
             beforeLeaveMessage: 'Your data may be lost. Do you want to save data?',


### PR DESCRIPTION
<!-- **Before submitting your PR, ensure that you made the following:**

- Linked the issue(if exists)
- Lint and unit tests pass locally with my changes
- Changelog is updated or not needed
- Documentation is updated/provided or not needed
- Property explorer is updated/provided or not needed
- TSDoc comments for public interfaces is updated/provided or not needed 
 -->

### Description:

Adds a **Decline** action to the unsaved-changes restore notification for `Form` / `useForm`.

When a form remounts with a draft in `uuiUserSettings`, the warning notification now offers **Restore** and **Decline**:

| User action | Form value | Draft in storage |
|---|---|---|
| **Restore** | Applies saved draft | Kept until save/revert |
| **Decline** | Keeps current `value` | Cleared |
| Close / timeout | Keeps current `value` | Kept (notification may appear again) |

**Core (`uui-core`):**
- Extended `loadUnsavedChanges` to `Promise<void | boolean>` with updated TSDoc
- Resolve / `true` → restore draft; resolve `false` → discard and clear storage; reject → keep draft

**Skin (`uui`):**
- Added shared `showUnsavedChangesNotification` helper used by `Form` and `useForm`
- Added **Decline** button to the default `WarningNotification`

**i18n:** Added `declineButtonCaption` and updated notification message in `uui`, `loveship`, and `epam-promo`.

**Tests:** Added unit tests for decline and dismiss flows in `useForm.test.tsx`.

#### Issue link:

https://github.com/epam/UUI/issues/3025

#### QA notes:
